### PR TITLE
test(renderer): make surviving navigation a build-time question, not an audit

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -319,10 +319,18 @@ jobs:
           pnpm check:toolchain-pin
           echo "::endgroup::"
 
-      - name: ❌ Check for Failures
-        if: steps.eslint.outcome == 'failure' || steps.format.outcome == 'failure' || steps.gen_ipc.outcome == 'failure' || steps.gen_prompts.outcome == 'failure' || steps.landing_drift.outcome == 'failure' || steps.agent_system.outcome == 'failure' || steps.tech_radar.outcome == 'failure' || steps.toolchain_pin.outcome == 'failure'
+      - name: 🔌 Check event-subscription inventory
+        id: event_subscriptions
+        continue-on-error: true
         run: |
-          echo "::error file=package.json::Lint, format, IPC codegen, prompts codegen, landing-diagram, agent-system, tech-radar, or toolchain-pin drift check failed. Run 'pnpm lint:fix', 'pnpm format', 'pnpm gen:ipc', 'pnpm gen:prompts', 'pnpm check:landing-drift', 'pnpm check:agent-system', 'pnpm check:tech-radar', and 'pnpm check:toolchain-pin' locally to fix."
+          echo "::group::Checking backend event-subscription inventory"
+          pnpm check:event-subscriptions
+          echo "::endgroup::"
+
+      - name: ❌ Check for Failures
+        if: steps.eslint.outcome == 'failure' || steps.format.outcome == 'failure' || steps.gen_ipc.outcome == 'failure' || steps.gen_prompts.outcome == 'failure' || steps.landing_drift.outcome == 'failure' || steps.agent_system.outcome == 'failure' || steps.tech_radar.outcome == 'failure' || steps.toolchain_pin.outcome == 'failure' || steps.event_subscriptions.outcome == 'failure'
+        run: |
+          echo "::error file=package.json::Lint, format, IPC codegen, prompts codegen, landing-diagram, agent-system, tech-radar, toolchain-pin, or event-subscription drift check failed. Run 'pnpm lint:fix', 'pnpm format', 'pnpm gen:ipc', 'pnpm gen:prompts', 'pnpm check:landing-drift', 'pnpm check:agent-system', 'pnpm check:tech-radar', 'pnpm check:toolchain-pin', and 'pnpm check:event-subscriptions' locally to fix."
           echo "::error::Please fix the issues above before merging."
           exit 1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Renderer → shell only via `AppClient` (`createTauriInvokeClient()` in `apps/de
 13. **Stale-branch check before work:** `git fetch origin && git branch -r | rg $(git branch --show-current)`.
 14. **New IPC capability** (5 steps): `ipc/contracts/` → `commands/` → `tauri-client/` → a `services/` hook → query key in `services/query-client/`.
 15. **Never bypass ESLint**: no `// eslint-disable`, no `@ts-ignore`. Scoped override in `eslint.config.mjs` with a reason. CI runs `lint:strict --max-warnings 0`.
+16. **Backend work must survive navigation.** A subscription only receives events while its component is mounted; the Rust work it describes does not unmount. Progress state kept in a route component is discarded on navigation, and the terminal event is dropped — so the UI shows idle for work still running. Mount subscriptions from `routes/__root.tsx` or a provider, and read in-flight truth from the backend (persisted status / the job registry), not from local state. Enforced: `pnpm check:event-subscriptions` fails until every subscribing file is declared with its mount lifetime.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check:landing-drift": "node scripts/check-landing-drift.mjs",
     "check:agent-system": "node scripts/check-agent-system.mjs",
     "check:tech-radar": "node scripts/check-tech-radar.mjs",
+    "check:event-subscriptions": "node scripts/check-event-subscriptions.mjs",
     "check:toolchain-pin": "node scripts/check-toolchain-pin.mjs",
     "clean": "pnpm -r exec rimraf dist out .turbo node_modules/.cache",
     "clean:turbo": "pnpm -r exec rimraf .turbo node_modules/.cache/turbo",

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -1,0 +1,309 @@
+// Drift guard: every backend event subscription is declared with its mount
+// lifetime.
+//
+// ── The defect this exists to stop ──────────────────────────────────────────
+//
+// The renderer subscribes to Tauri events through a small family of service
+// hooks (`useJobEvents`, `useAutopilotStepEvents`, `usePipelineStageEvents`, …).
+// Each is a `useEffect` that registers a listener on mount and unregisters it on
+// unmount. That is correct React — and it is exactly the problem, because the
+// WORK those events describe lives in the Rust backend and does not unmount with
+// the component.
+//
+// A board scrape, an autopilot run, a résumé pipeline, an Ollama model pull and
+// an embeddings re-index all take minutes. If the only listener is mounted
+// inside a route, then navigating away and back means:
+//
+//   * every event emitted while the user was away is dropped — including the
+//     TERMINAL one, so nothing ever tells the UI the work ended;
+//   * the component's local progress state was discarded on unmount, so it
+//     re-renders as idle for work that is still running;
+//   * a React Query mutation's `onSuccess` invalidation belongs to the unmounted
+//     observer, so the finished result never reaches the cache either.
+//
+// That combination shipped as a user-visible bug: an autopilot card showed a
+// finished run while the status bar showed it running, and clicking Run was
+// refused by the backend with "a run is already in progress". An audit then
+// found the same shape in the jobs scrape, the résumé pipeline, the model pull
+// and the re-index.
+//
+// ── What this enforces ──────────────────────────────────────────────────────
+//
+// NOT "no route-scoped subscriptions" — some are legitimate (a live activity
+// feed has nothing to preserve). It enforces that the question was ANSWERED:
+// every file that subscribes appears in SUBSCRIBERS, classified, and a
+// route-scoped one carries a note saying what is lost and why that is
+// acceptable. A new feature that subscribes fails this check until someone
+// writes that sentence — the build asks at the moment the code is written,
+// instead of an audit asking a year later.
+//
+// Both directions are checked, so the list cannot rot: an undeclared subscriber
+// fails, and so does a declared file that no longer subscribes.
+//
+// The hook family is DISCOVERED, not hardcoded — a brand-new subscription hook
+// added to `services/` is covered without touching this file.
+//
+// Lives here rather than in a vitest file because the renderer's tsconfig has no
+// node types, and this needs the filesystem. It runs in the `lint-format` CI job,
+// which carries no path filter, so it cannot be skipped by a diff that happens to
+// miss the renderer.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const RENDERER = join(REPO_ROOT, 'apps/desktop/src/renderer');
+const SERVICES = join(RENDERER, 'services');
+
+/**
+ * Every file outside `services/` that mounts a backend event subscription.
+ *
+ * Keys are POSIX paths relative to `apps/desktop/src/renderer`.
+ *
+ * `mount: 'always'`  — mounted for the life of the app; no event can be missed.
+ * `mount: 'route-scoped'` — mounted only while a route/panel renders, so events
+ *   are LOST while the user is elsewhere. These are a DEBT LIST, not an approval
+ *   list: each note says what that costs today. They are recorded rather than
+ *   fixed here so each fix is a separate reviewable change per feature — and so
+ *   the list cannot silently grow in the meantime.
+ */
+const SUBSCRIBERS = {
+  'routes/__root.tsx': {
+    mount: 'always',
+    note: 'The app shell. This is where a subscription belongs.',
+  },
+  'hooks/use-autopilot-focus-navigation.ts': {
+    mount: 'always',
+    note: 'Called only from routes/__root.tsx.',
+  },
+  'hooks/use-window-taskbar-sync.ts': {
+    mount: 'always',
+    note: 'Called only from routes/__root.tsx.',
+  },
+  'hooks/use-menu-navigation.ts': {
+    mount: 'always',
+    note: 'Called only from routes/__root.tsx. Subscribes via useUpdater.',
+  },
+  'components/ui/UpdateBanner/index.tsx': {
+    mount: 'always',
+    note: 'Rendered by routes/__root.tsx. Subscribes via useUpdater.',
+  },
+
+  // ── Debt: backend work whose only listener is route-scoped ────────────────
+
+  'hooks/use-resume-pipeline-session.ts': {
+    mount: 'route-scoped',
+    note:
+      'The largest instance. Mounts FOUR subscriptions (job events, notifications, ' +
+      'pipeline stages, draft stream) but is called from ' +
+      'features/documents/components/TailorFlow/GeneratingPanel.tsx — route-scoped AND ' +
+      'conditionally rendered. A résumé generation runs for minutes; leaving the tab drops ' +
+      'its stage events and its streamed draft. The session store keeps the stage but not ' +
+      'the run handle, so the remounted panel shows "generating" and can neither display ' +
+      'nor cancel it.',
+  },
+  'features/jobs/hooks/useScraping.ts': {
+    mount: 'route-scoped',
+    note:
+      'Scrape progress. Unmounting also discards the in-flight job id, which breaks the ' +
+      '"cancel the previous scrape first" exclusivity contract: the orphan keeps writing ' +
+      'into the postings cache and can no longer be cancelled from the UI, while the ' +
+      'always-mounted status bar still shows it running.',
+  },
+  'features/jobs/components/JobsPage/index.tsx': {
+    mount: 'route-scoped',
+    note:
+      'A scrape that finishes while the user is elsewhere drops its terminal job event, so ' +
+      'the per-board diagnostics strip ("aggregator: 429 rate limited") is lost for that ' +
+      'run — the one thing that explains an empty result.',
+  },
+  'features/autopilot/hooks/useAutopilotRun.ts': {
+    mount: 'route-scoped',
+    note:
+      'The originally-reported bug. Partly mitigated: the card now falls back to the ' +
+      "backend's persisted runStatus and the list is invalidated on a terminal step, so a " +
+      'run survives navigation visibly. The step LOG is still lost.',
+  },
+  'features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts': {
+    mount: 'route-scoped',
+    note:
+      'A multi-GB Ollama pull loses its progress and its completion event when the ' +
+      'onboarding step is skipped or navigated away from. The pull itself continues.',
+  },
+  'features/settings/components/ai-settings/EmbeddingsSettings/index.tsx': {
+    mount: 'route-scoped',
+    note:
+      'Re-index completion is handled only by the Settings panel that started it, and the ' +
+      "panel ignores the backend's own `indexing` flag on remount.",
+  },
+  'features/settings/components/update-section/index.tsx': {
+    mount: 'route-scoped',
+    note:
+      'The THIRD independent `useUpdater` instance, each with its own subscription and its ' +
+      'own local status. The other two are always-mounted (the banner and the menu), so the ' +
+      'update itself is never lost — but this copy resets to idle on every route change, so ' +
+      'a download started in Settings shows no progress when the user returns.',
+  },
+  'features/monitoring/hooks/useActivityFeed.ts': {
+    mount: 'route-scoped',
+    note:
+      'ACCEPTED, not debt. A live activity feed is a view of the current moment; there is no ' +
+      'per-run state to preserve and nothing is lost by only listening while the monitoring ' +
+      'page is open.',
+  },
+};
+
+/** Minimum note length for a route-scoped entry to count as an explanation. */
+const MIN_NOTE_CHARS = 40;
+
+/** Recursively list `.ts`/`.tsx` sources under `dir`, skipping tests. */
+function sourceFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (!/\.tsx?$/.test(name)) continue;
+    if (/\.(test|spec)\.tsx?$/.test(name)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The subscription hooks, discovered from `services/` rather than listed.
+ *
+ * A subscription hook is an exported function whose body registers a listener on
+ * the app client (`api.<namespace>.on<Event>(`) — the single idiom every one of
+ * them uses. Discovering it means a NEW subscription hook is covered the day it
+ * is written, which a hardcoded list could never promise.
+ */
+export function discoverSubscriptionHooks(servicesDir = SERVICES) {
+  const names = new Set();
+  for (const file of sourceFiles(servicesDir)) {
+    const src = readFileSync(file, 'utf8');
+    const decls = [...src.matchAll(/export\s+(?:const|function)\s+(use[A-Z]\w*)/g)];
+    for (const [index, match] of decls.entries()) {
+      const start = match.index ?? 0;
+      const end = decls[index + 1]?.index ?? src.length;
+      if (/\bapi\.\w+\.on[A-Z]\w*\s*\(/.test(src.slice(start, end))) names.add(match[1]);
+    }
+  }
+  return [...names].sort();
+}
+
+/** Files outside `services/` that call any discovered subscription hook. */
+export function discoverSubscribers(hooks, rendererDir = RENDERER) {
+  if (hooks.length === 0) return [];
+  const pattern = new RegExp(`\\b(?:${hooks.join('|')})\\s*\\(`);
+  return sourceFiles(rendererDir)
+    .filter((f) => !relative(rendererDir, f).split('\\').join('/').startsWith('services/'))
+    .filter((f) => pattern.test(readFileSync(f, 'utf8')))
+    .map((f) => relative(rendererDir, f).split('\\').join('/'))
+    .sort();
+}
+
+/**
+ * Every violation, as human-readable lines. Empty means the invariant holds.
+ *
+ * Returned rather than printed so the check is testable without capturing
+ * stdout or trapping `process.exit`.
+ */
+export function violations(inventory = SUBSCRIBERS, hooks, subscribers) {
+  const problems = [];
+
+  // ── Vacuity guards ───────────────────────────────────────────────────────
+  // Everything after this is a set comparison, and a set comparison against an
+  // empty discovery passes while checking nothing. Both discovery steps are
+  // regexes over source text, so a refactor of the service idiom — or of the
+  // directory layout — is exactly the change that would silently empty them.
+  // These make that fail loudly instead of turning the whole check into theatre.
+  if (hooks.length < 5) {
+    problems.push(
+      `Only ${hooks.length} subscription hooks found in services/ — the ` +
+        '`api.<ns>.on<Event>(` idiom this check discovers by must have changed, so every ' +
+        'check below is now vacuous. Fix the discovery before trusting a green run.'
+    );
+    return problems;
+  }
+  if (subscribers.length < 5) {
+    problems.push(
+      `Only ${subscribers.length} files outside services/ call a subscription hook — ` +
+        'discovery is broken and the inventory is being compared against nothing.'
+    );
+    return problems;
+  }
+
+  const undeclared = subscribers.filter((f) => !(f in inventory));
+  if (undeclared.length > 0) {
+    problems.push(
+      'These files subscribe to a backend event but are not declared in SUBSCRIBERS:\n' +
+        undeclared.map((f) => `    ${f}`).join('\n') +
+        '\n  A subscription only receives events while its component is mounted, but the work\n' +
+        '  it describes runs in the Rust backend and does NOT unmount. If this file is not\n' +
+        '  mounted for the life of the app, every event emitted while the user is on another\n' +
+        '  route — including the terminal one — is lost, and the UI shows idle for work that\n' +
+        '  is still running.\n' +
+        '  Add an entry to scripts/check-event-subscriptions.mjs: `always` if it is only ever\n' +
+        '  mounted from routes/__root.tsx or a provider, otherwise `route-scoped` with a note\n' +
+        '  saying what is dropped and why that is acceptable.'
+    );
+  }
+
+  const stale = Object.keys(inventory).filter((f) => !subscribers.includes(f));
+  if (stale.length > 0) {
+    problems.push(
+      'Declared in SUBSCRIBERS but no longer subscribing — delete the entries so the list\n' +
+        '  stays a true inventory:\n' +
+        stale.map((f) => `    ${f}`).join('\n')
+    );
+  }
+
+  // The note is the whole mechanism. A `route-scoped` entry with an empty note
+  // would silence the undeclared check while recording nothing, which is worse
+  // than no inventory: it reads as a decision that was made.
+  const unexplained = Object.entries(inventory)
+    .filter(([, e]) => e.mount === 'route-scoped' && e.note.trim().length < MIN_NOTE_CHARS)
+    .map(([f]) => f);
+  if (unexplained.length > 0) {
+    problems.push(
+      'A route-scoped subscription must state what is dropped while the user is elsewhere:\n' +
+        unexplained.map((f) => `    ${f}`).join('\n')
+    );
+  }
+
+  const badMount = Object.entries(inventory)
+    .filter(([, e]) => e.mount !== 'always' && e.mount !== 'route-scoped')
+    .map(([f]) => f);
+  if (badMount.length > 0) {
+    problems.push(
+      "`mount` must be 'always' or 'route-scoped':\n" + badMount.map((f) => `    ${f}`).join('\n')
+    );
+  }
+
+  return problems;
+}
+
+// Skipped when imported by the test file.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const hooks = discoverSubscriptionHooks();
+  const subscribers = discoverSubscribers(hooks);
+  const problems = violations(SUBSCRIBERS, hooks, subscribers);
+
+  if (problems.length > 0) {
+    for (const p of problems) console.error(`✗ ${p}`);
+    process.exit(1);
+  }
+
+  const scoped = Object.values(SUBSCRIBERS).filter((e) => e.mount === 'route-scoped').length;
+  console.log(
+    `check:event-subscriptions OK — ${hooks.length} subscription hooks discovered, ` +
+      `${subscribers.length} subscribing files all declared ` +
+      `(${subscribers.length - scoped} always-mounted, ${scoped} route-scoped and explained).`
+  );
+}
+
+export { SUBSCRIBERS, RENDERER, SERVICES };

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -49,7 +49,7 @@
 // miss the renderer.
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -88,6 +88,13 @@ const SUBSCRIBERS = {
   'components/ui/UpdateBanner/index.tsx': {
     mount: 'always',
     note: 'Rendered by routes/__root.tsx. Subscribes via useUpdater.',
+  },
+  'components/layout/StatusBar/index.tsx': {
+    mount: 'always',
+    note:
+      'The app-shell status bar, rendered by routes/__root.tsx. Subscribes via ' +
+      'useWorkerActivity, and is the one surface that keeps telling the truth about ' +
+      'in-flight work while every route-scoped copy below has forgotten it.',
   },
 
   // ── Debt: backend work whose only listener is route-scoped ────────────────
@@ -152,6 +159,19 @@ const SUBSCRIBERS = {
       'per-run state to preserve and nothing is lost by only listening while the monitoring ' +
       'page is open.',
   },
+  'features/monitoring/components/MonitoringPage/index.tsx': {
+    mount: 'route-scoped',
+    note:
+      'ACCEPTED, not debt. Subscribes via useWorkerActivity to render what is running RIGHT ' +
+      'NOW; the reading is re-derived from the job registry on mount, so there is no history ' +
+      'a missed event could have cost it.',
+  },
+  'features/dashboard/components/AISystemStatus/index.tsx': {
+    mount: 'route-scoped',
+    note:
+      'ACCEPTED, not debt. Same shape as the monitoring page — useWorkerActivity feeding a ' +
+      'live "what is busy" readout, re-derived from the job registry on mount.',
+  },
 };
 
 /** Minimum note length for a route-scoped entry to count as an explanation. */
@@ -173,6 +193,9 @@ function sourceFiles(dir) {
   return out;
 }
 
+/** Normalize a relative path to POSIX separators, so keys are stable on Windows. */
+const toPosix = (rel) => rel.split(sep).join('/');
+
 /**
  * The subscription hooks, discovered from `services/` rather than listed.
  *
@@ -182,27 +205,112 @@ function sourceFiles(dir) {
  * is written, which a hardcoded list could never promise.
  */
 export function discoverSubscriptionHooks(servicesDir = SERVICES) {
-  const names = new Set();
+  // Every exported hook in services/, with its own body and the source of the
+  // file it came from. The file source is kept because the closure below has to
+  // resolve import aliases, which are a per-file fact.
+  const hooks = new Map();
   for (const file of sourceFiles(servicesDir)) {
     const src = readFileSync(file, 'utf8');
     const decls = [...src.matchAll(/export\s+(?:const|function)\s+(use[A-Z]\w*)/g)];
     for (const [index, match] of decls.entries()) {
       const start = match.index ?? 0;
       const end = decls[index + 1]?.index ?? src.length;
-      if (/\bapi\.\w+\.on[A-Z]\w*\s*\(/.test(src.slice(start, end))) names.add(match[1]);
+      hooks.set(match[1], { body: src.slice(start, end), src });
     }
   }
-  return [...names].sort();
+
+  // Seed: hooks that register a listener themselves.
+  const subscribing = new Set(
+    [...hooks].filter(([, h]) => /\bapi\.\w+\.on[A-Z]\w*\s*\(/.test(h.body)).map(([name]) => name)
+  );
+
+  // Close transitively. A services hook that COMPOSES another subscription hook
+  // subscribes just as much as one that registers the listener itself, and a
+  // seed-only scan would leave every caller of the wrapper unclassified — the
+  // guard silently narrower than it looks. Iterating to a fixed point also
+  // handles a chain of wrappers, not just one level.
+  for (let changed = true; changed;) {
+    changed = false;
+    for (const [name, { body, src }] of hooks) {
+      if (subscribing.has(name)) continue;
+      const callable = [...subscribing, ...importedBindings(src, [...subscribing])];
+      if (callable.some((s) => new RegExp(`\\b${s}\\s*\\(`).test(body))) {
+        subscribing.add(name);
+        changed = true;
+      }
+    }
+  }
+
+  return [...subscribing].sort();
+}
+
+/**
+ * The LOCAL names a file has bound to any of `hooks`, following `as` aliases.
+ *
+ * Matching on the exported name alone is not sound in either direction, and a
+ * guard that can be stepped around by renaming is worse than none:
+ *
+ *   * `import { useJobEvents as useEvents }` then `useEvents(cb)` subscribes
+ *     exactly as much as the unaliased form, and a name-only scan misses it —
+ *     an unclassified subscriber silently dropping events on navigation, which
+ *     is the entire defect this check exists to prevent;
+ *   * a file that happens to declare its own local `useJobEvents` and never
+ *     imports ours would be reported as a subscriber it is not.
+ *
+ * Binding to the import is what makes both cases correct: a call only counts
+ * when the name it calls actually resolves to a service hook.
+ *
+ * Type-only imports are skipped — `import type { useJobEvents }` cannot call
+ * anything.
+ */
+export function importedBindings(src, hooks) {
+  const bindings = new Set();
+  const wanted = new Set(hooks);
+  // `[^}]*` spans newlines, which matters: this repo's import blocks are
+  // multi-line whenever more than two or three names are imported.
+  for (const match of src.matchAll(/import\s+(type\s+)?\{([^}]*)\}\s*from/g)) {
+    if (match[1]) continue; // `import type { … }`
+    for (const specifier of match[2].split(',')) {
+      const text = specifier.trim();
+      if (!text || text.startsWith('type ')) continue; // inline `{ type Foo }`
+      const [imported, alias] = text.split(/\s+as\s+/).map((s) => s.trim());
+      if (imported && wanted.has(imported)) bindings.add(alias || imported);
+    }
+  }
+  return bindings;
+}
+
+/**
+ * Files that import a namespace from a services module (`import * as s from
+ * '@/services'`).
+ *
+ * Nothing in the repo does this today, and supporting it would mean resolving
+ * member expressions. Rather than let the pattern silently defeat discovery, it
+ * is reported as a violation with an explanation — a guard whose blind spots are
+ * visible is honest; one whose blind spots are silent is theatre.
+ */
+export function namespaceImporters(rendererDir = RENDERER) {
+  return sourceFiles(rendererDir)
+    .filter((f) => !toPosix(relative(rendererDir, f)).startsWith('services/'))
+    .filter((f) =>
+      /import\s+\*\s+as\s+\w+\s+from\s+['"][^'"]*services[^'"]*['"]/.test(readFileSync(f, 'utf8'))
+    )
+    .map((f) => toPosix(relative(rendererDir, f)))
+    .sort();
 }
 
 /** Files outside `services/` that call any discovered subscription hook. */
 export function discoverSubscribers(hooks, rendererDir = RENDERER) {
   if (hooks.length === 0) return [];
-  const pattern = new RegExp(`\\b(?:${hooks.join('|')})\\s*\\(`);
   return sourceFiles(rendererDir)
-    .filter((f) => !relative(rendererDir, f).split('\\').join('/').startsWith('services/'))
-    .filter((f) => pattern.test(readFileSync(f, 'utf8')))
-    .map((f) => relative(rendererDir, f).split('\\').join('/'))
+    .filter((f) => !toPosix(relative(rendererDir, f)).startsWith('services/'))
+    .filter((f) => {
+      const src = readFileSync(f, 'utf8');
+      const bindings = [...importedBindings(src, hooks)];
+      if (bindings.length === 0) return false;
+      return new RegExp(`\\b(?:${bindings.join('|')})\\s*\\(`).test(src);
+    })
+    .map((f) => toPosix(relative(rendererDir, f)))
     .sort();
 }
 
@@ -212,8 +320,21 @@ export function discoverSubscribers(hooks, rendererDir = RENDERER) {
  * Returned rather than printed so the check is testable without capturing
  * stdout or trapping `process.exit`.
  */
-export function violations(inventory = SUBSCRIBERS, hooks, subscribers) {
+export function violations(inventory = SUBSCRIBERS, hooks, subscribers, namespaced = []) {
   const problems = [];
+
+  // Discovery resolves imported BINDINGS, which handles `as` aliases but not a
+  // namespace import. Reported rather than ignored, so the blind spot is visible
+  // instead of silently letting a subscriber through.
+  if (namespaced.length > 0) {
+    problems.push(
+      'These files import a services namespace (`import * as x from "…/services"`), which\n' +
+        '  this check cannot resolve to individual hooks — a subscription behind one would go\n' +
+        '  undiscovered. Use named imports instead, or extend importedBindings() to resolve\n' +
+        '  member expressions:\n' +
+        namespaced.map((f) => `    ${f}`).join('\n')
+    );
+  }
 
   // ── Vacuity guards ───────────────────────────────────────────────────────
   // Everything after this is a set comparison, and a set comparison against an
@@ -291,7 +412,7 @@ export function violations(inventory = SUBSCRIBERS, hooks, subscribers) {
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const hooks = discoverSubscriptionHooks();
   const subscribers = discoverSubscribers(hooks);
-  const problems = violations(SUBSCRIBERS, hooks, subscribers);
+  const problems = violations(SUBSCRIBERS, hooks, subscribers, namespaceImporters());
 
   if (problems.length > 0) {
     for (const p of problems) console.error(`✗ ${p}`);

--- a/scripts/check-event-subscriptions.test.mjs
+++ b/scripts/check-event-subscriptions.test.mjs
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   discoverSubscribers,
   discoverSubscriptionHooks,
+  importedBindings,
+  namespaceImporters,
   SUBSCRIBERS,
   violations,
 } from './check-event-subscriptions.mjs';
@@ -78,6 +80,57 @@ describe('discoverSubscriptionHooks', () => {
 
     expect(discoverSubscriptionHooks(services)).toEqual([]);
   });
+
+  it('counts a WRAPPER that composes a subscription hook instead of registering one', () => {
+    // The real gap this closes: `useWorkerActivity` never touches `api.*.on*`, it
+    // calls `useJobEvents`. Without the closure it is not a subscription hook, so
+    // its callers — the always-mounted status bar and two live dashboards — were
+    // invisible to the guard entirely.
+    write('services/use-jobs/use-jobs.ts', SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event'));
+    write(
+      'services/use-activity/use-activity.ts',
+      `import { useJobEvents } from '../use-jobs/use-jobs';\nexport const useActivity = () => { useJobEvents(noop); };`
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useActivity', 'useJobEvents']);
+  });
+
+  it('closes a CHAIN of wrappers, not just one level', () => {
+    // Why a fixed point rather than a single extra pass: the second wrapper is
+    // only reachable once the first has been promoted.
+    write('services/use-jobs/use-jobs.ts', SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event'));
+    write(
+      'services/use-a/use-a.ts',
+      `import { useJobEvents } from '../use-jobs/use-jobs';\nexport const useA = () => { useJobEvents(noop); };`
+    );
+    write(
+      'services/use-b/use-b.ts',
+      `import { useA } from '../use-a/use-a';\nexport const useB = () => { useA(); };`
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useA', 'useB', 'useJobEvents']);
+  });
+
+  it('follows an alias when a wrapper renames what it composes', () => {
+    write('services/use-jobs/use-jobs.ts', SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event'));
+    write(
+      'services/use-activity/use-activity.ts',
+      `import { useJobEvents as useEv } from '../use-jobs/use-jobs';\nexport const useActivity = () => { useEv(noop); };`
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useActivity', 'useJobEvents']);
+  });
+
+  it('does not promote a hook that merely sits in a file next to a subscriber', () => {
+    // Guards the closure against the sloppy version: "this FILE subscribes" would
+    // promote every hook in it and cascade to their callers.
+    write(
+      'services/use-jobs/use-jobs.ts',
+      SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event') + PLAIN_HOOK('useJobs')
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useJobEvents']);
+  });
 });
 
 describe('discoverSubscribers', () => {
@@ -102,6 +155,82 @@ describe('discoverSubscribers', () => {
     write('features/thing/index.tsx', `const useJobEventsFormatter = () => {};`);
 
     expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual([]);
+  });
+
+  it('follows an `as` alias — the rename that would otherwise walk past the guard', () => {
+    // A guard that can be stepped around by renaming an import is worse than
+    // none: this subscribes exactly as much as the unaliased form.
+    write(
+      'features/thing/index.tsx',
+      `import { useJobEvents as useEvents } from '@/services';\nuseEvents(cb);`
+    );
+
+    expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual(['features/thing/index.tsx']);
+  });
+
+  it('follows an alias inside a MULTI-LINE import block', () => {
+    // The realistic shape — this repo wraps any import of more than a few names,
+    // and a `[^}]` class that did not span newlines would miss every one.
+    write(
+      'features/thing/index.tsx',
+      `import {\n  useJobs,\n  useJobEvents as useEvents,\n  useCancelJob,\n} from '@/services';\nuseEvents(cb);`
+    );
+
+    expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual(['features/thing/index.tsx']);
+  });
+
+  it('ignores a same-named LOCAL function that was never imported', () => {
+    // The false-positive direction. Reporting this file would push someone to
+    // add an inventory entry for a subscription that does not exist.
+    write('features/thing/index.tsx', `function useJobEvents() {}\nuseJobEvents();`);
+
+    expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual([]);
+  });
+
+  it('ignores a type-only import, which cannot call anything', () => {
+    write(
+      'features/thing/index.tsx',
+      `import type { useJobEvents } from '@/services';\ndeclare const x: typeof useJobEvents;`
+    );
+
+    expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual([]);
+  });
+});
+
+describe('importedBindings', () => {
+  it('returns the local name, not the exported one, for an alias', () => {
+    const src = `import { useJobEvents as useEvents, useJobs } from '@/services';`;
+
+    expect([...importedBindings(src, ['useJobEvents', 'useJobs'])].sort()).toEqual([
+      'useEvents',
+      'useJobs',
+    ]);
+  });
+
+  it('skips an inline `type` specifier inside a value import', () => {
+    const src = `import { type useJobEvents, useJobs } from '@/services';`;
+
+    expect([...importedBindings(src, ['useJobEvents', 'useJobs'])]).toEqual(['useJobs']);
+  });
+});
+
+describe('namespaceImporters', () => {
+  it('reports a services namespace import rather than silently missing it', () => {
+    // Nothing does this today. Supporting it means resolving member expressions;
+    // until then the blind spot is surfaced, because a guard with SILENT blind
+    // spots is theatre.
+    write(
+      'features/thing/index.tsx',
+      `import * as services from '@/services';\nservices.useJobEvents(cb);`
+    );
+
+    expect(namespaceImporters(renderer)).toEqual(['features/thing/index.tsx']);
+  });
+
+  it('does not report an ordinary named import', () => {
+    write('features/thing/index.tsx', `import { useJobEvents } from '@/services';`);
+
+    expect(namespaceImporters(renderer)).toEqual([]);
   });
 });
 
@@ -158,6 +287,14 @@ describe('violations', () => {
 
     expect(problems).toHaveLength(1);
     expect(problems[0]).toContain('vacuous');
+  });
+
+  it('reports a namespace importer as a blind spot rather than ignoring it', () => {
+    const problems = violations(ok, hooks, subs, ['features/thing/index.tsx']);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('features/thing/index.tsx');
+    expect(problems[0]).toContain('namespace');
   });
 
   it('fails loudly when subscriber discovery finds nothing', () => {

--- a/scripts/check-event-subscriptions.test.mjs
+++ b/scripts/check-event-subscriptions.test.mjs
@@ -1,0 +1,191 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  discoverSubscribers,
+  discoverSubscriptionHooks,
+  SUBSCRIBERS,
+  violations,
+} from './check-event-subscriptions.mjs';
+
+// Two kinds of test here, and the split matters.
+//
+// The functions are exercised against a synthetic renderer tree, so a case can
+// state exactly what it is testing without depending on the real app's current
+// shape. Then a handful of cases run against the REAL tree, because a guard
+// whose discovery silently stops matching the actual source is the one failure
+// mode that makes all of this theatre — and only the real tree can catch that.
+
+const root = join(tmpdir(), `check-event-subs-test-${process.pid}`);
+const renderer = join(root, 'renderer');
+const services = join(renderer, 'services');
+
+function write(rel, content) {
+  const full = join(renderer, rel);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, content);
+}
+
+/** A service hook that registers a listener — the shape discovery looks for. */
+const SUBSCRIBING_HOOK = (name, ns, evt) => `
+export const ${name} = (cb) => {
+  const api = useAppClient();
+  useEffect(() => api.${ns}.on${evt}(cb), [api, cb]);
+};
+`;
+
+/** A service hook that does NOT subscribe — a query hook, the common case. */
+const PLAIN_HOOK = (name) => `
+export const ${name} = () => useQuery({ queryKey: ['${name}'], queryFn: () => api.${name}() });
+`;
+
+beforeEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(services, { recursive: true });
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+describe('discoverSubscriptionHooks', () => {
+  it('finds a hook that registers a listener and ignores one that does not', () => {
+    write(
+      'services/use-jobs/use-jobs.ts',
+      SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event') + PLAIN_HOOK('useJobs')
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useJobEvents']);
+  });
+
+  it('attributes the listener to the RIGHT hook when several share a file', () => {
+    // The bug this guards: a naive "does this file subscribe" check would mark
+    // every exported hook in the file, so the plain hook's name would enter the
+    // pattern and every file merely CALLING `useJobs` would be reported as a
+    // subscriber. Discovery slices per declaration for exactly this reason.
+    write(
+      'services/use-jobs/use-jobs.ts',
+      PLAIN_HOOK('useJobs') +
+        SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event') +
+        PLAIN_HOOK('useJobDetail')
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useJobEvents']);
+  });
+
+  it('skips test files, so a fixture cannot invent a hook', () => {
+    write('services/use-jobs/use-jobs.test.ts', SUBSCRIBING_HOOK('useFakeEvents', 'fake', 'Thing'));
+
+    expect(discoverSubscriptionHooks(services)).toEqual([]);
+  });
+});
+
+describe('discoverSubscribers', () => {
+  beforeEach(() => {
+    write('services/use-jobs/use-jobs.ts', SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event'));
+  });
+
+  it('finds a feature file that calls a subscription hook', () => {
+    write(
+      'features/thing/index.tsx',
+      `import { useJobEvents } from '@/services';\nuseJobEvents(x);`
+    );
+
+    expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual(['features/thing/index.tsx']);
+  });
+
+  it('does not report the services/ definitions themselves', () => {
+    expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual([]);
+  });
+
+  it('does not match a longer name that merely contains a hook name', () => {
+    write('features/thing/index.tsx', `const useJobEventsFormatter = () => {};`);
+
+    expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual([]);
+  });
+});
+
+describe('violations', () => {
+  const hooks = ['a', 'b', 'c', 'd', 'e'];
+  const subs = ['f1', 'f2', 'f3', 'f4', 'f5'];
+  const ok = Object.fromEntries(subs.map((f) => [f, { mount: 'always', note: 'root' }]));
+
+  it('passes when every subscriber is declared', () => {
+    expect(violations(ok, hooks, subs)).toEqual([]);
+  });
+
+  it('reports an undeclared subscriber by name', () => {
+    const missing = Object.fromEntries(Object.entries(ok).filter(([f]) => f !== 'f5'));
+    const problems = violations(missing, hooks, subs);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('f5');
+    expect(problems[0]).toContain('not declared in SUBSCRIBERS');
+  });
+
+  it('reports a stale entry for a file that no longer subscribes', () => {
+    const problems = violations({ ...ok, gone: { mount: 'always', note: 'x' } }, hooks, subs);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('gone');
+    expect(problems[0]).toContain('no longer subscribing');
+  });
+
+  it('rejects a route-scoped entry whose note explains nothing', () => {
+    const lazy = { ...ok, f5: { mount: 'route-scoped', note: 'todo' } };
+    const problems = violations(lazy, hooks, subs);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('f5');
+    expect(problems[0]).toContain('what is dropped');
+  });
+
+  it('rejects an unrecognized mount value instead of treating it as always', () => {
+    const typo = {
+      ...ok,
+      f5: { mount: 'root', note: 'a note long enough to pass the length test' },
+    };
+
+    expect(violations(typo, hooks, subs)[0]).toContain('f5');
+  });
+
+  // ── The vacuity guards ────────────────────────────────────────────────────
+  // Every check above is a set comparison, and a set comparison against an empty
+  // discovery passes while checking nothing.
+
+  it('fails loudly when hook discovery finds nothing, instead of passing', () => {
+    const problems = violations(ok, [], subs);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('vacuous');
+  });
+
+  it('fails loudly when subscriber discovery finds nothing', () => {
+    const problems = violations(ok, hooks, []);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('compared against nothing');
+  });
+});
+
+describe('against the real renderer', () => {
+  // The synthetic cases above prove the LOGIC. These prove the logic is still
+  // pointed at the real source — the failure this guard cannot survive is
+  // discovery quietly matching nothing while every assertion stays green.
+
+  const hooks = discoverSubscriptionHooks();
+  const subscribers = discoverSubscribers(hooks);
+
+  it('still recognises the real service idiom', () => {
+    expect(hooks).toContain('useJobEvents');
+    expect(hooks).toContain('useAutopilotStepEvents');
+  });
+
+  it('still finds real subscribing files', () => {
+    expect(subscribers).toContain('routes/__root.tsx');
+  });
+
+  it('holds the invariant', () => {
+    expect(violations(SUBSCRIBERS, hooks, subscribers)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

The autopilot bug you reported (#1013) was one instance of a class, not a one-off. A subscription only receives events while its component is mounted — but the Rust work it describes does **not** unmount. Leave the route and three things break at once:

- every event emitted while you were away is dropped, **including the terminal one**, so nothing tells the UI the work ended;
- the component's local progress state was discarded, so it re-renders as idle for work still running;
- a React Query mutation's `onSuccess` invalidation belongs to the unmounted observer, so the result never reaches the cache either.

An audit of the whole renderer found the same shape in the jobs scrape, the résumé pipeline, the Ollama model pull, the embeddings re-index and more. **Auditing again after every new feature is not a plan.** This asks the question at the moment the code is written instead.

## What it does

`pnpm check:event-subscriptions` **discovers** the subscription-hook family from `services/` by the one idiom they all share — `api.<ns>.on<Event>(` — and then requires every file outside `services/` that calls one to be declared with its mount lifetime:

- `always` needs no argument;
- `route-scoped` needs a note saying **what is dropped** and why that is acceptable.

Discovery matters more than the list: a brand-new subscription hook is covered the day it is written, which a hardcoded list could never promise. Both directions are checked, so the inventory cannot rot — an undeclared subscriber fails, and so does a declared file that no longer subscribes.

It is **not** "no route-scoped subscriptions". Some are legitimate; exactly one entry is an accepted non-defect (the monitoring activity feed is a view of the current moment and has no per-run state to preserve), and it says so in its note.

## It earned its keep before it was even wired up

It found **three subscribers the 34-agent audit of this exact question had missed** — all three reaching `useUpdater`, which turns out to have **three independent instances**, each with its own subscription and its own local status. Two are always-mounted (the banner, the menu), so the update itself is never lost; the Settings copy resets to idle on every route change.

## The `route-scoped` entries are a debt list, not approvals

Each one records what that file loses today. The largest, which is worse than the bug that started this:

> `hooks/use-resume-pipeline-session.ts` mounts **four** subscriptions (job events, notifications, pipeline stages, draft stream) and is called from `TailorFlow/GeneratingPanel.tsx` — route-scoped **and** conditionally rendered. A résumé generation runs for minutes; leaving the tab drops its stage events and its streamed draft. The session store keeps the stage but not the run handle, so the remounted panel shows "generating" and can neither display nor cancel it.

Recorded rather than fixed here so each fix is a separate, reviewable change per feature — and so the list cannot silently grow in the meantime.

## Mutation-checked, including the failure mode that would make this theatre

- A new feature file that subscribes → fails **by name**.
- Breaking the discovery regex → trips the **vacuity guards** rather than silently passing everything. Every check here is a set comparison, and a set comparison against an empty discovery passes while checking nothing.

16 unit tests cover the logic against a synthetic tree, plus **three that run against the real renderer**, so discovery drifting off the actual source cannot stay green.

## Placement

`scripts/` beside the other drift guards, not a vitest file: the renderer tsconfig carries no node types, and the `lint-format` CI job has **no path filter**, so a diff that happens to miss the renderer cannot skip this.

## Deliberately not shipped

A companion "state machines must be re-armable" guard. The autopilot machine's real defect was dropping an **unsolicited** backend event in a terminal state, and every predicate I could write for that was either vacuous — all three machines already reach a busy state via `RESET` — or arbitrary. A guard I cannot make bite is worse than none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to verify event subscriptions are correctly registered and classified.
  * Added actionable diagnostics when subscription coverage or mounting rules are invalid.

* **Tests**
  * Added comprehensive automated coverage for subscription discovery, validation, exclusions, and stale entries.

* **Documentation**
  * Documented guidance for keeping backend operations observable during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->