### PR TITLE
fix(scripts): stop a doc comment from promoting a hook to a subscriber

### DIFF
--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -159,18 +159,12 @@ const SUBSCRIBERS = {
       'per-run state to preserve and nothing is lost by only listening while the monitoring ' +
       'page is open.',
   },
-  'features/monitoring/components/MonitoringPage/index.tsx': {
-    mount: 'route-scoped',
-    note:
-      'ACCEPTED, not debt. Subscribes via useWorkerActivity to render what is running RIGHT ' +
-      'NOW; the reading is re-derived from the job registry on mount, so there is no history ' +
-      'a missed event could have cost it.',
-  },
   'features/dashboard/components/AISystemStatus/index.tsx': {
     mount: 'route-scoped',
     note:
-      'ACCEPTED, not debt. Same shape as the monitoring page — useWorkerActivity feeding a ' +
-      'live "what is busy" readout, re-derived from the job registry on mount.',
+      'ACCEPTED, not debt. useWorkerActivity feeding a live "what is busy right now" readout; ' +
+      'the reading is re-derived from the job registry on mount, so there is no history a ' +
+      'missed event could have cost it.',
   },
 };
 
@@ -197,6 +191,63 @@ function sourceFiles(dir) {
 const toPosix = (rel) => rel.split(sep).join('/');
 
 /**
+ * Blank out comments and string/template literals, preserving offsets.
+ *
+ * Discovery matches identifiers against source text, and prose that MENTIONS a
+ * hook is not a call to it. This is not hypothetical: `services/use-jobs` has a
+ * doc comment on `useJob` reading "a `useJobEvents()` subscription MUST be
+ * mounted somewhere in the tree". Because a declaration slice runs to the next
+ * `export`, that comment sits inside the PRECEDING hook's slice — so the plain
+ * query hook `useJobQueue` was promoted to a subscription hook by a sentence,
+ * and every file calling it was pulled into the inventory. The same structural
+ * fact — a doc comment sits above its item, so a naive slice attributes it to
+ * the item before — has bitten this repo from the other direction too.
+ *
+ * Characters are replaced one-for-one with spaces rather than deleted, so every
+ * `match.index` still points at the right place in the original text.
+ *
+ * String literals are blanked alongside comments for the same reason: a hook
+ * name inside a string is a mention, not a call. Doing it with a scanner rather
+ * than a regex is what keeps a `//` inside a URL from eating the rest of a line
+ * — which would silently DROP real code, the one failure direction a guard
+ * must not have.
+ */
+export function stripCommentsAndStrings(src) {
+  let out = '';
+  let i = 0;
+  const blank = (text) => text.replace(/[^\n]/g, ' ');
+
+  while (i < src.length) {
+    const two = src.slice(i, i + 2);
+    if (two === '//') {
+      const end = src.indexOf('\n', i);
+      const stop = end === -1 ? src.length : end;
+      out += blank(src.slice(i, stop));
+      i = stop;
+    } else if (two === '/*') {
+      const end = src.indexOf('*/', i + 2);
+      const stop = end === -1 ? src.length : end + 2;
+      out += blank(src.slice(i, stop));
+      i = stop;
+    } else if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
+      const quote = src[i];
+      let j = i + 1;
+      while (j < src.length && src[j] !== quote) {
+        if (src[j] === '\\') j++; // escaped char — skip the pair
+        j++;
+      }
+      const stop = Math.min(j + 1, src.length);
+      out += blank(src.slice(i, stop));
+      i = stop;
+    } else {
+      out += src[i];
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
  * The subscription hooks, discovered from `services/` rather than listed.
  *
  * A subscription hook is an exported function whose body registers a listener on
@@ -210,7 +261,10 @@ export function discoverSubscriptionHooks(servicesDir = SERVICES) {
   // resolve import aliases, which are a per-file fact.
   const hooks = new Map();
   for (const file of sourceFiles(servicesDir)) {
-    const src = readFileSync(file, 'utf8');
+    // Comments and strings blanked FIRST: prose that names a hook is not a call to
+    // it, and a declaration slice runs to the next `export`, so the next hook's
+    // doc comment lands inside this one's body.
+    const src = stripCommentsAndStrings(readFileSync(file, 'utf8'));
     const decls = [...src.matchAll(/export\s+(?:const|function)\s+(use[A-Z]\w*)/g)];
     for (const [index, match] of decls.entries()) {
       const start = match.index ?? 0;
@@ -305,7 +359,7 @@ export function discoverSubscribers(hooks, rendererDir = RENDERER) {
   return sourceFiles(rendererDir)
     .filter((f) => !toPosix(relative(rendererDir, f)).startsWith('services/'))
     .filter((f) => {
-      const src = readFileSync(f, 'utf8');
+      const src = stripCommentsAndStrings(readFileSync(f, 'utf8'));
       const bindings = [...importedBindings(src, hooks)];
       if (bindings.length === 0) return false;
       return new RegExp(`\\b(?:${bindings.join('|')})\\s*\\(`).test(src);

--- a/scripts/check-event-subscriptions.test.mjs
+++ b/scripts/check-event-subscriptions.test.mjs
@@ -7,6 +7,7 @@ import {
   discoverSubscribers,
   discoverSubscriptionHooks,
   importedBindings,
+  stripCommentsAndStrings,
   namespaceImporters,
   SUBSCRIBERS,
   violations,
@@ -121,6 +122,42 @@ describe('discoverSubscriptionHooks', () => {
     expect(discoverSubscriptionHooks(services)).toEqual(['useActivity', 'useJobEvents']);
   });
 
+  it("is not promoted by the NEXT hook's doc comment", () => {
+    // The bug that shipped. A declaration slice runs to the next `export`, so the
+    // doc comment belonging to the hook BELOW lands inside this one's body. The
+    // real `services/use-jobs` has exactly this: a doc comment on `useJob` reading
+    // "a `useJobEvents()` subscription MUST be mounted somewhere in the tree",
+    // which promoted the plain query hook above it and dragged every file calling
+    // that query into the inventory.
+    write(
+      'services/use-jobs/use-jobs.ts',
+      PLAIN_HOOK('useJobQueue') +
+        `\n/**\n * HARD REQUIREMENT: a \`useJobEvents()\` subscription MUST be mounted.\n */\n` +
+        SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event')
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useJobEvents']);
+  });
+
+  it('is not promoted by a commented-out call', () => {
+    write('services/use-jobs/use-jobs.ts', SUBSCRIBING_HOOK('useJobEvents', 'jobs', 'Event'));
+    write(
+      'services/use-dead/use-dead.ts',
+      `import { useJobEvents } from '../use-jobs/use-jobs';\nexport const useDead = () => {\n  // useJobEvents(noop);\n};`
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual(['useJobEvents']);
+  });
+
+  it('is not promoted by a listener registration that only appears in a string', () => {
+    write(
+      'services/use-doc/use-doc.ts',
+      `export const useDoc = () => logger.warn('call api.jobs.onEvent( to subscribe');`
+    );
+
+    expect(discoverSubscriptionHooks(services)).toEqual([]);
+  });
+
   it('does not promote a hook that merely sits in a file next to a subscriber', () => {
     // Guards the closure against the sloppy version: "this FILE subscribes" would
     // promote every hook in it and cascade to their callers.
@@ -194,6 +231,35 @@ describe('discoverSubscribers', () => {
     );
 
     expect(discoverSubscribers(['useJobEvents'], renderer)).toEqual([]);
+  });
+});
+
+describe('stripCommentsAndStrings', () => {
+  it('preserves length and line structure so match offsets stay valid', () => {
+    const src = `const a = 1; // note
+/* block */ const b = 2;`;
+    const out = stripCommentsAndStrings(src);
+
+    const lines = (text) => text.split(/\r?\n/).length;
+    expect(out).toHaveLength(src.length);
+    expect(lines(out)).toBe(lines(src));
+  });
+
+  it('does not let a // inside a URL string eat the rest of the line', () => {
+    // Why this is a scanner and not a regex. A naive `//.*$` strip would delete
+    // the real call after the URL — a guard that silently MISSES a subscription,
+    // which is the one failure direction it must not have.
+    const src = `const u = 'https://x.dev'; api.jobs.onEvent(cb);`;
+
+    expect(stripCommentsAndStrings(src)).toContain('api.jobs.onEvent(');
+  });
+
+  it('blanks a comment and a string but keeps the surrounding code', () => {
+    const out = stripCommentsAndStrings(`useX(); /* useY() */ const s = 'useZ()';`);
+
+    expect(out).toContain('useX()');
+    expect(out).not.toContain('useY()');
+    expect(out).not.toContain('useZ()');
   });
 });
 


### PR DESCRIPTION
Follow-up to #1015. The AI review posted a **HIGH** after the last push and the check went red; #1015 was merged before it was addressed, so this fixes it on `main`.

## The finding was right, and the cause is worse than a stale entry

It reported `features/monitoring/components/MonitoringPage/index.tsx` as declared-but-not-subscribing. Verified: that file imports `useJobQueue`, which is a plain `useQuery` hook with no subscription anywhere in it.

So why did discovery think it was one? Because a declaration slice runs to the *next* `export`, which means **the doc comment belonging to the hook below lands inside the preceding hook's body**. And `use-jobs.ts` documents `useJob` like this:

```
 * HARD REQUIREMENT: a `useJobEvents()` subscription MUST be mounted somewhere in
 * the tree, or this query never updates.
```

That sentence sits in `useJobQueue`'s slice. The transitive closure I added in #1015 saw `useJobEvents(` in the body, promoted the query hook to a subscription hook, and dragged every file calling it into the inventory. **Prose about a hook counted as a call to it.**

This is the same structural fact already recorded in this repo from the other direction — a doc comment sits *above* its item, so anything anchored on the item *before* swallows it.

## The fix

Blank comments and string/template literals before matching. A hook name inside a string is a mention, not a call; a commented-out subscription is not one either.

It is a **scanner, not a regex**, deliberately: `//.*$` would eat the rest of a line after a URL inside a string literal, silently **dropping a real call**. For a guard, a false negative is the one failure direction that cannot be tolerated — it reports green. Characters are replaced one-for-one with spaces so every `match.index` still points at the right place.

## Result

`useJobQueue` correctly drops out — **15 hooks, not 16** — and with it the `MonitoringPage` entry, which is removed.

The other four wrappers were checked by hand and are genuine, so the closure itself was sound:

| hook | why it counts |
| --- | --- |
| `useWorkerActivity` | calls `useJobEvents()` |
| `useAutoIndex` | calls `useJobEvents()` |
| `useMenuIntents` | registers `api.menu.onNavigate` / `onAction` |
| `useUpdater` | subscribes directly |

## Tests

35, up from 29. The new ones pin the shipped bug (the next hook's doc comment), a commented-out call, a listener appearing only inside a string, and that stripping preserves length and line structure so offsets stay valid.