### PR TITLE
fix(jobs): keep the scrape state alive across a route change

### DIFF
--- a/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsCommandBar/index.tsx
@@ -70,8 +70,13 @@ export function JobsCommandBar({
   scrapeButtonRef,
 }: JobsCommandBarProps) {
   const { t } = useTranslation();
-  const { jobs, setJobs } = useSessionStore();
-  const { filter, sortBy, viewMode, hideAgency } = jobs;
+  // One selector per field (see JobsPage): an unselected `useSessionStore()`
+  // re-renders this bar on every mutation of every other slice.
+  const setJobs = useSessionStore((s) => s.setJobs);
+  const filter = useSessionStore((s) => s.jobs.filter);
+  const sortBy = useSessionStore((s) => s.jobs.sortBy);
+  const viewMode = useSessionStore((s) => s.jobs.viewMode);
+  const hideAgency = useSessionStore((s) => s.jobs.hideAgency);
 
   const trimmedFilter = filter.trim();
   const hasActiveFilter = trimmedFilter.length > 0;

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.cluster-filter.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.cluster-filter.test.tsx
@@ -6,11 +6,12 @@
  *   - clusterCanonical === false rows are hidden (collapsed into the canonical).
  *   - Unannotated rows (no cluster fields) always show.
  *   - `hideAgency` (session state) removes isAgency rows.
- *   - The hide-agency toggle writes hideAgency via setJobs.
+ *   - The hide-agency toggle writes hideAgency into the session store.
  *
- * The session-store mock is a mutable container so hideAgency can be toggled
- * per test. All heavy dependencies are module-mocked. `mergePostings` is real —
- * fixtures use distinct urls/ids so nothing collapses at the stage-1 dedup.
+ * The session store is the REAL one (it owns scrape bookkeeping the page reads
+ * back synchronously), seeded per test. All heavy dependencies are
+ * module-mocked. `mergePostings` is real — fixtures use distinct urls/ids so
+ * nothing collapses at the stage-1 dedup.
  */
 
 import type { ReactNode } from 'react';
@@ -19,18 +20,6 @@ import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TEST_IDS } from '@ajh/test-ids';
-
-// Mutable jobs slice — mutate before render to drive hideAgency.
-const jobsState = {
-  filter: '',
-  sortBy: 'newest' as const,
-  viewMode: 'list' as const,
-  selectedId: null as string | null,
-  listScrollTop: 0,
-  hideAgency: false,
-};
-
-const setJobsSpy = vi.fn();
 
 // usePostings container + captured `filtered` forwarded to JobsResults.
 const postingsContainer: { data: Array<Record<string, unknown>> } = { data: [] };
@@ -42,8 +31,6 @@ vi.mock('@/features/jobs/hooks/useScraping', () => ({
     scrapeOutcome: null,
     livePostings: [],
     setLivePostings: vi.fn(),
-    scrapeJobRef: { current: 'job-1' },
-    replacePendingRef: { current: false },
     startScrape: vi.fn(),
     cancelScrape: vi.fn(),
     noteScrapeFinished: vi.fn(),
@@ -60,14 +47,6 @@ vi.mock('@/services', () => ({
 }));
 
 vi.mock('@/hooks/useDefaultResumeId', () => ({ useDefaultResumeId: () => null }));
-
-vi.mock('@/store/session-store', () => ({
-  useSessionStore: () => ({
-    jobs: jobsState,
-    setJobs: (...args: unknown[]) => setJobsSpy(...args),
-    setSettings: vi.fn(),
-  }),
-}));
 
 vi.mock('@/hooks/use-format-relative-time', () => ({
   useFormatRelativeTime: () => (ts: number) => String(ts),
@@ -134,7 +113,15 @@ vi.mock('@ajh/ui', () => {
   };
 });
 
+import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+
 import { JobsPage } from './index';
+
+/** Drive the agency filter through the real store (no re-render needed: the
+ *  page subscribes to it, and these tests set it before rendering). */
+function setHideAgency(hideAgency: boolean) {
+  useSessionStore.setState((s) => ({ jobs: { ...s.jobs, hideAgency } }));
+}
 
 function post(id: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -156,9 +143,8 @@ function filteredIds(): string[] {
 }
 
 beforeEach(() => {
-  setJobsSpy.mockClear();
+  useSessionStore.setState({ jobs: { ...JOBS_DEFAULTS, viewMode: 'list' } });
   resultsProps.filtered = undefined;
-  jobsState.hideAgency = false;
   postingsContainer.data = [
     post('canonical', { clusterId: 'canonical', clusterCanonical: true }),
     post('collapsed', { clusterId: 'canonical', clusterCanonical: false }),
@@ -182,7 +168,7 @@ describe('JobsPage — cross-board cluster filter', () => {
   });
 
   it('hides agency rows when hideAgency is true (canonical/unannotated still shown)', () => {
-    jobsState.hideAgency = true;
+    setHideAgency(true);
     render(<JobsPage />);
     const ids = new Set(filteredIds());
     expect(ids.has('agency')).toBe(false);
@@ -198,19 +184,19 @@ describe('JobsPage — cross-board cluster filter', () => {
   });
 
   it('hideAgency reduces only the numerator against the distinct denominator', () => {
-    jobsState.hideAgency = true;
+    setHideAgency(true);
     render(<JobsPage />);
     // Agency hidden → 2 visible; denominator stays the distinct base of 3.
     expect(screen.getByText('2 / 3')).toBeInTheDocument();
   });
 
-  it('the hide-agency toggle writes hideAgency via setJobs', async () => {
+  it('the hide-agency toggle writes hideAgency into the session store', async () => {
     const user = userEvent.setup();
     render(<JobsPage />);
     const toggle = within(screen.getByTestId(TEST_IDS.jobs.hideAgencyToggle)).getByRole('button');
     await act(async () => {
       await user.click(toggle);
     });
-    expect(setJobsSpy).toHaveBeenCalledWith({ hideAgency: true });
+    expect(useSessionStore.getState().jobs.hideAgency).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.cluster-filter.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.cluster-filter.test.tsx
@@ -113,7 +113,7 @@ vi.mock('@ajh/ui', () => {
   };
 });
 
-import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+import { makeJobsDefaults, useSessionStore } from '@/store/session-store';
 
 import { JobsPage } from './index';
 
@@ -143,7 +143,7 @@ function filteredIds(): string[] {
 }
 
 beforeEach(() => {
-  useSessionStore.setState({ jobs: { ...JOBS_DEFAULTS, viewMode: 'list' } });
+  useSessionStore.setState({ jobs: { ...makeJobsDefaults(), viewMode: 'list' } });
   resultsProps.filtered = undefined;
   postingsContainer.data = [
     post('canonical', { clusterId: 'canonical', clusterCanonical: true }),

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
@@ -152,7 +152,7 @@ vi.mock('@ajh/ui', () => ({
 }));
 
 // Import AFTER mocks.
-import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+import { makeJobsDefaults, useSessionStore } from '@/store/session-store';
 
 import { JobsPage } from './index';
 
@@ -160,7 +160,7 @@ import { JobsPage } from './index';
  *  page's active-job guard accepts the synthetic stream items. */
 function resetSessionJobs(replacePending = false) {
   useSessionStore.setState({
-    jobs: { ...JOBS_DEFAULTS, viewMode: 'list', scrapeJobId: 'job-abc', replacePending },
+    jobs: { ...makeJobsDefaults(), viewMode: 'list', scrapeJobId: 'job-abc', replacePending },
   });
 }
 

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.dedup-throttle.test.tsx
@@ -50,8 +50,9 @@ const invalidateSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
  * the component state.  setLivePostings is vi.fn() so tests can inspect
  * .mock.calls and call .mockClear() without casts.
  *
- * `replacePendingRef` is exposed here so tests can set `.current = true` to
- * exercise the eager-invalidation branch in the job.stream handler.
+ * The replace latch now lives in the session store (`jobs.replacePending`), so
+ * tests set it there to exercise the eager-invalidation branch in the
+ * job.stream handler.
  *
  * Kept as a plain-object container (accessed by property reference inside the
  * vi.mock factory) so hoisting of vi.mock doesn't cause TDZ issues.
@@ -59,7 +60,6 @@ const invalidateSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 const scrapingState = {
   livePostings: [] as Posting[],
   setLivePostings: vi.fn<(updater: Posting[] | ((prev: Posting[]) => Posting[])) => void>(),
-  replacePendingRef: { current: false },
 };
 
 // ---------------------------------------------------------------------------
@@ -72,8 +72,6 @@ vi.mock('@/features/jobs/hooks/useScraping', () => ({
     scrapeOutcome: null,
     livePostings: scrapingState.livePostings,
     setLivePostings: scrapingState.setLivePostings,
-    scrapeJobRef: { current: 'job-abc' },
-    replacePendingRef: scrapingState.replacePendingRef,
     startScrape: vi.fn(),
     cancelScrape: vi.fn(),
     noteScrapeFinished: vi.fn(),
@@ -95,14 +93,9 @@ vi.mock('@/hooks/useDefaultResumeId', () => ({
   useDefaultResumeId: () => null,
 }));
 
-vi.mock('@/store/session-store', () => ({
-  useSessionStore: () => ({
-    jobs: { filter: '', sortBy: 'newest', viewMode: 'list' },
-    setJobs: vi.fn(),
-    setSettings: vi.fn(),
-  }),
-}));
-
+// The session store is REAL — the page reads the active job id and the replace
+// latch back from it synchronously (`getState()`), which a plain object stub
+// cannot model. `resetSessionJobs()` seeds it per test.
 vi.mock('@/hooks/use-format-relative-time', () => ({
   useFormatRelativeTime: () => (ts: number) => String(ts),
 }));
@@ -159,7 +152,17 @@ vi.mock('@ajh/ui', () => ({
 }));
 
 // Import AFTER mocks.
+import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+
 import { JobsPage } from './index';
+
+/** `scrapeJobId: 'job-abc'` matches the jobId fireStreamEvent() emits, so the
+ *  page's active-job guard accepts the synthetic stream items. */
+function resetSessionJobs(replacePending = false) {
+  useSessionStore.setState({
+    jobs: { ...JOBS_DEFAULTS, viewMode: 'list', scrapeJobId: 'job-abc', replacePending },
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -263,6 +266,7 @@ function renderedIds(): string[] {
 
 describe('JobsPage — allPostings dedup (via rendered list)', () => {
   beforeEach(() => {
+    resetSessionJobs();
     scrapingState.livePostings = [];
     invalidateSpy.mockClear();
   });
@@ -412,8 +416,8 @@ describe('allPostings merge formula — pure function', () => {
 
 describe('JobsPage — stream invalidation throttle', () => {
   beforeEach(() => {
+    resetSessionJobs();
     scrapingState.livePostings = [];
-    scrapingState.replacePendingRef.current = false;
     invalidateSpy.mockClear();
     vi.useFakeTimers();
   });
@@ -535,23 +539,23 @@ describe('JobsPage — stream invalidation throttle', () => {
     unmount();
   });
 
-  it('replacePendingRef=true → invalidatePostings called immediately (eager, before throttle window)', async () => {
-    // The "first item of a new search" branch: when replacePendingRef.current is
-    // true the handler resets the ref to false, replaces livePostings with just
-    // the new item, and calls invalidatePostings() DIRECTLY — bypassing the
-    // ~1 s timer so the backend cache is flushed without waiting.
-    scrapingState.replacePendingRef.current = true;
+  it('replacePending=true → invalidatePostings called immediately (eager, before throttle window)', async () => {
+    // The "first item of a new search" branch: when jobs.replacePending is true
+    // the handler clears the latch, replaces livePostings with just the new
+    // item, and calls invalidatePostings() DIRECTLY — bypassing the ~1 s timer
+    // so the backend cache is flushed without waiting.
+    resetSessionJobs(true);
     const { unmount } = renderPage();
 
-    // Fire one stream event while replacePendingRef is true.
+    // Fire one stream event while replacePending is true.
     fireStreamEvent(posting('replace-item'));
 
     // Assert BEFORE advancing fake timers — the eager call must have happened
     // synchronously within the event handler, not deferred to the throttle.
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
 
-    // The ref must be consumed (reset to false) so a second tick falls through
-    // to the normal throttled path (no immediate second call).
+    // The latch must be consumed (reset to false) so a second tick falls
+    // through to the normal throttled path (no immediate second call).
     fireStreamEvent(posting('follow-up'));
 
     // Still only the one eager call — the follow-up is now throttled.
@@ -566,21 +570,21 @@ describe('JobsPage — stream invalidation throttle', () => {
     unmount();
   });
 
-  it('replacePendingRef=true + rejection → no unhandled rejection, ref consumed, follow-up is throttled', async () => {
+  it('replacePending=true + rejection → no unhandled rejection, latch consumed, follow-up is throttled', async () => {
     // Make the eager invalidatePostings call reject once.
     invalidateSpy.mockRejectedValueOnce(new Error('eager network error'));
-    scrapingState.replacePendingRef.current = true;
+    resetSessionJobs(true);
     const { unmount } = renderPage();
 
-    // (a) Fire one stream event while replacePendingRef is true — the eager path
+    // (a) Fire one stream event while replacePending is true — the eager path
     // runs, the rejection must be swallowed (no unhandled rejection / test throw).
     fireStreamEvent(posting('eager-reject-item'));
 
     // The eager call happened immediately (synchronous — before any timer).
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
 
-    // (b) The ref must have been consumed (reset to false) so the next tick is
-    // handled by the throttled path, not another eager call.
+    // (b) The latch must have been consumed (reset to false) so the next tick
+    // is handled by the throttled path, not another eager call.
     fireStreamEvent(posting('eager-follow-up'));
 
     // Still only the one eager call right now — the follow-up is throttled.

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.navigation.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.navigation.test.tsx
@@ -1,0 +1,420 @@
+/**
+ * JobsPage — the scrape survives a route change.
+ *
+ * A route change unmounts JobsPage while the Rust scrape keeps running. Three
+ * things used to die with the component; each gets a test here that fails if
+ * the corresponding field goes back to component state:
+ *
+ *   1. DATA LOSS — the search signature reset to '', so "Show more" after a
+ *      route change sent `replace: true` and the backend wiped the persisted
+ *      postings on the first streamed item. Asserted on the WIRE payload.
+ *   2. The in-flight jobId died, leaving an uncancellable orphan (no Cancel in
+ *      the command bar) that the next search also failed to supersede.
+ *   3. The per-board diagnostics — the only explanation of an empty result —
+ *      were dropped.
+ *
+ * Unlike the sibling JobsPage tests this file uses the REAL `useScraping` and
+ * the REAL session store: the defect lives precisely in the seam between them,
+ * so mocking either out would make the test unable to fail.
+ */
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+
+import { TEST_IDS } from '@ajh/test-ids';
+
+// ---------------------------------------------------------------------------
+// Shared containers (objects, so hoisted vi.mock factories can reference them)
+// ---------------------------------------------------------------------------
+
+const jobEvents = { handler: null as ((event: unknown) => void) | null };
+
+/** scrapeBoards mutation — the seam the `replace` flag actually crosses. */
+const scrapeSpy = vi.fn<(payload: Record<string, unknown>) => Promise<unknown>>();
+const cancelSpy = vi.fn<(jobId: string) => Promise<unknown>>();
+/** Job-tracker poll behind the watchdog; a running job unless a test says otherwise. */
+const fetchJobSpy = vi.fn<(jobId: string) => Promise<unknown>>();
+
+const postingsContainer: { data: Array<Record<string, unknown>> } = { data: [] };
+
+/** Props JobsCommandBar received on its last render. */
+const commandBar = {
+  scraping: undefined as unknown,
+  boardSummaries: undefined as unknown,
+  onCancelScrape: null as null | (() => void),
+};
+
+/** Props JobsResults received on its last render, plus its "Show more" handler. */
+const results = {
+  boardSummaries: undefined as unknown,
+  failureNote: undefined as unknown,
+  filtered: [] as Array<{ id: string }>,
+  onShowMore: null as null | (() => void),
+};
+
+/** ScrapeForm handlers — the drawer's Search button and field edits. */
+const scrapeForm = {
+  onStart: null as null | (() => void),
+  onFormChange: null as null | ((updates: Record<string, unknown>) => void),
+};
+
+// ---------------------------------------------------------------------------
+// Module mocks — everything EXCEPT useScraping and the session store.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/services', () => ({
+  usePostings: () => postingsContainer,
+  useClearPostings: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useInvalidatePostings: () => vi.fn().mockResolvedValue(undefined),
+  useJobPreferences: () => ({ data: undefined }),
+  useGeocodeSuggest: () => vi.fn().mockResolvedValue([]),
+  useJobEvents: (cb: (event: unknown) => void) => {
+    jobEvents.handler = cb;
+  },
+  useScrapeBoards: () => ({ mutateAsync: scrapeSpy }),
+  useCancelJob: () => ({ mutateAsync: cancelSpy }),
+  useScrapeProgress: () => null,
+  fetchJob: (jobId: string) => fetchJobSpy(jobId),
+}));
+
+vi.mock('@/hooks/useDefaultResumeId', () => ({ useDefaultResumeId: () => null }));
+
+vi.mock('@/hooks/use-format-relative-time', () => ({
+  useFormatRelativeTime: () => (ts: number) => String(ts),
+}));
+
+vi.mock('@/components/layout/PageTransition', () => ({
+  PageTransition: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/features/jobs/providers', () => ({
+  MatchScoresProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/scrape/BoardSummaryChips', () => ({
+  BoardSummaryChips: () => null,
+  sanitizeReason: (raw: string) => `sanitized:${raw}`,
+}));
+
+vi.mock('@/features/jobs/components/JobsCommandBar', () => ({
+  JobsCommandBar: (props: {
+    scraping?: unknown;
+    boardSummaries?: unknown;
+    onCancelScrape?: () => void;
+  }) => {
+    commandBar.scraping = props.scraping;
+    commandBar.boardSummaries = props.boardSummaries;
+    commandBar.onCancelScrape = props.onCancelScrape ?? null;
+    return null;
+  },
+}));
+
+vi.mock('@/features/jobs/components/JobsResults', () => ({
+  JobsResults: (props: {
+    boardSummaries?: unknown;
+    failureNote?: unknown;
+    filtered?: Array<{ id: string }>;
+    onShowMore?: () => void;
+  }) => {
+    results.boardSummaries = props.boardSummaries;
+    results.failureNote = props.failureNote;
+    results.filtered = props.filtered ?? [];
+    results.onShowMore = props.onShowMore ?? null;
+    return <div data-testid={TEST_IDS.jobs.jobsResults} />;
+  },
+}));
+
+vi.mock('@/features/jobs/components/ScrapeForm', () => ({
+  ScrapeForm: (props: {
+    onStart?: () => void;
+    onFormChange?: (updates: Record<string, unknown>) => void;
+  }) => {
+    scrapeForm.onStart = props.onStart ?? null;
+    scrapeForm.onFormChange = props.onFormChange ?? null;
+    return <div data-testid={TEST_IDS.jobs.scrapeForm} />;
+  },
+}));
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@ajh/ui', () => ({
+  Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  ConfirmModal: () => null,
+  // Always render the children: the drawer's open state is component-local, and
+  // these tests drive the form through the captured handlers, not the DOM.
+  Drawer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Dropdown: () => null,
+  Input: () => null,
+  SegmentedControl: () => null,
+  Tag: Object.assign(({ children }: { children: ReactNode }) => <span>{children}</span>, {
+    CheckableTag: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  }),
+  useNotification: () => ({ error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() }),
+}));
+
+// Import AFTER mocks.
+import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+
+import { JobsPage } from './index';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderPage() {
+  jobEvents.handler = null;
+  return render(<JobsPage />);
+}
+
+/** The payload of the nth scrapeBoards invocation, as the backend received it. */
+function sentPayload(callIndex: number): Record<string, unknown> {
+  const payload = scrapeSpy.mock.calls[callIndex]?.[0];
+  expect(payload).toBeDefined();
+  return payload as Record<string, unknown>;
+}
+
+async function search(query: string) {
+  await act(async () => {
+    scrapeForm.onFormChange?.({ query });
+  });
+  await act(async () => {
+    scrapeForm.onStart?.();
+    await Promise.resolve();
+  });
+}
+
+/** A minimal valid streamed Posting (the handler shape-checks these fields). */
+function posting(id: string) {
+  return {
+    id,
+    source: 'linkedin',
+    externalId: id,
+    url: `https://example.com/${id}`,
+    title: `Role ${id}`,
+    company: 'Acme',
+    description: '',
+    capturedAt: 0,
+  };
+}
+
+function fireJobEvent(event: unknown) {
+  act(() => {
+    jobEvents.handler?.(event);
+  });
+}
+
+beforeEach(() => {
+  useSessionStore.setState({ jobs: { ...JOBS_DEFAULTS, viewMode: 'list' } });
+  scrapeSpy.mockReset().mockResolvedValue({ jobId: 'job-1' });
+  cancelSpy.mockReset().mockResolvedValue(undefined);
+  fetchJobSpy.mockReset().mockResolvedValue({ status: 'running' });
+  postingsContainer.data = [];
+  commandBar.scraping = undefined;
+  commandBar.boardSummaries = undefined;
+  results.boardSummaries = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// 1 — DATA LOSS
+// ---------------------------------------------------------------------------
+
+describe('JobsPage — "Show more" after a route change (defect 1: data loss)', () => {
+  it('appends instead of replacing: no `replace` flag reaches the backend', async () => {
+    const first = renderPage();
+    await search('engineer');
+
+    // A brand-new search legitimately replaces — an absolute baseline, so a
+    // regression that made `replace` disappear everywhere cannot pass this file.
+    expect(sentPayload(0).replace).toBe(true);
+    expect(sentPayload(0)).toMatchObject({ query: 'engineer', amount: 25 });
+
+    // The user goes to Settings and comes back.
+    first.unmount();
+    renderPage();
+
+    // …and presses "Show more", whose entire contract is APPEND.
+    await act(async () => {
+      results.onShowMore?.();
+      await Promise.resolve();
+    });
+
+    expect(scrapeSpy).toHaveBeenCalledTimes(2);
+    expect(sentPayload(1).replace).toBeUndefined();
+    // The criteria survived too — otherwise "Show more" would silently run a
+    // DIFFERENT (empty-query) search and append foreign results.
+    expect(sentPayload(1)).toMatchObject({ query: 'engineer', amount: 50 });
+  });
+
+  it('two form changes in one tick both survive (#884 — the store patch re-reads state)', async () => {
+    renderPage();
+
+    // A location pick fires onChange then onSelectSuggestion in the SAME tick.
+    // Both must compose; spreading a render-captured form would drop the first.
+    await act(async () => {
+      scrapeForm.onFormChange?.({ location: 'Berlin' });
+      scrapeForm.onFormChange?.({ countryCode: 'DE' });
+    });
+
+    const stored = useSessionStore.getState().jobs.scrapeForm;
+    expect(stored.location).toBe('Berlin');
+    expect(stored.countryCode).toBe('DE');
+  });
+
+  it('a genuinely new search after a route change still replaces', async () => {
+    const first = renderPage();
+    await search('engineer');
+    first.unmount();
+
+    renderPage();
+    await search('designer');
+
+    expect(sentPayload(1)).toMatchObject({ query: 'designer', replace: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2 — the orphaned, uncancellable scrape
+// ---------------------------------------------------------------------------
+
+describe('JobsPage — the in-flight scrape after a route change (defect 2: orphan)', () => {
+  it('the command bar comes back in a scraping state and can cancel the run', async () => {
+    const first = renderPage();
+    await search('engineer');
+    expect(commandBar.scraping).toBe(true);
+
+    first.unmount();
+    renderPage();
+
+    // Both the progress strip and the Cancel button are gated on `scraping`.
+    expect(commandBar.scraping).toBe(true);
+
+    await act(async () => {
+      commandBar.onCancelScrape?.();
+      await Promise.resolve();
+    });
+
+    expect(cancelSpy).toHaveBeenCalledWith('job-1');
+    expect(commandBar.scraping).toBe(false);
+    expect(useSessionStore.getState().jobs.scrapeJobId).toBeNull();
+  });
+
+  it('the next search supersedes the orphan instead of racing it into the same cache', async () => {
+    const first = renderPage();
+    await search('engineer');
+    first.unmount();
+
+    scrapeSpy.mockResolvedValue({ jobId: 'job-2' });
+    renderPage();
+    await search('designer');
+
+    expect(cancelSpy).toHaveBeenCalledWith('job-1');
+    expect(useSessionStore.getState().jobs.scrapeJobId).toBe('job-2');
+  });
+
+  it("the superseded job's stream items are still rejected (two scrapes, one cache)", async () => {
+    const first = renderPage();
+    await search('engineer');
+    first.unmount();
+
+    scrapeSpy.mockResolvedValue({ jobId: 'job-2' });
+    renderPage();
+    await search('designer');
+
+    // An item still in flight from the cancelled job-1 must not land, and must
+    // not consume the replace latch job-2's first item is waiting on.
+    fireJobEvent({ type: 'job.stream', jobId: 'job-1', data: posting('stale') });
+    expect(results.filtered.map((p) => p.id)).toEqual([]);
+    expect(useSessionStore.getState().jobs.replacePending).toBe(true);
+
+    fireJobEvent({ type: 'job.stream', jobId: 'job-2', data: posting('fresh') });
+    expect(results.filtered.map((p) => p.id)).toEqual(['fresh']);
+    expect(useSessionStore.getState().jobs.replacePending).toBe(false);
+  });
+
+  it('a remount onto a job that already finished settles instead of spinning forever', async () => {
+    const first = renderPage();
+    await search('engineer');
+    first.unmount();
+
+    // The job ended while the user was away: the `job.completed` event was
+    // emitted to nobody (the subscription is page-scoped). Only the watchdog,
+    // re-armed off the stored job id, can reconcile this.
+    fetchJobSpy.mockResolvedValue({ status: 'completed', result: { count: 0, boards: [] } });
+    vi.useFakeTimers();
+    try {
+      renderPage();
+      expect(commandBar.scraping).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+
+      expect(commandBar.scraping).toBe(false);
+      expect(useSessionStore.getState().jobs.scrapeJobId).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3 — the per-board diagnostics
+// ---------------------------------------------------------------------------
+
+describe('JobsPage — per-board diagnostics after a route change (defect 3)', () => {
+  const boards = [
+    { board: 'aggregator', count: 0, error: '429 rate limited' },
+    { board: 'greenhouse', count: 4 },
+  ];
+
+  it('the chip strip is still there after navigating away and back', async () => {
+    const first = renderPage();
+    await search('engineer');
+
+    fireJobEvent({ type: 'job.completed', jobId: 'job-1', data: { boards } });
+    expect(results.boardSummaries).toEqual(boards);
+
+    first.unmount();
+    renderPage();
+
+    expect(results.boardSummaries).toEqual(boards);
+  });
+
+  it('a scrape that finishes off-page recovers its summaries from the job tracker', async () => {
+    const first = renderPage();
+    await search('engineer');
+    first.unmount();
+
+    fetchJobSpy.mockResolvedValue({ status: 'completed', result: { count: 4, boards } });
+    vi.useFakeTimers();
+    try {
+      renderPage();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+
+      expect(results.boardSummaries).toEqual(boards);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('an outright failure note also survives the route change', async () => {
+    const first = renderPage();
+    await search('engineer');
+
+    fireJobEvent({ type: 'job.failed', jobId: 'job-1', data: 'connection refused' });
+    expect(results.failureNote).toBe('sanitized:connection refused');
+
+    first.unmount();
+    renderPage();
+
+    expect(results.failureNote).toBe('sanitized:connection refused');
+  });
+});

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.navigation.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.navigation.test.tsx
@@ -50,6 +50,8 @@ const results = {
   failureNote: undefined as unknown,
   filtered: [] as Array<{ id: string }>,
   onShowMore: null as null | (() => void),
+  /** Bumped on every JobsPage render — the stub is not memoized. */
+  renderCount: 0,
 };
 
 /** ScrapeForm handlers — the drawer's Search button and field edits. */
@@ -120,6 +122,7 @@ vi.mock('@/features/jobs/components/JobsResults', () => ({
     results.failureNote = props.failureNote;
     results.filtered = props.filtered ?? [];
     results.onShowMore = props.onShowMore ?? null;
+    results.renderCount += 1;
     return <div data-testid={TEST_IDS.jobs.jobsResults} />;
   },
 }));
@@ -159,7 +162,7 @@ vi.mock('@ajh/ui', () => ({
 }));
 
 // Import AFTER mocks.
-import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+import { makeJobsDefaults, useSessionStore } from '@/store/session-store';
 
 import { JobsPage } from './index';
 
@@ -210,7 +213,7 @@ function fireJobEvent(event: unknown) {
 }
 
 beforeEach(() => {
-  useSessionStore.setState({ jobs: { ...JOBS_DEFAULTS, viewMode: 'list' } });
+  useSessionStore.setState({ jobs: { ...makeJobsDefaults(), viewMode: 'list' } });
   scrapeSpy.mockReset().mockResolvedValue({ jobId: 'job-1' });
   cancelSpy.mockReset().mockResolvedValue(undefined);
   fetchJobSpy.mockReset().mockResolvedValue({ status: 'running' });
@@ -218,6 +221,35 @@ beforeEach(() => {
   commandBar.scraping = undefined;
   commandBar.boardSummaries = undefined;
   results.boardSummaries = undefined;
+  results.renderCount = 0;
+});
+
+// ---------------------------------------------------------------------------
+// 0 — store subscription shape (this page is render-expensive)
+// ---------------------------------------------------------------------------
+
+describe('JobsPage — session-store subscription shape', () => {
+  it('an unrelated slice changing does NOT re-render the page', async () => {
+    renderPage();
+    const before = results.renderCount;
+    expect(before).toBeGreaterThan(0);
+
+    // A background AI generation (or autopilot run, or job-summary cache write)
+    // touches its own slice. This page renders a virtualized posting list plus
+    // several sort/filter memo passes, so an unselected `useSessionStore()`
+    // would re-run all of that here for nothing.
+    await act(async () => {
+      useSessionStore.getState().setAIGenerate({ resume: 'a background generation' });
+    });
+    expect(results.renderCount).toBe(before);
+
+    // …while a jobs field the page actually reads must still drive exactly one
+    // render — otherwise the assertion above could pass on an inert page.
+    await act(async () => {
+      useSessionStore.getState().setJobs({ filter: 'rust' });
+    });
+    expect(results.renderCount).toBe(before + 1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -41,9 +41,6 @@ const notifyMock = {
   warning: vi.fn(),
 };
 
-// setJobs spy — lifted so SegmentedControl onChange tests can assert call args.
-const setJobsSpy = vi.fn();
-
 // BoardSummaryChips capture — records the `summaries` prop each time the strip
 // renders, so tests can assert the page retained + forwarded the per-board data
 // (the strip replaced the old transient skip-toasts).
@@ -109,8 +106,6 @@ vi.mock('@/features/jobs/hooks/useScraping', () => ({
     scrapeOutcome: null,
     livePostings: [],
     setLivePostings: vi.fn(),
-    scrapeJobRef: { current: 'job-123' },
-    replacePendingRef: { current: false },
     startScrape: vi.fn(),
     cancelScrape: vi.fn(),
     noteScrapeFinished: (...args: [string, { ok: boolean; note?: string }]) =>
@@ -133,13 +128,10 @@ vi.mock('@/hooks/useDefaultResumeId', () => ({
   useDefaultResumeId: () => null,
 }));
 
-vi.mock('@/store/session-store', () => ({
-  useSessionStore: () => ({
-    jobs: { filter: '', sortBy: 'newest', viewMode: 'list' },
-    setJobs: (...args: unknown[]) => setJobsSpy(...args),
-    setSettings: vi.fn(),
-  }),
-}));
+// The session store is NOT mocked: it now owns the scrape bookkeeping the page
+// reads back synchronously (`useSessionStore.getState()`), so a hand-rolled
+// object stub would have to re-implement zustand to stay honest. It is a plain
+// in-memory store — `resetSessionJobs()` below seeds it per test instead.
 
 vi.mock('@/hooks/use-format-relative-time', () => ({
   useFormatRelativeTime: () => (ts: number) => String(ts),
@@ -252,11 +244,26 @@ vi.mock('@ajh/ui', () => ({
 }));
 
 // Import AFTER mocks
+import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+
 import { JobsPage } from './index';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Seed the (real, module-scoped) jobs slice. `scrapeJobId: 'job-123'` stands in
+ * for an in-flight scrape — the page's active-job guard compares event ids
+ * against it, which is what the old `scrapeJobRef` mock used to supply.
+ */
+function resetSessionJobs() {
+  useSessionStore.setState({
+    jobs: { ...JOBS_DEFAULTS, viewMode: 'list', scrapeJobId: 'job-123' },
+  });
+}
+
+beforeEach(resetSessionJobs);
 
 function renderJobsPage() {
   jobEvents.handler = null;
@@ -714,11 +721,10 @@ describe('JobsPage — header strip mutual exclusivity with the empty state', ()
 
 describe('JobsPage — SegmentedControl viewMode toggle', () => {
   beforeEach(() => {
-    setJobsSpy.mockClear();
     segmentedControlContainer.onChange = null;
   });
 
-  it('switching to "split" calls setJobs with viewMode:split', () => {
+  it('switching to "split" stores viewMode:split', () => {
     renderJobsPage();
     expect(segmentedControlContainer.onChange).toBeTypeOf('function');
 
@@ -726,10 +732,11 @@ describe('JobsPage — SegmentedControl viewMode toggle', () => {
       segmentedControlContainer.onChange?.('split');
     });
 
-    expect(setJobsSpy).toHaveBeenCalledWith({ viewMode: 'split' });
+    expect(useSessionStore.getState().jobs.viewMode).toBe('split');
   });
 
-  it('switching to "list" calls setJobs with viewMode:list', () => {
+  it('switching to "list" stores viewMode:list', () => {
+    useSessionStore.setState((s) => ({ jobs: { ...s.jobs, viewMode: 'split' } }));
     renderJobsPage();
     expect(segmentedControlContainer.onChange).toBeTypeOf('function');
 
@@ -737,7 +744,7 @@ describe('JobsPage — SegmentedControl viewMode toggle', () => {
       segmentedControlContainer.onChange?.('list');
     });
 
-    expect(setJobsSpy).toHaveBeenCalledWith({ viewMode: 'list' });
+    expect(useSessionStore.getState().jobs.viewMode).toBe('list');
   });
 });
 

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/JobsPage.test.tsx
@@ -244,7 +244,7 @@ vi.mock('@ajh/ui', () => ({
 }));
 
 // Import AFTER mocks
-import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+import { makeJobsDefaults, useSessionStore } from '@/store/session-store';
 
 import { JobsPage } from './index';
 
@@ -259,7 +259,7 @@ import { JobsPage } from './index';
  */
 function resetSessionJobs() {
   useSessionStore.setState({
-    jobs: { ...JOBS_DEFAULTS, viewMode: 'list', scrapeJobId: 'job-123' },
+    jobs: { ...makeJobsDefaults(), viewMode: 'list', scrapeJobId: 'job-123' },
   });
 }
 

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -9,11 +9,10 @@ import { sanitizeReason } from '@/components/scrape/BoardSummaryChips';
 import { JobsCommandBar } from '@/features/jobs/components/JobsCommandBar';
 import { JobsResults } from '@/features/jobs/components/JobsResults';
 import { ScrapeForm } from '@/features/jobs/components/ScrapeForm';
-import type { ScrapeFormState } from '@/features/jobs/components/ScrapeForm/constants';
 import { useScraping } from '@/features/jobs/hooks/useScraping';
 import { mergePostings } from '@/features/jobs/lib/merge-postings';
 import { MatchScoresProvider } from '@/features/jobs/providers';
-import type { JobEvent, Posting } from '@/features/jobs/types';
+import type { JobEvent, Posting, ScrapeFormState } from '@/features/jobs/types';
 import { useFormatRelativeTime } from '@/hooks/use-format-relative-time';
 import { useDefaultResumeId } from '@/hooks/useDefaultResumeId';
 import {
@@ -38,11 +37,24 @@ export function JobsPage() {
   const clearPostings = useClearPostings();
   const invalidatePostings = useInvalidatePostings();
 
-  const { jobs, setJobs } = useSessionStore();
   // `scrapeForm` and the two diagnostics fields live in the session store, not
   // in this component: they describe a backend scrape that keeps running across
   // a route change (see `JobsSlice`).
-  const { filter, sortBy, hideAgency, scrapeForm, scrapeSummaries, scrapeFailureNote } = jobs;
+  //
+  // One selector PER FIELD, never `useSessionStore()` unselected: this page
+  // renders the virtualized posting list plus several sort/filter memo passes,
+  // so subscribing to the whole store would re-render all of it on every
+  // unrelated mutation (a background AI generation, an autopilot run, the job
+  // summary cache). Each selector returns a stored value, never a fresh object
+  // or array literal — that would defeat the default `Object.is` equality and
+  // re-render on every store change anyway.
+  const setJobs = useSessionStore((s) => s.setJobs);
+  const filter = useSessionStore((s) => s.jobs.filter);
+  const sortBy = useSessionStore((s) => s.jobs.sortBy);
+  const hideAgency = useSessionStore((s) => s.jobs.hideAgency);
+  const scrapeForm = useSessionStore((s) => s.jobs.scrapeForm);
+  const scrapeSummaries = useSessionStore((s) => s.jobs.scrapeSummaries);
+  const scrapeFailureNote = useSessionStore((s) => s.jobs.scrapeFailureNote);
   const [showScrapeForm, setShowScrapeForm] = useState(false);
   // Always-mounted opener for the scrape drawer. The drawer normally returns
   // focus to whatever opened it, but the empty-state "Search jobs" CTA unmounts

--- a/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsPage/index.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import {
-  AGGREGATOR_BOARD_ID,
-  type BoardScrapeSummary,
-  type DATE_FILTER_OPTIONS,
-} from '@ajh/shared';
+import type { BoardScrapeSummary } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
 import { ConfirmModal, Drawer, useNotification } from '@ajh/ui';
 
@@ -42,8 +38,11 @@ export function JobsPage() {
   const clearPostings = useClearPostings();
   const invalidatePostings = useInvalidatePostings();
 
-  const { jobs } = useSessionStore();
-  const { filter, sortBy, hideAgency } = jobs;
+  const { jobs, setJobs } = useSessionStore();
+  // `scrapeForm` and the two diagnostics fields live in the session store, not
+  // in this component: they describe a backend scrape that keeps running across
+  // a route change (see `JobsSlice`).
+  const { filter, sortBy, hideAgency, scrapeForm, scrapeSummaries, scrapeFailureNote } = jobs;
   const [showScrapeForm, setShowScrapeForm] = useState(false);
   // Always-mounted opener for the scrape drawer. The drawer normally returns
   // focus to whatever opened it, but the empty-state "Search jobs" CTA unmounts
@@ -51,24 +50,18 @@ export function JobsPage() {
   // <body> on the first-run path.
   const scrapeButtonRef = useRef<HTMLButtonElement>(null);
   const [confirmClear, setConfirmClear] = useState(false);
-  // Per-board outcome of the most recent scrape. Kept in page state (not dropped
-  // after reading) so the chip strip persists in the results header once the
-  // form auto-closes, and the empty state can explain a zero result per board.
-  const [lastSummaries, setLastSummaries] = useState<BoardScrapeSummary[]>([]);
-  // An outright scrape failure (no per-board summaries exist for it) — kept
-  // separately so the header/empty-state stay explainable even after the
-  // dismissible form-footer note is gone. Sanitized before it ever reaches
-  // state (the raw error can carry paths/URLs — same rule as chip reasons).
-  const [lastFailureNote, setLastFailureNote] = useState<string | null>(null);
-  const [scrapeForm, setScrapeForm] = useState<ScrapeFormState>({
-    boards: [AGGREGATOR_BOARD_ID],
-    query: '',
-    location: '',
-    radiusKm: 0,
-    amount: 25,
-    dateFilter: '' as '' | (typeof DATE_FILTER_OPTIONS)[number],
-    companies: [],
-  });
+
+  /**
+   * Patch the scrape form through the store.
+   *
+   * Reads the LATEST slice via `getState()` rather than the render-captured
+   * `scrapeForm` so two changes dispatched in the same tick (#884 — e.g. a
+   * location pick firing onChange then onSelectSuggestion) compose instead of
+   * the second clobbering the first. `setJobs` is a plain patch setter, so the
+   * functional-update guarantee `setState` gave us has to come from here.
+   */
+  const patchScrapeForm = (updates: Partial<ScrapeFormState>) =>
+    setJobs({ scrapeForm: { ...useSessionStore.getState().jobs.scrapeForm, ...updates } });
 
   // One-way prefill: seed the scrape location (+ its countryCode, when the saved
   // preference carries one — autopilot aggregator zero-jobs fix) from the saved
@@ -80,12 +73,14 @@ export function JobsPage() {
   useEffect(() => {
     if (seededLocation.current || !jobPrefs?.location) return;
     seededLocation.current = true;
-    setScrapeForm((f) =>
-      f.location
-        ? f
-        : { ...f, location: jobPrefs.location ?? '', countryCode: jobPrefs.countryCode }
-    );
-  }, [jobPrefs?.location, jobPrefs?.countryCode]);
+    // The ref is per-mount, but the form is not: on a remount the stored
+    // location already satisfies this guard, so re-seeding is a no-op.
+    const form = useSessionStore.getState().jobs.scrapeForm;
+    if (form.location) return;
+    setJobs({
+      scrapeForm: { ...form, location: jobPrefs.location ?? '', countryCode: jobPrefs.countryCode },
+    });
+  }, [jobPrefs?.location, jobPrefs?.countryCode, setJobs]);
 
   const {
     scraping,
@@ -93,8 +88,6 @@ export function JobsPage() {
     scrapeOutcome,
     livePostings,
     setLivePostings,
-    scrapeJobRef,
-    replacePendingRef,
     startScrape,
     cancelScrape,
     noteScrapeFinished,
@@ -108,6 +101,12 @@ export function JobsPage() {
   const throttledInvalidatePostings = useRef(invalidatePostings);
   throttledInvalidatePostings.current = invalidatePostings;
 
+  // Every identity check below reads the store SYNCHRONOUSLY via `getState()`
+  // rather than a `useSessionStore(selector)` value captured in this closure.
+  // The handler runs on backend stream events, not on React's schedule, so a
+  // captured value can be a render behind — which is exactly the staleness the
+  // old `scrapeJobRef` existed to prevent, and would drop stream items or
+  // attribute them to the wrong job.
   useJobEvents((raw: unknown) => {
     const ev = raw as JobEvent;
 
@@ -121,9 +120,9 @@ export function JobsPage() {
         'company' in item &&
         'url' in item
       ) {
-        if (ev.jobId !== scrapeJobRef.current) return;
-        if (replacePendingRef.current) {
-          replacePendingRef.current = false;
+        if (ev.jobId !== useSessionStore.getState().jobs.scrapeJobId) return;
+        if (useSessionStore.getState().jobs.replacePending) {
+          setJobs({ replacePending: false });
           setLivePostings([item]);
           void invalidatePostings().catch(() => {}); // backend already cleared old + added this first item
         } else {
@@ -162,26 +161,25 @@ export function JobsPage() {
           failed: failedNames,
         });
       }
-      // Capture the active job id BEFORE noteScrapeFinished clears scrapeJobRef.
+      // Capture the active job id BEFORE noteScrapeFinished clears it.
       // Guard: only surface diagnostics for the active scrape job — stale
       // `job.completed` events from a previous round must not overwrite the strip.
-      const isActiveJob = ev.jobId === scrapeJobRef.current;
+      const isActiveJob = ev.jobId === useSessionStore.getState().jobs.scrapeJobId;
       noteScrapeFinished(ev.jobId, { ok: true, note });
       void invalidatePostings();
       if (!isActiveJob) return;
       // Persist the full per-board summaries so the chip strip surfaces WHY a
       // board returned 0 (needs-login / needs-company / needs-keys / errored /
       // truncated) — persistently, replacing the previous transient skip-toasts.
-      setLastSummaries(boardSummaries);
-      setLastFailureNote(null);
+      setJobs({ scrapeSummaries: boardSummaries, scrapeFailureNote: null });
     } else if (ev.type === 'job.failed') {
       // Guard: `jobs:event` is a global channel — scrape, AI, autopilot, agent,
       // and pipeline jobs ALL emit `job.failed` on it. Capture isActiveJob
-      // BEFORE noteScrapeFinished (which clears scrapeJobRef on a match) so an
-      // unrelated background failure (e.g. an autopilot run) can't wipe the
+      // BEFORE noteScrapeFinished (which clears the stored job id on a match) so
+      // an unrelated background failure (e.g. an autopilot run) can't wipe the
       // strip or paint a foreign error as "Last scrape failed" — mirrors the
       // job.completed guard above.
-      const isActiveJob = ev.jobId === scrapeJobRef.current;
+      const isActiveJob = ev.jobId === useSessionStore.getState().jobs.scrapeJobId;
       const raw = typeof ev.data === 'string' ? ev.data : t('jobs.scrapeFailed');
       const sanitized = sanitizeReason(raw);
       // noteScrapeFinished stays unconditional — it's internally buffered/
@@ -192,8 +190,7 @@ export function JobsPage() {
       // chip), so keep a minimal sanitized failure note instead: the dismissible
       // form-footer note alone would make the failure invisible again once the
       // form closes/is dismissed.
-      setLastSummaries([]);
-      setLastFailureNote(sanitized);
+      setJobs({ scrapeSummaries: [], scrapeFailureNote: sanitized });
     }
   });
 
@@ -223,8 +220,7 @@ export function JobsPage() {
     setConfirmClear(false);
     await clearPostings.mutateAsync();
     setLivePostings([]);
-    setLastSummaries([]);
-    setLastFailureNote(null);
+    setJobs({ scrapeSummaries: [], scrapeFailureNote: null });
   };
 
   // Start a fresh scrape — drop the previous run's chip strip/failure note so
@@ -239,8 +235,7 @@ export function JobsPage() {
   // focus to <body>. Closing on the click also means a scrape that returns ZERO
   // results still closes the drawer instead of stranding it open (WCAG 2.4.3).
   const handleStartScrape = () => {
-    setLastSummaries([]);
-    setLastFailureNote(null);
+    setJobs({ scrapeSummaries: [], scrapeFailureNote: null });
     setShowScrapeForm(false);
     void startScrape();
   };
@@ -250,7 +245,7 @@ export function JobsPage() {
   // kept and the extra results append (deduped by id).
   const handleShowMore = () => {
     const next = scrapeForm.amount + 25;
-    setScrapeForm({ ...scrapeForm, amount: next });
+    patchScrapeForm({ amount: next });
     void startScrape(next);
   };
 
@@ -341,8 +336,8 @@ export function JobsPage() {
             onClear={() => setConfirmClear(true)}
             onScrape={() => setShowScrapeForm(true)}
             onCancelScrape={cancelScrape}
-            boardSummaries={showDiagnostics ? lastSummaries : []}
-            failureNote={showDiagnostics ? lastFailureNote : null}
+            boardSummaries={showDiagnostics ? scrapeSummaries : []}
+            failureNote={showDiagnostics ? scrapeFailureNote : null}
             scrapeButtonRef={scrapeButtonRef}
           />
 
@@ -351,8 +346,8 @@ export function JobsPage() {
             formatRelativeTime={formatRelativeTime}
             scraping={scraping}
             scrapeProgress={scrapeProgress}
-            boardSummaries={lastSummaries}
-            failureNote={lastFailureNote}
+            boardSummaries={scrapeSummaries}
+            failureNote={scrapeFailureNote}
             // Unfiltered count — lets JobsResults tell "genuinely zero
             // postings" apart from "the text filter hid everything" so the
             // empty state doesn't re-show a prior scrape's diagnostics when a
@@ -382,11 +377,10 @@ export function JobsPage() {
           scraping={scraping}
           scrapeOutcome={scrapeOutcome}
           onToggle={() => setShowScrapeForm(false)}
-          // Functional update (#884): two changes dispatched in one tick (e.g. a
-          // location pick firing onChange then onSelectSuggestion) would
-          // otherwise both spread the SAME captured `scrapeForm` and the first
-          // would be lost.
-          onFormChange={(updates) => setScrapeForm((f) => ({ ...f, ...updates }))}
+          // #884: two changes dispatched in one tick (e.g. a location pick
+          // firing onChange then onSelectSuggestion) must not both spread the
+          // SAME captured `scrapeForm` — `patchScrapeForm` re-reads the store.
+          onFormChange={(updates) => patchScrapeForm(updates)}
           onStart={handleStartScrape}
           onCancel={cancelScrape}
           onGeocode={geocodeSuggest}

--- a/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
+++ b/apps/desktop/src/renderer/features/jobs/components/JobsSplitView/index.tsx
@@ -24,15 +24,20 @@ export function JobsSplitView({
   onShowMore,
 }: JobsSplitViewProps) {
   const { t } = useTranslation();
-  const { jobs, setJobs } = useSessionStore();
-  const { selectedId } = jobs;
+  // One selector per field (see JobsPage): this component owns the virtualized
+  // list, so an unselected `useSessionStore()` re-runs it on every mutation of
+  // every other slice.
+  const setJobs = useSessionStore((s) => s.setJobs);
+  const selectedId = useSessionStore((s) => s.jobs.selectedId);
 
   const selectedPosting = display.find((p) => p.id === selectedId) ?? null;
 
   const listScrollRef = useRef<HTMLDivElement>(null);
   // Captured once at mount so the restore effect has a stable reference without
-  // being reactive to subsequent scrollTop saves.
-  const initialScrollTop = useRef(jobs.listScrollTop);
+  // being reactive to subsequent scrollTop saves. Read through `getState()`
+  // rather than a selector for exactly that reason: subscribing here would make
+  // every scroll-save re-render the virtualized list it was saved from.
+  const initialScrollTop = useRef(useSessionStore.getState().jobs.listScrollTop);
   const virtualizer = useVirtualizer({
     count: display.length,
     getScrollElement: () => listScrollRef.current,

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/constants.ts
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/constants.ts
@@ -1,33 +1,5 @@
-import { AGGREGATOR_BOARD_ID, type DATE_FILTER_OPTIONS } from '@ajh/shared';
-
-export interface ScrapeFormState {
-  boards: string[];
-  query: string;
-  location: string;
-  /** Structured location captured from a picked geocode suggestion (#49/#40). */
-  countryCode?: string;
-  latitude?: number;
-  longitude?: number;
-  /** Search radius in km; 0 = exact location (no radius). */
-  radiusKm: number;
-  /** Target number of jobs to fetch (#41); sent as the scrape `amount` (backend clamps to 100). */
-  amount: number;
-  dateFilter: '' | (typeof DATE_FILTER_OPTIONS)[number];
-  /**
-   * Company slugs for ATS boards (greenhouse, lever, ashby, etc.) whose APIs
-   * require a company identifier. Comma-separated in the UI, stored as an array.
-   * Empty array = no filter; backend skips ATS boards with `needs-company`.
-   */
-  companies: string[];
-}
-
-/** Initial scrape form — the session store seeds `jobs.scrapeForm` from this. */
-export const SCRAPE_FORM_DEFAULTS: ScrapeFormState = {
-  boards: [AGGREGATOR_BOARD_ID],
-  query: '',
-  location: '',
-  radiusKm: 0,
-  amount: 25,
-  dateFilter: '',
-  companies: [],
-};
+// The scrape form's shape and defaults live at the FEATURE level
+// (`features/jobs/types`) so the session store, which owns `jobs.scrapeForm`,
+// imports a feature module instead of reaching into this component's internals.
+// Re-exported here so the ScrapeForm subtree keeps its short relative import.
+export { makeScrapeFormDefaults, type ScrapeFormState } from '../../types';

--- a/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/constants.ts
+++ b/apps/desktop/src/renderer/features/jobs/components/ScrapeForm/constants.ts
@@ -1,4 +1,4 @@
-import type { DATE_FILTER_OPTIONS } from '@ajh/shared';
+import { AGGREGATOR_BOARD_ID, type DATE_FILTER_OPTIONS } from '@ajh/shared';
 
 export interface ScrapeFormState {
   boards: string[];
@@ -20,3 +20,14 @@ export interface ScrapeFormState {
    */
   companies: string[];
 }
+
+/** Initial scrape form — the session store seeds `jobs.scrapeForm` from this. */
+export const SCRAPE_FORM_DEFAULTS: ScrapeFormState = {
+  boards: [AGGREGATOR_BOARD_ID],
+  query: '',
+  location: '',
+  radiusKm: 0,
+  amount: 25,
+  dateFilter: '',
+  companies: [],
+};

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
@@ -11,7 +11,7 @@ import { act } from '@testing-library/react';
 
 import type { useNotification } from '@ajh/ui';
 
-import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
+import { makeJobsDefaults, useSessionStore } from '@/store/session-store';
 import { renderHookWithClient } from '@/test-support';
 
 // ---------------------------------------------------------------------------
@@ -36,7 +36,7 @@ vi.mock('@/services', async (importActual) => {
 });
 
 // Import under test AFTER mocks.
-import type { ScrapeFormState } from '../components/ScrapeForm/constants';
+import type { ScrapeFormState } from '../types';
 import { useScraping } from './useScraping';
 
 // ---------------------------------------------------------------------------
@@ -77,7 +77,14 @@ function sentReplace(callIndex: number): unknown {
 beforeEach(() => {
   // The session store now owns the scrape bookkeeping and is module-scoped, so
   // it leaks between tests unless reset.
-  useSessionStore.setState({ jobs: { ...JOBS_DEFAULTS } });
+  useSessionStore.setState({ jobs: makeJobsDefaults() });
+  // Reset the mutation spies HERE, not per test: `sentReplace(n)` indexes into
+  // `mutateAsync.mock.calls`, so a test added without a manual clear would
+  // silently read a previous test's calls — an order-dependent failure in the
+  // very assertions that prove the data-loss fix.
+  mutateAsync.mockClear().mockResolvedValue({ jobId: 'j1' });
+  cancelMutateAsync.mockClear().mockResolvedValue(undefined);
+  fetchJobMock.mockClear().mockResolvedValue({ status: 'running' });
 });
 
 // ---------------------------------------------------------------------------
@@ -86,7 +93,6 @@ beforeEach(() => {
 
 describe('useScraping — companies field in scrapeBoards payload', () => {
   it('omits companies from the payload when the array is empty', async () => {
-    mutateAsync.mockClear();
     const form = makeForm({ companies: [] });
 
     const { result } = renderHookWithClient(() => useScraping(noopNotify, form));
@@ -101,7 +107,6 @@ describe('useScraping — companies field in scrapeBoards payload', () => {
   });
 
   it('includes companies in the payload when the array is non-empty', async () => {
-    mutateAsync.mockClear();
     const form = makeForm({ companies: ['stripe', 'airbnb'] });
 
     const { result } = renderHookWithClient(() => useScraping(noopNotify, form));
@@ -118,7 +123,6 @@ describe('useScraping — companies field in scrapeBoards payload', () => {
 
 describe('useScraping — geo fields in the replace-vs-append signature', () => {
   it('replaces (not appends) when only the countryCode differs', async () => {
-    mutateAsync.mockClear();
     const { result, rerender } = renderHookWithClient(
       ({ form }: { form: ScrapeFormState }) => useScraping(noopNotify, form),
       { initialProps: { form: makeForm({ countryCode: 'US' }) } }
@@ -140,7 +144,6 @@ describe('useScraping — geo fields in the replace-vs-append signature', () => 
   });
 
   it('replaces (not appends) when only the search radius differs', async () => {
-    mutateAsync.mockClear();
     const { result, rerender } = renderHookWithClient(
       ({ form }: { form: ScrapeFormState }) => useScraping(noopNotify, form),
       { initialProps: { form: makeForm({ radiusKm: 0 }) } }
@@ -161,7 +164,6 @@ describe('useScraping — geo fields in the replace-vs-append signature', () => 
   });
 
   it('appends (does not replace) when the search is byte-for-byte identical', async () => {
-    mutateAsync.mockClear();
     const { result, rerender } = renderHookWithClient(
       ({ form }: { form: ScrapeFormState }) => useScraping(noopNotify, form),
       { initialProps: { form: makeForm({ countryCode: 'US' }) } }
@@ -191,7 +193,6 @@ describe('useScraping — geo fields in the replace-vs-append signature', () => 
 
 describe('useScraping — the scrape survives a route change', () => {
   it('"Show more" after an unmount/remount APPENDS (no replace flag on the wire)', async () => {
-    mutateAsync.mockClear();
     const form = makeForm({ query: 'engineer', amount: 25 });
 
     // 1. The user runs a search on the jobs page.
@@ -219,8 +220,6 @@ describe('useScraping — the scrape survives a route change', () => {
   });
 
   it('a genuinely different search after a remount still REPLACES', async () => {
-    mutateAsync.mockClear();
-
     const first = renderHookWithClient(() => useScraping(noopNotify, makeForm({ query: 'rust' })));
     await act(async () => {
       await first.result.current.startScrape();
@@ -244,8 +243,6 @@ describe('useScraping — the scrape survives a route change', () => {
 
 describe('useScraping — the in-flight job survives a route change', () => {
   it('remounts into `scraping` and cancels the job the PREVIOUS mount started', async () => {
-    mutateAsync.mockClear();
-    cancelMutateAsync.mockClear();
     const form = makeForm();
 
     const first = renderHookWithClient(() => useScraping(noopNotify, form));
@@ -271,8 +268,6 @@ describe('useScraping — the in-flight job survives a route change', () => {
   });
 
   it('the next search after a remount cancels the orphaned scrape first', async () => {
-    mutateAsync.mockClear();
-    cancelMutateAsync.mockClear();
     const form = makeForm();
 
     const first = renderHookWithClient(() => useScraping(noopNotify, form));
@@ -295,7 +290,6 @@ describe('useScraping — the in-flight job survives a route change', () => {
   });
 
   it('a remount onto a job that already FINISHED settles to a finished state', async () => {
-    mutateAsync.mockClear();
     fetchJobMock.mockResolvedValue({ status: 'completed', result: { boards: [] } });
     vi.useFakeTimers();
     try {
@@ -320,7 +314,6 @@ describe('useScraping — the in-flight job survives a route change', () => {
       expect(second.result.current.scrapeOutcome).toEqual({ ok: true });
     } finally {
       vi.useRealTimers();
-      fetchJobMock.mockResolvedValue({ status: 'running' });
     }
   });
 });
@@ -333,7 +326,6 @@ describe('useScraping — the in-flight job survives a route change', () => {
 
 describe('useScraping — per-board diagnostics survive', () => {
   it('recovers the per-board summaries from the job tracker after finishing off-page', async () => {
-    mutateAsync.mockClear();
     const boards = [{ board: 'aggregator', count: 0, error: '429 rate limited' }];
     fetchJobMock.mockResolvedValue({ status: 'completed', result: { count: 0, boards } });
     vi.useFakeTimers();
@@ -353,7 +345,6 @@ describe('useScraping — per-board diagnostics survive', () => {
       expect(useSessionStore.getState().jobs.scrapeSummaries).toEqual(boards);
     } finally {
       vi.useRealTimers();
-      fetchJobMock.mockResolvedValue({ status: 'running' });
     }
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
@@ -6,11 +6,12 @@
  * so the IPC contract is honoured and the Rust engine's is_empty() skip
  * check behaves correctly.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from '@testing-library/react';
 
 import type { useNotification } from '@ajh/ui';
 
+import { JOBS_DEFAULTS, useSessionStore } from '@/store/session-store';
 import { renderHookWithClient } from '@/test-support';
 
 // ---------------------------------------------------------------------------
@@ -18,14 +19,18 @@ import { renderHookWithClient } from '@/test-support';
 // ---------------------------------------------------------------------------
 
 const mutateAsync = vi.fn().mockResolvedValue({ jobId: 'j1' });
+const cancelMutateAsync = vi.fn().mockResolvedValue(undefined);
+/** Job-tracker poll used by the watchdog; defaults to a still-running job. */
+const fetchJobMock = vi.fn().mockResolvedValue({ status: 'running' });
 
 vi.mock('@/services', async (importActual) => {
   const actual = await importActual<Record<string, unknown>>();
   return {
     ...actual,
     useScrapeBoards: () => ({ mutateAsync }),
-    useCancelJob: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }),
-    fetchJob: vi.fn().mockResolvedValue({ status: 'completed' }),
+    useCancelJob: () => ({ mutateAsync: cancelMutateAsync }),
+    fetchJob: (jobId: string) => fetchJobMock(jobId),
+    useScrapeProgress: () => null,
     useInvalidatePostings: () => vi.fn().mockResolvedValue(undefined),
   };
 });
@@ -57,6 +62,23 @@ const noopNotify = {
   warning: vi.fn(),
   error: vi.fn(),
 } as unknown as ReturnType<typeof useNotification>;
+
+/**
+ * The `replace` flag as it reached the BACKEND on the nth scrapeBoards call.
+ * Asserting the wire payload (not an internal boolean) is the point: `replace`
+ * is what clears the persisted postings cache.
+ */
+function sentReplace(callIndex: number): unknown {
+  const payload = mutateAsync.mock.calls[callIndex]?.[0] as Record<string, unknown> | undefined;
+  expect(payload).toBeDefined();
+  return payload?.replace;
+}
+
+beforeEach(() => {
+  // The session store now owns the scrape bookkeeping and is module-scoped, so
+  // it leaks between tests unless reset.
+  useSessionStore.setState({ jobs: { ...JOBS_DEFAULTS } });
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -114,7 +136,7 @@ describe('useScraping — geo fields in the replace-vs-append signature', () => 
       await result.current.startScrape();
     });
 
-    expect(result.current.replacePendingRef.current).toBe(true);
+    expect(sentReplace(1)).toBe(true);
   });
 
   it('replaces (not appends) when only the search radius differs', async () => {
@@ -135,7 +157,7 @@ describe('useScraping — geo fields in the replace-vs-append signature', () => 
       await result.current.startScrape();
     });
 
-    expect(result.current.replacePendingRef.current).toBe(true);
+    expect(sentReplace(1)).toBe(true);
   });
 
   it('appends (does not replace) when the search is byte-for-byte identical', async () => {
@@ -155,6 +177,183 @@ describe('useScraping — geo fields in the replace-vs-append signature', () => 
       await result.current.startScrape();
     });
 
-    expect(result.current.replacePendingRef.current).toBe(false);
+    // The first run REPLACES (nothing on screen belongs to it yet), the second
+    // APPENDS — `replace` is omitted entirely from the payload.
+    expect(sentReplace(0)).toBe(true);
+    expect(sentReplace(1)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 1 — DATA LOSS: "Show more" after a route change must not send
+// replace:true (which clears the persisted postings cache on the first item).
+// ---------------------------------------------------------------------------
+
+describe('useScraping — the scrape survives a route change', () => {
+  it('"Show more" after an unmount/remount APPENDS (no replace flag on the wire)', async () => {
+    mutateAsync.mockClear();
+    const form = makeForm({ query: 'engineer', amount: 25 });
+
+    // 1. The user runs a search on the jobs page.
+    const first = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    expect(sentReplace(0)).toBe(true);
+
+    // 2. The user navigates to Settings — the page (and this hook) unmounts.
+    first.unmount();
+
+    // 3. …and comes back. Fresh component state, same session store.
+    const second = renderHookWithClient(() => useScraping(noopNotify, form));
+
+    // 4. "Show more": same criteria, a bigger amount. Contract: APPEND.
+    await act(async () => {
+      await second.result.current.startScrape(50);
+    });
+
+    expect(mutateAsync).toHaveBeenCalledTimes(2);
+    expect(sentReplace(1)).toBeUndefined();
+    const payload = mutateAsync.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(payload).toMatchObject({ query: 'engineer', amount: 50 });
+  });
+
+  it('a genuinely different search after a remount still REPLACES', async () => {
+    mutateAsync.mockClear();
+
+    const first = renderHookWithClient(() => useScraping(noopNotify, makeForm({ query: 'rust' })));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    first.unmount();
+
+    const second = renderHookWithClient(() =>
+      useScraping(noopNotify, makeForm({ query: 'python' }))
+    );
+    await act(async () => {
+      await second.result.current.startScrape();
+    });
+
+    expect(sentReplace(1)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 2 — the in-flight scrape must stay cancellable across a route change.
+// ---------------------------------------------------------------------------
+
+describe('useScraping — the in-flight job survives a route change', () => {
+  it('remounts into `scraping` and cancels the job the PREVIOUS mount started', async () => {
+    mutateAsync.mockClear();
+    cancelMutateAsync.mockClear();
+    const form = makeForm();
+
+    const first = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    expect(first.result.current.scraping).toBe(true);
+    first.unmount();
+
+    const second = renderHookWithClient(() => useScraping(noopNotify, form));
+
+    // Both the progress strip and the Cancel button are gated on `scraping`.
+    expect(second.result.current.scraping).toBe(true);
+    expect(second.result.current.scrapeJobId).toBe('j1');
+
+    await act(async () => {
+      await second.result.current.cancelScrape();
+    });
+
+    expect(cancelMutateAsync).toHaveBeenCalledWith('j1');
+    expect(second.result.current.scraping).toBe(false);
+    expect(second.result.current.scrapeJobId).toBeNull();
+  });
+
+  it('the next search after a remount cancels the orphaned scrape first', async () => {
+    mutateAsync.mockClear();
+    cancelMutateAsync.mockClear();
+    const form = makeForm();
+
+    const first = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    first.unmount();
+
+    // A second scrape from a fresh mount: without the stored job id this used
+    // to start a rival run writing into the same postings cache.
+    const second = renderHookWithClient(() =>
+      useScraping(noopNotify, makeForm({ query: 'another' }))
+    );
+    await act(async () => {
+      await second.result.current.startScrape();
+    });
+
+    expect(cancelMutateAsync).toHaveBeenCalledWith('j1');
+    expect(cancelMutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('a remount onto a job that already FINISHED settles to a finished state', async () => {
+    mutateAsync.mockClear();
+    fetchJobMock.mockResolvedValue({ status: 'completed', result: { boards: [] } });
+    vi.useFakeTimers();
+    try {
+      const form = makeForm();
+      const first = renderHookWithClient(() => useScraping(noopNotify, form));
+      await act(async () => {
+        await first.result.current.startScrape();
+      });
+      first.unmount();
+
+      // The job.completed EVENT is never delivered — the subscription lives on
+      // the unmounted page. Only the watchdog can reconcile this.
+      const second = renderHookWithClient(() => useScraping(noopNotify, form));
+      expect(second.result.current.scraping).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+
+      expect(second.result.current.scraping).toBe(false);
+      expect(second.result.current.scrapeJobId).toBeNull();
+      expect(second.result.current.scrapeOutcome).toEqual({ ok: true });
+    } finally {
+      vi.useRealTimers();
+      fetchJobMock.mockResolvedValue({ status: 'running' });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 3 — the per-board diagnostics ("aggregator: 429 rate limited") are the
+// only explanation of an empty result; they must survive navigation AND a
+// scrape that finishes while the user is on another route.
+// ---------------------------------------------------------------------------
+
+describe('useScraping — per-board diagnostics survive', () => {
+  it('recovers the per-board summaries from the job tracker after finishing off-page', async () => {
+    mutateAsync.mockClear();
+    const boards = [{ board: 'aggregator', count: 0, error: '429 rate limited' }];
+    fetchJobMock.mockResolvedValue({ status: 'completed', result: { count: 0, boards } });
+    vi.useFakeTimers();
+    try {
+      const form = makeForm();
+      const first = renderHookWithClient(() => useScraping(noopNotify, form));
+      await act(async () => {
+        await first.result.current.startScrape();
+      });
+      first.unmount();
+
+      renderHookWithClient(() => useScraping(noopNotify, form));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+
+      expect(useSessionStore.getState().jobs.scrapeSummaries).toEqual(boards);
+    } finally {
+      vi.useRealTimers();
+      fetchJobMock.mockResolvedValue({ status: 'running' });
+    }
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
@@ -3,8 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { BoardScrapeSummary } from '@ajh/shared';
 import type { useNotification } from '@ajh/ui';
 
-import type { ScrapeFormState } from '@/features/jobs/components/ScrapeForm/constants';
-import type { Posting, ScrapeOutcome } from '@/features/jobs/types';
+import type { Posting, ScrapeFormState, ScrapeOutcome } from '@/features/jobs/types';
 import { fetchJob, useCancelJob, useScrapeBoards, useScrapeProgress } from '@/services';
 import { useSessionStore } from '@/store/session-store';
 

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
@@ -1,31 +1,41 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import type { BoardScrapeSummary } from '@ajh/shared';
 import type { useNotification } from '@ajh/ui';
 
 import type { ScrapeFormState } from '@/features/jobs/components/ScrapeForm/constants';
-import type { Posting } from '@/features/jobs/types';
+import type { Posting, ScrapeOutcome } from '@/features/jobs/types';
 import { fetchJob, useCancelJob, useScrapeBoards, useScrapeProgress } from '@/services';
-
-type ScrapeOutcome = { ok: boolean; note?: string };
+import { useSessionStore } from '@/store/session-store';
 
 export function useScraping(
   notify: ReturnType<typeof useNotification>,
   scrapeForm: ScrapeFormState
 ) {
-  const [scraping, setScraping] = useState(false);
-  const [scrapeJobId, setScrapeJobId] = useState<string | null>(null);
-  const [scrapeOutcome, setScrapeOutcome] = useState<ScrapeOutcome | null>(null);
+  // Everything that describes the BACKEND job lives in the session store
+  // (`JobsSlice`), not in this hook: the Rust scrape outlives a route change, so
+  // component-local state meant navigating away orphaned an uncancellable run,
+  // lost its diagnostics, and reset the replace/append bookkeeping — which then
+  // made the next "Show more" wipe the persisted postings.
+  const setJobs = useSessionStore((s) => s.setJobs);
+  const scrapeJobId = useSessionStore((s) => s.jobs.scrapeJobId);
+  const scrapeOutcome = useSessionStore((s) => s.jobs.scrapeOutcome);
+  // `scraping` stays LOCAL and derived — never a stored field of its own, which
+  // could desync from the job id it describes. It is seeded from the surviving
+  // job id so a remount mid-scrape shows the progress strip and Cancel again;
+  // the watchdog below reconciles it against the job tracker.
+  const [scraping, setScraping] = useState(
+    () => useSessionStore.getState().jobs.scrapeJobId !== null
+  );
+  // Transient display buffer only: the backend posting cache plus the throttled
+  // `invalidatePostings` in JobsPage rehydrate the list on remount, so this does
+  // NOT need to survive navigation.
   const [livePostings, setLivePostings] = useState<Posting[]>([]);
-  const scrapeJobRef = useRef<string | null>(null);
   // Completion/failure events can arrive before startScrape records the jobId
   // (the backend spawns the task and streams events before invoke resolves).
-  // Buffer those here so the outcome isn't lost.
+  // Buffer those here — a per-invoke buffer cannot outlive the call it serves,
+  // so it stays local.
   const pendingFinishRef = useRef<Map<string, ScrapeOutcome>>(new Map());
-  // Signature of the last search; a new search clears previous scraped jobs.
-  const lastSearchRef = useRef<string>('');
-  // Latched when the search target changes: the next scrape replaces (rather
-  // than appends to) the persisted postings, applied on the first stream item.
-  const replacePendingRef = useRef(false);
 
   const scrapeBoards = useScrapeBoards();
   const cancelJob = useCancelJob();
@@ -54,7 +64,6 @@ export function useScraping(
     // "Show more" (#36) re-runs with a larger amount; the search signature is
     // unchanged so scraped postings are NOT cleared and the extra pages append.
     const amount = amountOverride ?? scrapeForm.amount;
-    setScrapeOutcome(null);
     setScraping(true);
     pendingFinishRef.current.clear();
 
@@ -76,17 +85,20 @@ export function useScraping(
       scrapeForm.dateFilter ?? '',
       scrapeForm.companies.slice().sort().join(','),
     ].join('|');
-    if (signature !== lastSearchRef.current) {
-      lastSearchRef.current = signature;
-      replacePendingRef.current = true;
-    } else {
-      replacePendingRef.current = false;
-    }
+    // Read through getState(): the signature of the search the DISPLAYED
+    // postings came from, which survives a route change. Compared against a
+    // freshly-mounted `''` every navigation made "Show more" send replace:true
+    // and destroy the user's result set.
+    const replace = signature !== useSessionStore.getState().jobs.lastSearchSignature;
+    setJobs({
+      scrapeOutcome: null,
+      lastSearchSignature: signature,
+      replacePending: replace,
+    });
 
-    const prevJobId = scrapeJobRef.current;
+    const prevJobId = useSessionStore.getState().jobs.scrapeJobId;
     if (prevJobId) {
-      scrapeJobRef.current = null;
-      setScrapeJobId(null);
+      setJobs({ scrapeJobId: null });
       try {
         await cancelJob.mutateAsync(prevJobId);
       } catch {
@@ -95,17 +107,16 @@ export function useScraping(
     }
 
     try {
-      const res = await doScrape(amount, replacePendingRef.current);
+      const res = await doScrape(amount, replace);
 
       if (res.error) {
         setScraping(false);
-        setScrapeOutcome({ ok: false, note: res.error });
+        setJobs({ scrapeOutcome: { ok: false, note: res.error } });
         notify.error({ message: res.error });
         return;
       }
 
-      scrapeJobRef.current = res.jobId;
-      setScrapeJobId(res.jobId);
+      setJobs({ scrapeJobId: res.jobId });
 
       // If the job already finished during the invoke round-trip, apply it now.
       const buffered = pendingFinishRef.current.get(res.jobId);
@@ -115,17 +126,20 @@ export function useScraping(
       }
     } catch (err) {
       setScraping(false);
-      setScrapeOutcome({ ok: false, note: err instanceof Error ? err.message : String(err) });
+      setJobs({
+        scrapeOutcome: { ok: false, note: err instanceof Error ? err.message : String(err) },
+      });
       notify.error({ message: err instanceof Error ? err.message : 'Scraping failed.' });
     }
   };
 
   const cancelScrape = async () => {
     setScraping(false);
-    setScrapeOutcome(null);
-    scrapeJobRef.current = null;
-    const jobId = scrapeJobId;
-    setScrapeJobId(null);
+    // getState(), not the subscribed value: this handler can run on a mount that
+    // never started the scrape it is cancelling (the user navigated away and
+    // back), and it must cancel whatever is actually in flight right now.
+    const jobId = useSessionStore.getState().jobs.scrapeJobId;
+    setJobs({ scrapeOutcome: null, scrapeJobId: null });
     if (jobId) {
       try {
         await cancelJob.mutateAsync(jobId);
@@ -139,14 +153,23 @@ export function useScraping(
    * Reset scraping state once the active job finishes/fails. Idempotent and
    * keyed by jobId, so the event path and the watchdog poll can both call it
    * safely — only the first one for the active job takes effect.
+   *
+   * `summaries` is written under the SAME identity guard (the watchdog recovery
+   * path); the event path leaves it undefined because JobsPage owns the
+   * translated per-board strip.
    */
-  const finishScrape = useCallback((jobId: string, outcome: ScrapeOutcome) => {
-    if (!jobId || jobId !== scrapeJobRef.current) return;
-    scrapeJobRef.current = null;
-    setScrapeJobId(null);
-    setScraping(false);
-    setScrapeOutcome(outcome);
-  }, []);
+  const finishScrape = useCallback(
+    (jobId: string, outcome: ScrapeOutcome, summaries?: BoardScrapeSummary[]) => {
+      if (!jobId || jobId !== useSessionStore.getState().jobs.scrapeJobId) return;
+      setJobs({
+        scrapeJobId: null,
+        scrapeOutcome: outcome,
+        ...(summaries ? { scrapeSummaries: summaries, scrapeFailureNote: null } : {}),
+      });
+      setScraping(false);
+    },
+    [setJobs]
+  );
 
   /**
    * Handle a completion/failure event. If it arrives before startScrape has
@@ -155,22 +178,35 @@ export function useScraping(
    */
   const noteScrapeFinished = (jobId: string, outcome: ScrapeOutcome) => {
     if (!jobId) return;
-    if (jobId === scrapeJobRef.current) finishScrape(jobId, outcome);
+    if (jobId === useSessionStore.getState().jobs.scrapeJobId) finishScrape(jobId, outcome);
     else pendingFinishRef.current.set(jobId, outcome);
   };
 
   // Watchdog: streamed events can be dropped (async listener churn, missed
-  // emits). Poll the job tracker — the authoritative terminal state — so a
-  // finished scrape can never leave the UI stuck "searching".
+  // emits) and are not delivered at all while JobsPage is unmounted. Poll the
+  // job tracker — the authoritative terminal state — so a finished scrape can
+  // never leave the UI stuck "searching". Because `scrapeJobId` now comes from
+  // the store, this re-arms on remount and settles a job that ended while the
+  // user was on another route.
   useEffect(() => {
     if (!scrapeJobId) return;
     let cancelled = false;
     const check = async () => {
       try {
-        const job = (await fetchJob(scrapeJobId)) as { status?: string; error?: string } | null;
+        const job = (await fetchJob(scrapeJobId)) as {
+          status?: string;
+          error?: string;
+          result?: { boards?: BoardScrapeSummary[] };
+        } | null;
         if (cancelled || !job?.status) return;
-        if (job.status === 'completed') finishScrape(scrapeJobId, { ok: true });
-        else if (job.status === 'failed')
+        if (job.status === 'completed') {
+          // The tracker keeps the same `{ count, boards }` payload the
+          // `job.completed` EVENT carries, so a scrape that finished while the
+          // page was unmounted (no subscription, no event) still gets its
+          // per-board diagnostics back instead of an unexplained empty result.
+          const boards = job.result?.boards;
+          finishScrape(scrapeJobId, { ok: true }, Array.isArray(boards) ? boards : undefined);
+        } else if (job.status === 'failed')
           finishScrape(scrapeJobId, { ok: false, note: job.error ?? undefined });
         else if (job.status === 'cancelled') finishScrape(scrapeJobId, { ok: false });
       } catch {
@@ -192,8 +228,6 @@ export function useScraping(
     scrapeOutcome,
     livePostings,
     setLivePostings,
-    scrapeJobRef,
-    replacePendingRef,
     startScrape,
     cancelScrape,
   };

--- a/apps/desktop/src/renderer/features/jobs/types.ts
+++ b/apps/desktop/src/renderer/features/jobs/types.ts
@@ -45,3 +45,13 @@ export interface JobEvent {
   data?: unknown;
   ts: number;
 }
+
+/**
+ * Terminal outcome of a scrape run — `ok` plus an optional human note (a
+ * partial-failure summary or a sanitized error message). Kept in the session
+ * store so it survives a route change while the backend job keeps running.
+ */
+export interface ScrapeOutcome {
+  ok: boolean;
+  note?: string;
+}

--- a/apps/desktop/src/renderer/features/jobs/types.ts
+++ b/apps/desktop/src/renderer/features/jobs/types.ts
@@ -1,4 +1,9 @@
-import type { JobInteraction, JobTrustAssessment } from '@ajh/shared';
+import {
+  AGGREGATOR_BOARD_ID,
+  type DATE_FILTER_OPTIONS,
+  type JobInteraction,
+  type JobTrustAssessment,
+} from '@ajh/shared';
 
 export interface Posting {
   id: string;
@@ -54,4 +59,50 @@ export interface JobEvent {
 export interface ScrapeOutcome {
   ok: boolean;
   note?: string;
+}
+
+/**
+ * The scrape drawer's search criteria.
+ *
+ * Feature-level (not `components/ScrapeForm/constants`) because the session
+ * store owns `jobs.scrapeForm`: the store reaching into a component's internals
+ * would be a level worse than the feature-level type imports it already makes.
+ * `ScrapeForm/constants` re-exports this for the component subtree.
+ */
+export interface ScrapeFormState {
+  boards: string[];
+  query: string;
+  location: string;
+  /** Structured location captured from a picked geocode suggestion (#49/#40). */
+  countryCode?: string;
+  latitude?: number;
+  longitude?: number;
+  /** Search radius in km; 0 = exact location (no radius). */
+  radiusKm: number;
+  /** Target number of jobs to fetch (#41); sent as the scrape `amount` (backend clamps to 100). */
+  amount: number;
+  dateFilter: '' | (typeof DATE_FILTER_OPTIONS)[number];
+  /**
+   * Company slugs for ATS boards (greenhouse, lever, ashby, etc.) whose APIs
+   * require a company identifier. Comma-separated in the UI, stored as an array.
+   * Empty array = no filter; backend skips ATS boards with `needs-company`.
+   */
+  companies: string[];
+}
+
+/**
+ * A FRESH initial scrape form. A factory, not a shared constant: `boards` and
+ * `companies` are arrays, and a single shared instance spread into every store
+ * reset would alias them across resets.
+ */
+export function makeScrapeFormDefaults(): ScrapeFormState {
+  return {
+    boards: [AGGREGATOR_BOARD_ID],
+    query: '',
+    location: '',
+    radiusKm: 0,
+    amount: 25,
+    dateFilter: '',
+    companies: [],
+  };
 }

--- a/apps/desktop/src/renderer/store/session-store/session-store.test.ts
+++ b/apps/desktop/src/renderer/store/session-store/session-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { JOBS_DEFAULTS, useSessionStore } from './session-store';
+import { makeJobsDefaults, useSessionStore } from './session-store';
 
 const initial = useSessionStore.getState();
 
@@ -57,25 +57,44 @@ describe('useSessionStore', () => {
   it('patches jobs, resumes and settings slices', () => {
     useSessionStore.getState().setJobs({ filter: 'react', sortBy: 'company' });
     expect(useSessionStore.getState().jobs).toEqual({
-      ...JOBS_DEFAULTS,
+      ...makeJobsDefaults(),
       filter: 'react',
       sortBy: 'company',
     });
+    const defaults = makeJobsDefaults();
     // Anchored to absolutes as well as the spread, so a default that silently
     // flips (e.g. `replacePending` starting true, which would make the next
-    // scrape wipe the persisted postings) can't ride along in JOBS_DEFAULTS.
-    expect(JOBS_DEFAULTS.lastSearchSignature).toBe('');
-    expect(JOBS_DEFAULTS.replacePending).toBe(false);
-    expect(JOBS_DEFAULTS.scrapeJobId).toBeNull();
-    expect(JOBS_DEFAULTS.scrapeSummaries).toEqual([]);
-    expect(JOBS_DEFAULTS.scrapeFailureNote).toBeNull();
-    expect(JOBS_DEFAULTS.scrapeOutcome).toBeNull();
+    // scrape wipe the persisted postings) can't ride along in the defaults.
+    expect(defaults.lastSearchSignature).toBe('');
+    expect(defaults.replacePending).toBe(false);
+    expect(defaults.scrapeJobId).toBeNull();
+    expect(defaults.scrapeSummaries).toEqual([]);
+    expect(defaults.scrapeFailureNote).toBeNull();
+    expect(defaults.scrapeOutcome).toBeNull();
 
     useSessionStore.getState().setResumes({ tab: 'activity' });
     expect(useSessionStore.getState().resumes.tab).toBe('activity');
 
     useSessionStore.getState().setSettings({ activeSection: 'ai' });
     expect(useSessionStore.getState().settings.activeSection).toBe('ai');
+  });
+
+  it('the jobs defaults hand out FRESH arrays, never a shared instance', () => {
+    // Two resets must not share `scrapeSummaries` or the arrays inside
+    // `scrapeForm`: aliasing them would let a mutation through one reset show
+    // up in every other.
+    const a = makeJobsDefaults();
+    const b = makeJobsDefaults();
+    expect(a.scrapeSummaries).not.toBe(b.scrapeSummaries);
+    expect(a.scrapeForm).not.toBe(b.scrapeForm);
+    expect(a.scrapeForm.boards).not.toBe(b.scrapeForm.boards);
+    expect(a.scrapeForm.companies).not.toBe(b.scrapeForm.companies);
+
+    // …and mutating one leaves the other at its absolute default.
+    a.scrapeSummaries.push({ board: 'linkedin', count: 1 });
+    a.scrapeForm.boards.push('greenhouse');
+    expect(b.scrapeSummaries).toEqual([]);
+    expect(b.scrapeForm.boards).toEqual(['aggregator']);
   });
 
   it('jobs slice defaults to split view with no selection', () => {

--- a/apps/desktop/src/renderer/store/session-store/session-store.test.ts
+++ b/apps/desktop/src/renderer/store/session-store/session-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { useSessionStore } from './session-store';
+import { JOBS_DEFAULTS, useSessionStore } from './session-store';
 
 const initial = useSessionStore.getState();
 
@@ -57,13 +57,19 @@ describe('useSessionStore', () => {
   it('patches jobs, resumes and settings slices', () => {
     useSessionStore.getState().setJobs({ filter: 'react', sortBy: 'company' });
     expect(useSessionStore.getState().jobs).toEqual({
+      ...JOBS_DEFAULTS,
       filter: 'react',
       sortBy: 'company',
-      viewMode: 'split',
-      selectedId: null,
-      listScrollTop: 0,
-      hideAgency: false,
     });
+    // Anchored to absolutes as well as the spread, so a default that silently
+    // flips (e.g. `replacePending` starting true, which would make the next
+    // scrape wipe the persisted postings) can't ride along in JOBS_DEFAULTS.
+    expect(JOBS_DEFAULTS.lastSearchSignature).toBe('');
+    expect(JOBS_DEFAULTS.replacePending).toBe(false);
+    expect(JOBS_DEFAULTS.scrapeJobId).toBeNull();
+    expect(JOBS_DEFAULTS.scrapeSummaries).toEqual([]);
+    expect(JOBS_DEFAULTS.scrapeFailureNote).toBeNull();
+    expect(JOBS_DEFAULTS.scrapeOutcome).toBeNull();
 
     useSessionStore.getState().setResumes({ tab: 'activity' });
     expect(useSessionStore.getState().resumes.tab).toBe('activity');

--- a/apps/desktop/src/renderer/store/session-store/session-store.ts
+++ b/apps/desktop/src/renderer/store/session-store/session-store.ts
@@ -6,10 +6,10 @@ import type { BoardScrapeSummary } from '@ajh/shared';
 import type { WizardState } from '@/features/autopilot/types';
 import type { TailorWizardState } from '@/features/documents/components/TailorFlow/lib/tailor-state';
 import {
-  SCRAPE_FORM_DEFAULTS,
+  makeScrapeFormDefaults,
   type ScrapeFormState,
-} from '@/features/jobs/components/ScrapeForm/constants';
-import type { ScrapeOutcome } from '@/features/jobs/types';
+  type ScrapeOutcome,
+} from '@/features/jobs/types';
 import type {
   EmphasisId,
   GenerationMeta,
@@ -300,25 +300,31 @@ const RESUME_BUILDER_DEFAULTS: ResumeBuilderSlice = {
 };
 
 /**
- * Exported so tests (and any future reset path) can restore the jobs slice to a
- * known baseline instead of hand-rolling a partial literal that silently drifts
- * from the interface.
+ * A FRESH jobs slice. Exported so tests (and any future reset path) can restore
+ * a known baseline instead of hand-rolling a partial literal that silently
+ * drifts from the interface.
+ *
+ * A factory rather than a shared constant: the slice holds arrays
+ * (`scrapeSummaries`, and `boards`/`companies` inside `scrapeForm`), and a
+ * single instance spread into every reset would alias them across resets.
  */
-export const JOBS_DEFAULTS: JobsSlice = {
-  filter: '',
-  sortBy: 'newest',
-  viewMode: 'split',
-  selectedId: null,
-  listScrollTop: 0,
-  hideAgency: false,
-  scrapeForm: { ...SCRAPE_FORM_DEFAULTS },
-  lastSearchSignature: '',
-  replacePending: false,
-  scrapeJobId: null,
-  scrapeOutcome: null,
-  scrapeSummaries: [],
-  scrapeFailureNote: null,
-};
+export function makeJobsDefaults(): JobsSlice {
+  return {
+    filter: '',
+    sortBy: 'newest',
+    viewMode: 'split',
+    selectedId: null,
+    listScrollTop: 0,
+    hideAgency: false,
+    scrapeForm: makeScrapeFormDefaults(),
+    lastSearchSignature: '',
+    replacePending: false,
+    scrapeJobId: null,
+    scrapeOutcome: null,
+    scrapeSummaries: [],
+    scrapeFailureNote: null,
+  };
+}
 
 // Store
 
@@ -362,7 +368,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   aiGenerate: { ...AI_GENERATE_DEFAULTS },
   analyze: { ...ANALYZE_DEFAULTS },
   resumeBuilder: { ...RESUME_BUILDER_DEFAULTS },
-  jobs: { ...JOBS_DEFAULTS },
+  jobs: makeJobsDefaults(),
   resumes: { tab: 'resumes', filter: '' },
   settings: { activeSection: 'general' },
   autopilot: {

--- a/apps/desktop/src/renderer/store/session-store/session-store.ts
+++ b/apps/desktop/src/renderer/store/session-store/session-store.ts
@@ -1,9 +1,15 @@
 import { create } from 'zustand';
 
 import type { InterviewAnswers } from '@ajh/prompts/builder';
+import type { BoardScrapeSummary } from '@ajh/shared';
 
 import type { WizardState } from '@/features/autopilot/types';
 import type { TailorWizardState } from '@/features/documents/components/TailorFlow/lib/tailor-state';
+import {
+  SCRAPE_FORM_DEFAULTS,
+  type ScrapeFormState,
+} from '@/features/jobs/components/ScrapeForm/constants';
+import type { ScrapeOutcome } from '@/features/jobs/types';
 import type {
   EmphasisId,
   GenerationMeta,
@@ -74,6 +80,19 @@ export interface ResumeBuilderSlice {
   atsMode: boolean;
 }
 
+/**
+ * Jobs-page state.
+ *
+ * The `scrape*` fields describe work that runs in the BACKEND and outlives any
+ * route change, so they cannot live in `JobsPage`/`useScraping` component state:
+ * navigating away used to discard the cancel handle, the diagnostics strip and
+ * the replace/append bookkeeping while the Rust job kept streaming.
+ *
+ * Memory-only on purpose — this store is a plain `create<>()` with no persist
+ * middleware, so quitting the app resets every field here. That means there is
+ * no "job id left over from a previous app run" case to defend against; the
+ * only lifetime that matters is the current session.
+ */
 interface JobsSlice {
   filter: string;
   sortBy: 'newest' | 'oldest' | 'company';
@@ -83,6 +102,33 @@ interface JobsSlice {
   listScrollTop: number;
   /** Hide postings flagged as recruiting/staffing agencies (ADR-029 §i). */
   hideAgency: boolean;
+  /**
+   * The search criteria in the scrape drawer. Here rather than in `JobsPage`
+   * because `lastSearchSignature` below is DERIVED from it: if the form reset on
+   * navigation while the signature didn't (or vice versa) the two desync and the
+   * next scrape mis-decides replace-vs-append.
+   */
+  scrapeForm: ScrapeFormState;
+  /**
+   * Signature of the search the currently-displayed postings came from. A scrape
+   * whose signature matches APPENDS ("Show more"); a different one REPLACES.
+   * Empty string = no search has run in this session.
+   */
+  lastSearchSignature: string;
+  /**
+   * Latched by `startScrape` when the signature changed; consumed by the first
+   * `job.stream` item. Moves with `lastSearchSignature` — split across two
+   * lifetimes they desync exactly like the form/signature pair above.
+   */
+  replacePending: boolean;
+  /** jobId of the in-flight scrape; null when idle. The Cancel handle. */
+  scrapeJobId: string | null;
+  /** Outcome of the most recent finished scrape (scrape-form footer note). */
+  scrapeOutcome: ScrapeOutcome | null;
+  /** Per-board diagnostics of the most recent scrape (the chip strip). */
+  scrapeSummaries: BoardScrapeSummary[];
+  /** Sanitized note for an outright scrape failure (which has no per-board data). */
+  scrapeFailureNote: string | null;
 }
 
 type ResumesTab = 'resumes' | 'coverLetters' | 'activity';
@@ -253,6 +299,27 @@ const RESUME_BUILDER_DEFAULTS: ResumeBuilderSlice = {
   atsMode: false,
 };
 
+/**
+ * Exported so tests (and any future reset path) can restore the jobs slice to a
+ * known baseline instead of hand-rolling a partial literal that silently drifts
+ * from the interface.
+ */
+export const JOBS_DEFAULTS: JobsSlice = {
+  filter: '',
+  sortBy: 'newest',
+  viewMode: 'split',
+  selectedId: null,
+  listScrollTop: 0,
+  hideAgency: false,
+  scrapeForm: { ...SCRAPE_FORM_DEFAULTS },
+  lastSearchSignature: '',
+  replacePending: false,
+  scrapeJobId: null,
+  scrapeOutcome: null,
+  scrapeSummaries: [],
+  scrapeFailureNote: null,
+};
+
 // Store
 
 interface SessionState {
@@ -295,14 +362,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   aiGenerate: { ...AI_GENERATE_DEFAULTS },
   analyze: { ...ANALYZE_DEFAULTS },
   resumeBuilder: { ...RESUME_BUILDER_DEFAULTS },
-  jobs: {
-    filter: '',
-    sortBy: 'newest',
-    viewMode: 'split',
-    selectedId: null,
-    listScrollTop: 0,
-    hideAgency: false,
-  },
+  jobs: { ...JOBS_DEFAULTS },
   resumes: { tab: 'resumes', filter: '' },
   settings: { activeSection: 'general' },
   autopilot: {


### PR DESCRIPTION
The worst instance of the defect class #1015 now guards: state describing long-running Rust work kept in a route-scoped React component. Three defects, one of them **data loss**.

## 1. "Show more" after a route change wiped the persisted posting list

`startScrape` compares the current search signature against the last one; a difference latches `replace: true`, which makes the backend **clear the postings cache** the instant the first new item streams.

Both halves of that comparison were per-mount. Run a search → go to Settings → come back → press **Show more**, and the entire result set is destroyed by a button whose whole contract is *append*.

My original trace said the search signature alone was at fault. **That was wrong, and the fix is bigger:** `scrapeForm` was also `useState` in `JobsPage`, so a route change reset the *criteria* too. Even with the signature restored, the form reads back as `{boards:[aggregator], query:'', amount:25}` and the comparison legitimately says "different search" → same wipe. Mutation **B** below is that proof: signature stored, form left local, and the end-to-end test is still red. The signature is *derived* from the form, and two derived-from lifetimes that differ desync — the same argument that forced the replace latch to move with it.

"Show more" renders unconditionally whenever there are rows, so the repro needs nothing unusual.

## 2. The in-flight scrape became an uncancellable orphan

`scrapeJobId` died with the component. On remount the command bar showed no progress and no Cancel — while the always-mounted status bar still showed it running — and `startScrape`'s "cancel the previous scrape first" step read a now-null id, so **the next search did not cancel the orphan either**: two scrapes writing into one postings cache.

## 3. Per-board diagnostics were lost

`scrapeOutcome` and the summaries hold the "aggregator: 429 rate limited" strip — the one thing that explains an empty result.

**Storing them was not sufficient**, and this is the second thing the trace missed: `useJobEvents` is page-scoped, so `job.completed` is emitted to nobody while unmounted. The job tracker keeps the identical payload, so the watchdog now recovers `result.boards` under `finishScrape`'s existing jobId guard. Five lines, and it's what actually closes defect 3.

## What moved, and what deliberately did not

**Into `JobsSlice`** (which already holds `listScrollTop`, documented as "restored on remount"): the search signature, the replace latch, `scrapeJobId`, the scrape outcome, the summaries, the failure note, and `scrapeForm`.

**Left local, on purpose:** `livePostings` (transient buffer — the backend cache plus the existing throttled invalidation rehydrates it), `pendingFinishRef` (cannot outlive the call that needs it), and **`scraping`**, which stays `useState` seeded from the stored job id. The watchdog remains the reconciler: it keys on `scrapeJobId`, polls the authoritative terminal state, and now settles a remount-onto-a-finished-job on the first tick — tested explicitly, rather than "eventually".

## Mutation checks

Each deletes the *feature*, not a constant:

| | mutation | red tests |
| --- | --- | --- |
| A | signature back to a per-mount ref | 2 |
| B | `scrapeForm` back to `useState` | 1 (the end-to-end one) |
| C | `scrapeJobId` back to `useState` | 10 |
| D | summaries/failure note back to `useState` | 3 |
| E | drop only the watchdog boards recovery | 2 |
| F | `patchScrapeForm` spreads the captured form | 1 |
| G | drop the `job.stream` identity guard | 1 |

The "Show more" test asserts the **wire payload** — `replace === undefined` on the second call, with `replace === true` on the first as an absolute baseline, so a regression that deleted `replace` everywhere cannot pass. Three existing assertions that poked at an internal boolean were replaced with wire-payload assertions for the same reason.

## Test-quality notes

Three sibling `JobsPage` tests mocked the session store with a plain object, which cannot model `getState()` or propagate `setJobs`; they now use the real store seeded per test, and two spy assertions became state assertions. `session-store.test.ts` compared the whole slice to a literal; it now spreads the defaults **plus** six absolute assertions, so a default silently flipping cannot ride along.

## Note

Identity checks inside the event handler read `useSessionStore.getState()` synchronously — the handler runs on backend events, not on React's schedule, so a subscription-captured value would reintroduce exactly the staleness the old ref existed to prevent. The `isActiveJob`-before-`noteScrapeFinished` ordering is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scraping progress and results now persist when navigating away from and returning to the Jobs page.
  * Active jobs remain cancellable, while completed jobs and per-board summaries are restored automatically.
  * Search changes correctly append or replace results as appropriate.
  * Scrape failures now display clearer, board-specific diagnostics.

* **Bug Fixes**
  * Prevented stale or unrelated job updates from overwriting current results or error details.
  * Improved recovery and reconciliation of jobs after navigation or remounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->