### PR TITLE
feat(match): report hard constraints beside the score instead of blending them into it

### DIFF
--- a/apps/desktop/src-tauri/src/commands/match_resume.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume.rs
@@ -21,6 +21,14 @@ use crate::ipc_contracts::resume::ResumeExtractTextRequest;
 use crate::locale::LocaleProfile;
 use crate::postings::PostingsCache;
 
+/// The hard-constraint pass — the non-negotiables (can I take this job at all?)
+/// that a relevance score structurally cannot answer. A sibling module rather
+/// than more of this file: it shares nothing with the scoring kernel by design,
+/// and must not be able to reach it. See its module doc for the three rules it
+/// holds to and for which constraints were refused for lack of candidate-side
+/// data.
+mod constraints;
+
 /// Score a resume against a job posting.
 ///
 /// Returns a `MatchScore` (see packages/shared types): a semantic score from
@@ -642,7 +650,7 @@ pub async fn match_resume(app: AppHandle, req: MatchResumeRequest) -> Value {
     let semantic_enabled = semantic_enabled_bit(req.semantic_scoring_enabled);
     let job_text = job_text_for(&app, &req.job_id);
 
-    score_one(
+    let scored = score_one(
         &AppScoreIo(&app),
         &store,
         &resume,
@@ -654,7 +662,18 @@ pub async fn match_resume(app: AppHandle, req: MatchResumeRequest) -> Value {
         MatchSurface::JobsPage,
         None, // user-initiated: not charged against the unattended daily ceiling
     )
-    .await
+    .await;
+
+    // Hard constraints, reported SEPARATELY and computed AFTER the kernel — the
+    // verdict is a sibling field of the score, never an input to it. Deliberately
+    // out here rather than inside `score_one`: `score_one`'s result is cached in
+    // `match_scores` under a key composed of SCORING inputs only, so a verdict
+    // frozen into that row would be served stale for the whole TTL the moment the
+    // user edits their job preferences. Out here it is recomputed every call, and
+    // a cache HIT gets a fresh verdict on a cached score. It also keeps the
+    // Autopilot and extension entry points — which share the kernel but not this
+    // command — byte-identical.
+    constraints::attach(&app, &req.job_id, scored)
 }
 
 /// Build a searchable text blob for a single cached posting JSON value (title +

--- a/apps/desktop/src-tauri/src/commands/match_resume.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume.rs
@@ -648,7 +648,7 @@ pub async fn match_resume(app: AppHandle, req: MatchResumeRequest) -> Value {
     let resume_raw_keywords = parse_resume_keywords(&resume);
     let active = store.embedding_config();
     let semantic_enabled = semantic_enabled_bit(req.semantic_scoring_enabled);
-    let job_text = job_text_for(&app, &req.job_id);
+    let (job_text, posting_facts) = job_text_and_posting_facts(&app, &req.job_id);
 
     let scored = score_one(
         &AppScoreIo(&app),
@@ -673,7 +673,7 @@ pub async fn match_resume(app: AppHandle, req: MatchResumeRequest) -> Value {
     // a cache HIT gets a fresh verdict on a cached score. It also keeps the
     // Autopilot and extension entry points — which share the kernel but not this
     // command — byte-identical.
-    constraints::attach(&app, &req.job_id, scored)
+    constraints::attach(&app, &posting_facts, scored)
 }
 
 /// Build a searchable text blob for a single cached posting JSON value (title +
@@ -708,6 +708,47 @@ pub(crate) fn job_text_for(app: &AppHandle, job_id: &str) -> Option<String> {
         .iter()
         .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(job_id))?;
     posting_to_text(posting)
+}
+
+/// Everything [`match_resume`] needs from the live posting cache, under ONE lock
+/// and ONE linear scan: the JD blob the scoring kernel consumes, and the
+/// posting-side facts the hard-constraint pass compares against.
+///
+/// Split out from [`job_text_for`] (whose other callers want only the text)
+/// rather than letting `constraints` take the lock again for itself. The
+/// duplicate scan was not free in the place it ran: the constraint verdict is
+/// deliberately recomputed even on a `match_scores` cache HIT — see the call
+/// site — so on the Jobs page, the path where the score costs nothing, a second
+/// full scan of the cache would have run on every single call.
+fn job_text_and_posting_facts(
+    app: &AppHandle,
+    job_id: &str,
+) -> (Option<String>, constraints::PostingFacts) {
+    let cache = app.state::<Mutex<PostingsCache>>();
+    let guard = cache.lock();
+    resolve_posting(
+        guard
+            .get_all()
+            .iter()
+            .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(job_id)),
+    )
+}
+
+/// The pure half of [`job_text_and_posting_facts`]: what a resolved (or missing)
+/// cached posting yields for each consumer.
+///
+/// Split out so the hand-off itself is testable without an `AppHandle`.
+/// Replacing the facts here with a default is invisible to every other test —
+/// the constraint pass would silently report on an empty posting forever — which
+/// is exactly the shape that already bit this feature once at the command's tail
+/// expression. `posting_facts_hand_off_carries_the_real_posting` pins it.
+fn resolve_posting(posting: Option<&Value>) -> (Option<String>, constraints::PostingFacts) {
+    match posting {
+        Some(p) => (posting_to_text(p), constraints::posting_facts_from_value(p)),
+        // No such posting: `score_one` returns its job-not-found error, and
+        // `attach` passes that through untouched, so these facts are never read.
+        None => (None, constraints::PostingFacts::default()),
+    }
 }
 
 /// Identity fields of a cached posting: the company/title/url/board an

--- a/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
@@ -77,13 +77,21 @@
 //!   matcher is reused and the epistemics are re-derived: `Mismatch` maps to
 //!   `Unknown` here.
 //!
-//! `Met` survives because it rests on positive evidence in both directions (a
-//! requested place name appears in the posting's location, or the posting is
-//! flagged/marked remote) and because it never accuses. Its known weakness is
-//! the shared matcher's deliberate token-substring conservatism — "San
-//! Francisco" matches a "San Diego" posting on `san` — which overstates
-//! agreement but costs the user nothing, and which the evidence fields make
-//! visible: both sides' own words ride in the payload.
+//! `Met` survives, but on the STRICT reading of the same matcher: the posting
+//! is flagged or marked remote, or every place token the user actually typed
+//! appears as a WHOLE token of the posting's location (diaeresis variants and
+//! curated exonyms included). The looser reading the scrape filter uses — any
+//! requested token, as a substring — would have "San Francisco" agreeing with a
+//! "San Diego" posting on the shared `san`. That errs toward agreement rather
+//! than accusation, which makes it cheap, not correct: `met` is a positive claim
+//! rendered to the user ("this posting matches where you're looking"), and a
+//! four-state contract whose one confident state is loose has moved the
+//! imprecision rather than removed it.
+//!
+//! The cost is deliberate and one-directional: a request MORE specific than the
+//! posting ("Berlin, Germany" against a bare "Berlin") reads `unknown` rather
+//! than `met`. That loses a true positive; it never states a false one, and
+//! `unknown` claims nothing.
 //!
 //! [`ConstraintStatus::NotMet`] therefore has no producer today. It stays in the
 //! contract because it is the slot a constraint with real two-sided evidence
@@ -297,10 +305,17 @@ fn evidence(s: &str) -> String {
 /// the user be told not to bother?", against a settings field and a posting that
 /// may have arrived from an entirely different search.
 ///
-/// So `Mismatch` — which is only ever the ABSENCE of a substring hit — maps to
-/// [`ConstraintStatus::Unknown`], not to a knock-out. See the module doc for the
-/// concrete pairs (`Germany`/`Berlin`, `Vienna`/`Wien`, `Berlin`/`EMEA`) that
-/// make it absence of evidence rather than evidence of conflict.
+/// Both directions are re-derived, not just the negative one:
+///
+/// - `Mismatch` — only ever the ABSENCE of a substring hit — maps to
+///   [`ConstraintStatus::Unknown`], not to a knock-out. See the module doc for
+///   the concrete pairs (`Germany`/`Berlin`, `Vienna`/`Wien`, `Berlin`/`EMEA`)
+///   that make it absence of evidence rather than evidence of conflict.
+/// - `PlaceOverlap` maps to `Unknown` too. `Met` is a positive claim rendered to
+///   the user, so it takes the strict whole-token reading: a four-state contract
+///   whose one confident state is loose has moved the imprecision rather than
+///   removed it. The looser reading stays where it belongs — in the scrape
+///   filter, which keeps the row.
 fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> ConstraintCheck {
     let posting_evidence = stated(posting.location.as_deref()).map(evidence);
     // No stored preference → nothing to compare against. Not a pass.
@@ -323,11 +338,27 @@ fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> Constra
         posting.board_remote,
         &requested,
     ) {
-        LocationVerdict::Match => ConstraintStatus::Met,
-        // Both of these are "we could not establish a conflict". Collapsing them
-        // is the whole correction: `Mismatch` is a failed substring search, not
-        // a contradiction the user should act on.
-        LocationVerdict::Mismatch | LocationVerdict::Undecided => ConstraintStatus::Unknown,
+        // The posting says it is remote, so where the user is looking cannot
+        // conflict with it. Positive evidence, no place comparison needed.
+        LocationVerdict::Remote => ConstraintStatus::Met,
+        // Every place token the user typed is present as a WHOLE token of the
+        // posting's location. The only place-based claim strong enough to state.
+        LocationVerdict::PlaceMatch => ConstraintStatus::Met,
+        // Everything else is "we could not establish it", in one direction or
+        // the other, and all three publish as Unknown:
+        //
+        // - `PlaceOverlap` — something matched, but only as a substring or on
+        //   part of the request ("San Francisco" against a "San Diego" posting,
+        //   on the shared `san`). Keeping that row in a search is the right
+        //   conservative call; telling the user the posting matches where they
+        //   are looking would simply be false.
+        // - `Mismatch` — a failed substring search, which is the ABSENCE of a
+        //   hit, not a contradiction. `Germany`/`Berlin`, `Vienna`/`Wien`,
+        //   `Berlin`/`EMEA` all land here.
+        // - `Undecided` — nothing comparable on one side or the other.
+        LocationVerdict::PlaceOverlap | LocationVerdict::Mismatch | LocationVerdict::Undecided => {
+            ConstraintStatus::Unknown
+        }
     };
     ConstraintCheck::new(
         LOCATION,
@@ -539,6 +570,42 @@ mod tests {
         );
     }
 
+    /// A partial place-name overlap is not agreement.
+    ///
+    /// The scrape filter deliberately keeps a "San Diego" row for a "San
+    /// Francisco" search — discarding a job is the expensive mistake there. This
+    /// pass must not turn that same conservatism into a claim, because here the
+    /// expensive mistake is telling the user something false. Same matcher,
+    /// opposite risk, so the epistemics differ.
+    #[test]
+    fn a_partial_place_name_overlap_is_unknown_not_met() {
+        // (preference, posting location, what is only partially shared)
+        let partial: &[(&str, &str, &str)] = &[
+            ("San Francisco", "San Diego, CA", "the `san` token only"),
+            ("San Francisco", "Santa Monica, CA", "`san` inside `santa`"),
+            (
+                "Berlin, Germany",
+                "Berlin",
+                "a requested token with no home",
+            ),
+            ("New York", "Newark, NJ", "`new` inside `newark`"),
+        ];
+        for (pref, loc, why) in partial {
+            assert_eq!(
+                status_of(pref, loc, false),
+                ConstraintStatus::Unknown,
+                "{pref:?} vs {loc:?} ({why}) must not read as a match"
+            );
+        }
+        // The control: the SAME preference against a posting that really does
+        // name it reads met, so this is a strictness rule and not a blanket
+        // refusal to ever match a two-token place.
+        assert_eq!(
+            status_of("San Francisco", "San Francisco, CA", false),
+            ConstraintStatus::Met
+        );
+    }
+
     #[test]
     fn location_is_unknown_when_the_posting_states_no_location() {
         for absent in [None, Some(""), Some("   ")] {
@@ -592,6 +659,10 @@ mod tests {
             Some("Multiple locations"),
             Some("EMEA"),
             Some("東京"),
+            // Carries the partial-overlap pairing (with the "San Francisco"
+            // preference below) so the strict-Met rule is exercised by the
+            // distribution, not only by the dedicated test.
+            Some("San Diego, CA"),
         ];
         let prefs = [
             None,
@@ -601,6 +672,7 @@ mod tests {
             Some("Munich"),
             Some("Vienna"),
             Some("Germany"),
+            Some("San Francisco"),
         ];
         let (mut total, mut met, mut unknown, mut no_pref) = (0, 0, 0, 0);
         for p in places {
@@ -623,19 +695,24 @@ mod tests {
             }
         }
         // The whole distribution, hand-derived, so this cannot pass by the
-        // corpus quietly collapsing to one answer. 10 places × 7 preferences
+        // corpus quietly collapsing to one answer. 11 places × 8 preferences
         // × 2 remote flags.
-        assert_eq!(total, 140);
-        // 2 blank preferences × 10 places × 2 flags — checked before anything
+        assert_eq!(total, 176);
+        // 2 blank preferences × 11 places × 2 flags — checked before anything
         // about the posting is read.
-        assert_eq!(no_pref, 40);
-        // 50 from board_remote=true with a stored preference (5 × 10), plus 8
-        // genuine text matches at remote=false: "Berlin, Germany" for both
-        // Berlin and Germany, "München" for Munich via the exonym table, and
-        // "Remote" for all 5 non-blank preferences via the marker list.
-        assert_eq!(met, 50 + 8);
+        assert_eq!(no_pref, 44);
+        // 66 from board_remote=true with a stored preference (6 × 11), plus 9
+        // at remote=false: "Berlin, Germany" for both Berlin and Germany,
+        // "München" for Munich via the exonym table, and "Remote" for all 6
+        // non-blank preferences via the marker list.
+        //
+        // NOT among them: "San Francisco" against "San Diego, CA". That pair
+        // shares the `san` token and was `met` under the loose reading — it is
+        // the cell that fails this assertion if the strict whole-token rule is
+        // ever relaxed.
+        assert_eq!(met, 66 + 9);
         // Everything left over — including every pair in the table above.
-        assert_eq!(unknown, 42);
+        assert_eq!(unknown, 57);
         assert_eq!(met + unknown + no_pref, total);
     }
 

--- a/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
@@ -1,15 +1,15 @@
 //! Hard-constraint pass: the non-negotiables a relevance score cannot carry.
 //!
-//! `combined = f(semantic, ats)` measures how much a posting's vocabulary the
+//! `combined = f(semantic, ats)` measures how much of a posting's vocabulary the
 //! résumé covers. It is a good answer to "is this role about what I do?" and it
-//! is structurally incapable of answering "could I actually take this job?" —
-//! so a candidate who fails a non-negotiable still scores well on keyword
-//! overlap. This module answers the second question **separately** and reports
-//! it as its own payload field.
+//! is structurally incapable of answering "could I actually take this job?" — so
+//! a candidate who fails a non-negotiable still scores well on keyword overlap.
+//! This module answers the second question **separately** and reports it as its
+//! own payload field.
 //!
 //! ## Three rules, and why each exists
 //!
-//! 1. **Never touched the score.** The verdict is computed in the L3 command
+//! 1. **Never touches the score.** The verdict is computed in the L3 command
 //!    ([`super::match_resume`]) AFTER the kernel returns, and merged into the
 //!    result value. It is not a multiplier, not a penalty, and not an input to
 //!    [`super::score_one`] — which means it also never enters the `match_scores`
@@ -18,45 +18,78 @@
 //!    user edits their preferences and would then be served for the whole TTL.
 //! 2. **Never hides a job.** Nothing here filters, sorts, or gates. A wrong
 //!    knock-out tells the user not to bother applying, which is far more costly
-//!    than a wrong relevance number, so the only thing a `NotMet` does is
-//!    appear next to the score.
+//!    than a wrong relevance number.
 //! 3. **Absence of evidence is never evidence.** [`ConstraintStatus`] has FOUR
 //!    values, and the two "we don't know" ones are distinct from both a pass and
 //!    a fail. [`ConstraintStatus::NotMet`] requires positive evidence on BOTH
 //!    sides — the posting states the thing, and the candidate's own stored data
-//!    contradicts it — and that requirement is enforced structurally, inside
-//!    the one constructor every check must go through
-//!    ([`ConstraintCheck::new`]), not merely by convention.
+//!    contradicts it.
 //!
-//! ## What is checked, and what is deliberately NOT
+//! ## No shipped constraint emits `NotMet` today. That is the finding.
 //!
-//! Shipped:
+//! The four constraints the architecture audit ranked, and what this app
+//! actually holds for each:
 //!
-//! - **`location`** — the candidate's stored job-search location
-//!   (`job_preferences.location`, optionally with its geocode-picked
-//!   `country_code`) against the posting's own location text and its board
-//!   remote flag. Both sides are real, persisted, user-entered data.
-//!
-//! Refused, because the CANDIDATE side does not exist in this app today. Each
-//! of these would have required inventing a settings surface and then guessing
-//! at the answer, which is how a check comes to accuse on absence of evidence:
-//!
-//! - **`workAuthorization`** — ranked first by the audit, and the app stores
-//!   nothing about it anywhere: no visa/sponsorship/citizenship/right-to-work
-//!   field on `ContactProfile` or `JobPreferences`. The tempting proxy — the
-//!   candidate's own address — is exactly the false accusation: living in one
-//!   country is not evidence of lacking authorization in another.
+//! - **`workAuthorization`** — ranked first, and the app stores nothing about it
+//!   anywhere: no visa/sponsorship/citizenship/right-to-work field on
+//!   `ContactProfile` or `JobPreferences`. The tempting proxy — the candidate's
+//!   own address — is exactly the false accusation: living in one country is not
+//!   evidence of lacking authorization in another.
 //! - **`employmentType`** — no persisted candidate preference exists.
 //!   `AutopilotTarget::work_type` is a per-autopilot SEARCH filter (and is a
-//!   work arrangement: remote/hybrid/on-site, not full-time/contract), scoped
-//!   to one autopilot config; the Jobs-page match has no autopilot in hand.
+//!   work arrangement: remote/hybrid/on-site, not full-time/contract), scoped to
+//!   one autopilot config; the Jobs-page match has no autopilot in hand.
 //! - **`salaryFloor`** — `job_preferences.salary_expectation` is free text
 //!   ("80k DOE"), documented as the answer to an application's
 //!   salary-expectation question. An expectation is not a stated floor, it
 //!   carries no currency and no period, and the posting side is a structured
 //!   range on ONE board (Adzuna's `salaryMin`/`salaryMax`/`salaryCurrency`).
-//!   Comparing them needs a free-text money parser plus an FX assumption —
-//!   two invented facts per verdict.
+//!   Comparing them needs a free-text money parser plus an FX assumption — two
+//!   invented facts per verdict.
+//! - **`location`** — shipped, but **`Met` / `Unknown` / `NoPreference` only**.
+//!   Two independent facts stop it short of a knock-out, and both were found by
+//!   review after the first cut of this module did publish `NotMet`:
+//!
+//!   1. *The candidate side is a search-personalization setting, not a mobility
+//!      statement.* `job_preferences.location` is written by one free-text
+//!      "Preferred Location" input whose own description reads "personalize
+//!      search results and recommendations". `JobsPage` seeds its scrape form
+//!      from it ONE WAY and never writes back, so a user who deliberately
+//!      searches Austin while Settings still says Berlin leaves no trace here.
+//!      `PostingsCache` holds postings from every past search and retains no
+//!      per-posting record of the `LocationSpec` that produced them, so this
+//!      pass cannot recover which search a given posting came from.
+//!   2. *A failed substring match is absence of evidence, not evidence of
+//!      conflict.* [`location_verdict`]'s `Mismatch` fires on
+//!      `Germany`/`Berlin` (granularity), `Vienna`/`Wien` and `NYC`/`New York`
+//!      (exonym and abbreviation, outside the curated table), `Berlin`/`EMEA`
+//!      and `Berlin`/`Multiple locations` (non-place location text), and
+//!      `Berlin`/`Telecommute` (a remote synonym the marker list lacks). It
+//!      would also fire on most postings from the app's primary aggregator:
+//!      Adzuna never writes `extra.remote` (only the three remote-only boards
+//!      do), so remote detection there rests entirely on location text Adzuna's
+//!      `display_name` does not carry.
+//!
+//!   The same predicate is safe where it already lives — as the scrape-time
+//!   post-filter, judging a posting against a location the user typed seconds
+//!   earlier, costing one row in one search. It is not safe as a published
+//!   verdict against every cached posting, keyed off a settings field. So the
+//!   matcher is reused and the epistemics are re-derived: `Mismatch` maps to
+//!   `Unknown` here.
+//!
+//! `Met` survives because it rests on positive evidence in both directions (a
+//! requested place name appears in the posting's location, or the posting is
+//! flagged/marked remote) and because it never accuses. Its known weakness is
+//! the shared matcher's deliberate token-substring conservatism — "San
+//! Francisco" matches a "San Diego" posting on `san` — which overstates
+//! agreement but costs the user nothing, and which the evidence fields make
+//! visible: both sides' own words ride in the payload.
+//!
+//! [`ConstraintStatus::NotMet`] therefore has no producer today. It stays in the
+//! contract because it is the slot a constraint with real two-sided evidence
+//! will use, and because the renderer's `isKnockOut` predicate needs it to
+//! exist; `no_shipped_constraint_can_emit_a_knock_out` pins that it is unreachable
+//! rather than merely unused.
 //!
 //! ## Language
 //!
@@ -67,106 +100,153 @@
 //! "Muenchen" — is owned by [`location_verdict`]'s exonym table and diaeresis
 //! folding, which this module reuses rather than re-deriving.
 
-use serde::Serialize;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
-use crate::applications::clamp_to_bytes;
 use crate::scraping::engine::location_filter::{location_verdict, LocationVerdict};
 use crate::scraping::types::LocationSpec;
+
+pub(crate) use check::{ConstraintCheck, ConstraintStatus};
 
 /// Stable id of the location constraint, on the wire and in the tests.
 const LOCATION: &str = "location";
 
 /// Byte cap on each piece of evidence echoed into the payload. The posting's
 /// location text is scraped and `job_preferences.location` is renderer-supplied
-/// and uncapped at its write boundary, so both are clamped here rather than
-/// letting an absurd string ride into every match result. Cuts on a UTF-8 char
-/// boundary (see [`clamp_to_bytes`]).
+/// and uncapped at its write boundary, so both are clamped rather than letting an
+/// absurd string ride into every match result.
 const MAX_EVIDENCE_BYTES: usize = 200;
 
-/// The verdict for ONE hard constraint. Four values, because "we cannot tell"
-/// is not one state and is never a pass:
-///
-/// The two knowable answers ([`Self::Met`] / [`Self::NotMet`]) are only ever
-/// reachable with positive evidence on both sides. The two unknowable ones are
-/// kept apart because they are differently actionable: the user can fix
-/// [`Self::NoPreference`] by filling in a setting; nothing they do fixes a
-/// posting that simply does not say ([`Self::Unknown`]).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) enum ConstraintStatus {
-    /// The posting states this, the candidate has stated their side, and they
-    /// agree.
-    Met,
-    /// The posting states this, the candidate has stated their side, and they
-    /// conflict. The only knock-out — and still only ever reported, never acted
-    /// on.
-    NotMet,
-    /// The candidate stated a preference, but no verdict was reachable: the
-    /// posting says nothing about it, or what the candidate stated is not
-    /// usable for a comparison. NOT a pass and NOT a fail.
-    Unknown,
-    /// The candidate has expressed nothing about this constraint, so it cannot
-    /// be evaluated at all. Said out loud rather than assumed either way.
-    NoPreference,
+/// `Some(trimmed)` for a string with content, `None` for absent-or-blank. One
+/// helper so "the user left it empty" and "the user never set it" cannot be
+/// treated as different kinds of nothing.
+fn stated(s: Option<&str>) -> Option<&str> {
+    s.map(str::trim).filter(|s| !s.is_empty())
 }
 
-/// One constraint's verdict plus the evidence it rests on.
+/// The check type and its ONE constructor, sealed in their own module.
 ///
-/// The two evidence fields are the point, not decoration: carrying each side's
-/// own words makes "positive evidence on BOTH sides" a property of the payload
-/// that a test can check, and lets the renderer compose a localized sentence
-/// instead of shipping English prose from the backend.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct ConstraintCheck {
-    /// Stable machine id (`"location"`), not a label — the renderer localizes.
-    id: &'static str,
-    status: ConstraintStatus,
-    /// What the POSTING states about this constraint, verbatim. `None` when it
-    /// states nothing.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    posting: Option<String>,
-    /// What the CANDIDATE has stored about it, verbatim. `None` when they have
-    /// expressed no preference.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    candidate: Option<String>,
-}
+/// The nesting is the point. Rust field privacy is module-scoped, so a
+/// `ConstraintCheck { .. }` struct literal compiles anywhere inside
+/// `mod constraints` — which is precisely where the next constraint gets
+/// written, and precisely the bypass the constructor exists to prevent. One
+/// module boundary makes [`ConstraintCheck::new`] the only reachable way to
+/// build one, so the guarantee below is structural rather than a comment.
+mod check {
+    use serde::Serialize;
 
-impl ConstraintCheck {
-    /// The ONLY way to build a check — the fields are private precisely so this
-    /// is unavoidable.
+    use super::stated;
+
+    /// The verdict for ONE hard constraint. Four values, because "we cannot
+    /// tell" is not one state and is never a pass.
     ///
-    /// Rule 3 is enforced **here, at construction**, rather than as a pass over
-    /// the finished list: a [`ConstraintStatus::NotMet`] that is not backed by
-    /// evidence from BOTH sides is downgraded to [`ConstraintStatus::Unknown`].
-    /// A post-pass would be one `evaluate` edit away from being skipped, and
-    /// would leave the guard testable only in isolation from the checks it
-    /// guards; a constructor cannot be forgotten by a constraint added later.
+    /// The two knowable answers ([`Self::Met`] / [`Self::NotMet`]) are only ever
+    /// reachable with positive evidence on both sides. The two unknowable ones
+    /// are kept apart because they are differently actionable: the user can fix
+    /// [`Self::NoPreference`] by filling in a setting; nothing they do fixes a
+    /// posting that simply does not say ([`Self::Unknown`]).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) enum ConstraintStatus {
+        /// The posting states this, the candidate has stated their side, and
+        /// they agree.
+        Met,
+        /// The posting states this, the candidate has stated their side, and
+        /// they conflict. The only knock-out — and still only ever reported,
+        /// never acted on. No shipped constraint produces it today; see the
+        /// module doc.
+        NotMet,
+        /// No verdict was reachable: the posting says nothing about it, or what
+        /// is known cannot settle the question. NOT a pass and NOT a fail.
+        Unknown,
+        /// The candidate has expressed nothing about this constraint, so it
+        /// cannot be evaluated at all. Said out loud rather than assumed.
+        NoPreference,
+    }
+
+    /// One constraint's verdict plus the evidence it rests on.
     ///
-    /// The location check below is already written so this can never fire. That
-    /// is the point: a knock-out is the one output of this module that costs the
-    /// user something (it tells them not to apply), and this repo has a live,
-    /// still-open incident from a check that accused on absence of evidence.
-    fn new(
+    /// The two evidence fields are the point, not decoration: carrying each
+    /// side's own words makes "positive evidence on BOTH sides" a property of
+    /// the payload that a test can check, and lets the renderer compose a
+    /// localized sentence instead of shipping English prose from the backend.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct ConstraintCheck {
+        /// Stable machine id (`"location"`), not a label — the renderer
+        /// localizes.
         id: &'static str,
         status: ConstraintStatus,
+        /// What the POSTING states about this constraint, verbatim. `None` when
+        /// it states nothing.
+        #[serde(skip_serializing_if = "Option::is_none")]
         posting: Option<String>,
+        /// What the CANDIDATE has stored about it, verbatim. `None` when they
+        /// have expressed no preference. For `location` this is a stated
+        /// PREFERENCE, not an address and not a mobility limit — see the module
+        /// doc.
+        #[serde(skip_serializing_if = "Option::is_none")]
         candidate: Option<String>,
-    ) -> Self {
-        let two_sided =
-            stated(posting.as_deref()).is_some() && stated(candidate.as_deref()).is_some();
-        let status = if status == ConstraintStatus::NotMet && !two_sided {
-            ConstraintStatus::Unknown
-        } else {
-            status
-        };
-        Self {
-            id,
-            status,
-            posting,
-            candidate,
+    }
+
+    impl ConstraintCheck {
+        /// The only way to build a check.
+        ///
+        /// Rule 3 is enforced **here, at construction**, rather than as a pass
+        /// over the finished list: a [`ConstraintStatus::NotMet`] that is not
+        /// backed by evidence from BOTH sides is downgraded to
+        /// [`ConstraintStatus::Unknown`]. A post-pass would be one `evaluate`
+        /// edit away from being skipped, and would leave the guard testable only
+        /// in isolation from the checks it guards.
+        ///
+        /// This is a floor, not the whole rule: two non-empty strings satisfy it
+        /// while still not being evidence of a CONFLICT (a failed substring
+        /// match is not a contradiction). Deciding that is each check's own job
+        /// — see `location_check`, which is why nothing emits `NotMet` today.
+        pub(crate) fn new(
+            id: &'static str,
+            status: ConstraintStatus,
+            posting: Option<String>,
+            candidate: Option<String>,
+        ) -> Self {
+            let two_sided =
+                stated(posting.as_deref()).is_some() && stated(candidate.as_deref()).is_some();
+            let status = if status == ConstraintStatus::NotMet && !two_sided {
+                ConstraintStatus::Unknown
+            } else {
+                status
+            };
+            Self {
+                id,
+                status,
+                posting,
+                candidate,
+            }
+        }
+
+        /// Read accessors are `#[cfg(test)]` because production genuinely has no
+        /// reader: this type exists to be SERIALIZED, and serde's derive reads
+        /// the private fields directly. Gating them on test says that out loud
+        /// (and keeps `dead_code` honest) instead of silencing the warning with
+        /// an `allow`.
+        #[cfg(test)]
+        pub(crate) fn id(&self) -> &'static str {
+            self.id
+        }
+
+        #[cfg(test)]
+        pub(crate) fn status(&self) -> ConstraintStatus {
+            self.status
+        }
+
+        #[cfg(test)]
+        pub(crate) fn posting(&self) -> Option<&str> {
+            self.posting.as_deref()
+        }
+
+        #[cfg(test)]
+        pub(crate) fn candidate(&self) -> Option<&str> {
+            self.candidate.as_deref()
         }
     }
 }
@@ -177,9 +257,11 @@ impl ConstraintCheck {
 pub(crate) struct PostingFacts {
     /// The posting's location text as the board gave it.
     pub location: Option<String>,
-    /// The board's own `remote` flag (Remotive/RemoteOK/WWR and the engine's
-    /// location filter set it), flattened to the top level of the cached
-    /// posting JSON by `JobPosting`'s `#[serde(flatten)] extra`.
+    /// The board's own `remote` flag. Written by exactly three remote-only
+    /// boards (Remotive/RemoteOK/WWR); the aggregator that supplies most
+    /// postings never sets it, so `false` here means "not asserted", never "not
+    /// remote". Flattened to the top level of the cached posting JSON by
+    /// `JobPosting`'s `#[serde(flatten)] extra`.
     pub board_remote: bool,
 }
 
@@ -188,36 +270,40 @@ pub(crate) struct PostingFacts {
 /// module doc for what is missing and why nothing was invented to fill it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CandidateFacts {
-    /// `job_preferences.location` — the job-search location the user typed or
-    /// picked in Settings.
+    /// `job_preferences.location` — the free-text "Preferred Location" setting.
+    ///
+    /// Deliberately the only field here. `job_preferences.country_code` is NOT
+    /// read: no renderer surface ever writes it (both call sites only read it,
+    /// to seed a search), and `location_filter`'s matcher draws needles from
+    /// city/region text only, so a country code contributes nothing to the
+    /// comparison. Threading a field that is inert on both ends would be a claim
+    /// the code does not honour.
     pub location: Option<String>,
-    /// `job_preferences.country_code` — ISO 3166-1 alpha-2, present only when
-    /// the location came from a picked geocode suggestion.
-    pub country_code: Option<String>,
-}
-
-/// `Some(trimmed)` for a string with content, `None` for absent-or-blank. One
-/// helper so "the user left it empty" and "the user never set it" cannot be
-/// treated as different kinds of nothing.
-fn stated(s: Option<&str>) -> Option<&str> {
-    s.map(str::trim).filter(|s| !s.is_empty())
 }
 
 /// Evidence as it goes on the wire: trimmed and byte-capped.
 fn evidence(s: &str) -> String {
-    clamp_to_bytes(s.trim().to_string(), MAX_EVIDENCE_BYTES)
+    crate::applications::clamp_to_bytes(s.trim().to_string(), MAX_EVIDENCE_BYTES)
 }
 
-/// The location constraint: can the candidate take the job where it is?
+/// The location constraint — **`Met` / `Unknown` / `NoPreference` only.**
 ///
-/// The comparison itself is [`location_verdict`] — the same matcher the
-/// scrape-time location post-filter runs, so the remote-marker list, the
-/// diaeresis folding and the curated exonym table have exactly one home. This
-/// function's own job is the epistemics: which of the four statuses that
-/// three-valued answer maps to, and what evidence backs it.
+/// The comparison is [`location_verdict`], the same matcher the scrape-time
+/// location post-filter runs, so the remote-marker list, the diaeresis folding
+/// and the curated exonym table have exactly one home. What differs is the
+/// epistemics, and deliberately so: that matcher answers "should this row be
+/// dropped from THIS search?", which is a cheap, reversible, conservative call
+/// against a location the user typed seconds ago. This function answers "should
+/// the user be told not to bother?", against a settings field and a posting that
+/// may have arrived from an entirely different search.
+///
+/// So `Mismatch` — which is only ever the ABSENCE of a substring hit — maps to
+/// [`ConstraintStatus::Unknown`], not to a knock-out. See the module doc for the
+/// concrete pairs (`Germany`/`Berlin`, `Vienna`/`Wien`, `Berlin`/`EMEA`) that
+/// make it absence of evidence rather than evidence of conflict.
 fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> ConstraintCheck {
     let posting_evidence = stated(posting.location.as_deref()).map(evidence);
-    // No stored job-search location → nothing to compare against. Not a pass.
+    // No stored preference → nothing to compare against. Not a pass.
     let Some(candidate_location) = stated(candidate.location.as_deref()) else {
         return ConstraintCheck::new(
             LOCATION,
@@ -226,12 +312,10 @@ fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> Constra
             None,
         );
     };
-    // `region` stays empty: `job_preferences` has no region column, and
-    // `country_code` alone yields no matchable token — a country-code-only
-    // preference lands on `Undecided`, which is the honest answer.
+    // `region`/`country_code` stay empty: `job_preferences` has no region, and a
+    // country code yields no matchable token (see `CandidateFacts::location`).
     let requested = LocationSpec {
         city: Some(candidate_location.to_string()),
-        country_code: stated(candidate.country_code.as_deref()).map(str::to_string),
         ..Default::default()
     };
     let status = match location_verdict(
@@ -240,8 +324,10 @@ fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> Constra
         &requested,
     ) {
         LocationVerdict::Match => ConstraintStatus::Met,
-        LocationVerdict::Mismatch => ConstraintStatus::NotMet,
-        LocationVerdict::Undecided => ConstraintStatus::Unknown,
+        // Both of these are "we could not establish a conflict". Collapsing them
+        // is the whole correction: `Mismatch` is a failed substring search, not
+        // a contradiction the user should act on.
+        LocationVerdict::Mismatch | LocationVerdict::Undecided => ConstraintStatus::Unknown,
     };
     ConstraintCheck::new(
         LOCATION,
@@ -262,9 +348,11 @@ pub(crate) fn evaluate(posting: &PostingFacts, candidate: &CandidateFacts) -> Ve
 /// `remote` is read from the TOP level (not under `extra`) because
 /// `JobPosting::extra` is `#[serde(flatten)]`.
 fn posting_facts_from_value(posting: &Value) -> PostingFacts {
-    let str_field = |k: &str| posting.get(k).and_then(Value::as_str).map(str::to_string);
     PostingFacts {
-        location: str_field("location"),
+        location: posting
+            .get("location")
+            .and_then(Value::as_str)
+            .map(str::to_string),
         board_remote: posting
             .get("remote")
             .and_then(Value::as_bool)
@@ -289,12 +377,8 @@ fn checks_for_job(app: &AppHandle, job_id: &str) -> Vec<ConstraintCheck> {
         .unwrap_or_default();
     let candidate = app
         .try_state::<crate::job_preferences::JobPreferencesStore>()
-        .map(|store| {
-            let prefs = store.get();
-            CandidateFacts {
-                location: prefs.location,
-                country_code: prefs.country_code,
-            }
+        .map(|store| CandidateFacts {
+            location: store.get().location,
         })
         .unwrap_or_default();
     evaluate(&posting, &candidate)
@@ -339,46 +423,52 @@ mod tests {
     fn candidate(location: Option<&str>) -> CandidateFacts {
         CandidateFacts {
             location: location.map(str::to_string),
-            country_code: None,
         }
     }
 
     /// The one shipped check, by id.
     fn only(checks: &[ConstraintCheck]) -> &ConstraintCheck {
         assert_eq!(checks.len(), 1, "exactly one constraint ships today");
-        assert_eq!(checks[0].id, "location");
+        assert_eq!(checks[0].id(), "location");
         &checks[0]
     }
 
-    // ── location: positive ────────────────────────────────────────────────────
+    /// Status for one (preference, posting location, board remote flag) triple.
+    fn status_of(pref: &str, posting_location: &str, board_remote: bool) -> ConstraintStatus {
+        let checks = evaluate(
+            &posting(Some(posting_location), board_remote),
+            &candidate(Some(pref)),
+        );
+        only(&checks).status()
+    }
+
+    // ── location: the positive case ───────────────────────────────────────────
 
     #[test]
-    fn location_is_met_when_the_posting_names_the_candidates_stored_city() {
+    fn location_is_met_when_the_posting_names_the_candidates_stored_place() {
         let checks = evaluate(
             &posting(Some("Berlin, Germany"), false),
             &candidate(Some("Berlin")),
         );
         let check = only(&checks);
-        assert_eq!(check.status, ConstraintStatus::Met);
+        assert_eq!(check.status(), ConstraintStatus::Met);
         // Both sides' own words are carried, verbatim.
-        assert_eq!(check.posting.as_deref(), Some("Berlin, Germany"));
-        assert_eq!(check.candidate.as_deref(), Some("Berlin"));
+        assert_eq!(check.posting(), Some("Berlin, Germany"));
+        assert_eq!(check.candidate(), Some("Berlin"));
     }
 
     #[test]
-    fn a_remote_posting_is_met_against_any_stored_city() {
+    fn a_remote_posting_is_met_against_any_stored_place() {
         // By the board flag, even with a far-away location text …
-        let by_flag = evaluate(
-            &posting(Some("Austin, TX"), true),
-            &candidate(Some("Berlin")),
+        assert_eq!(
+            status_of("Berlin", "Austin, TX", true),
+            ConstraintStatus::Met
         );
-        assert_eq!(only(&by_flag).status, ConstraintStatus::Met);
         // … and by a marker in the location text alone.
-        let by_text = evaluate(
-            &posting(Some("Remote — Worldwide"), false),
-            &candidate(Some("Berlin")),
+        assert_eq!(
+            status_of("Berlin", "Remote — Worldwide", false),
+            ConstraintStatus::Met
         );
-        assert_eq!(only(&by_text).status, ConstraintStatus::Met);
     }
 
     #[test]
@@ -386,28 +476,68 @@ mod tests {
         // Proof the shared matcher is what decides: "Munich" ↔ "München" is
         // bridged only by `location_filter`'s curated table, which a forked
         // matcher here would not have.
-        let checks = evaluate(
-            &posting(Some("München, Bayern"), false),
-            &candidate(Some("Munich")),
+        assert_eq!(
+            status_of("Munich", "München, Bayern", false),
+            ConstraintStatus::Met
         );
-        assert_eq!(only(&checks).status, ConstraintStatus::Met);
     }
 
-    // ── location: negative ────────────────────────────────────────────────────
+    // ── location: everything else is Unknown, never a knock-out ───────────────
 
+    /// The correction this module was rewritten for.
+    ///
+    /// Every pair below is a job the candidate could plausibly take, and every
+    /// one of them made the FIRST cut of this module publish `notMet` — the
+    /// strongest negative signal the payload has. A failed substring search is
+    /// absence of evidence, not evidence of conflict, so all of them are
+    /// `Unknown` now.
     #[test]
-    fn location_is_not_met_when_the_posting_names_a_different_place_and_is_not_remote() {
-        let checks = evaluate(
-            &posting(Some("Austin, TX, United States"), false),
-            &candidate(Some("Berlin")),
+    fn a_failed_place_name_match_is_unknown_not_a_knock_out() {
+        // (stored preference, posting location, why the substring search fails)
+        let takeable: &[(&str, &str, &str)] = &[
+            ("Germany", "Berlin", "granularity: country vs city"),
+            ("Berlin", "Germany", "granularity: city vs country"),
+            ("Vienna", "Wien", "exonym outside the curated table"),
+            ("NYC", "New York, NY", "abbreviation"),
+            ("San Francisco", "Bay Area", "metro synonym"),
+            ("Tokyo", "東京", "non-Latin script"),
+            (
+                "Berlin",
+                "Telecommute",
+                "remote synonym off the marker list",
+            ),
+            ("Berlin", "Virtual", "remote synonym off the marker list"),
+            ("Berlin", "Multiple locations", "not a place name"),
+            ("Berlin", "EMEA", "region, not a place name"),
+            (
+                "Berlin",
+                "HQ: Austin, TX",
+                "unknowable from a settings field",
+            ),
+        ];
+        for (pref, loc, why) in takeable {
+            let got = status_of(pref, loc, false);
+            assert_eq!(
+                got,
+                ConstraintStatus::Unknown,
+                "{pref:?} vs {loc:?} ({why}) must be unknown, never a knock-out"
+            );
+        }
+        // The three the review named explicitly, asserted individually so a
+        // corpus edit cannot quietly drop them.
+        assert_eq!(
+            status_of("Germany", "Berlin", false),
+            ConstraintStatus::Unknown
         );
-        let check = only(&checks);
-        assert_eq!(check.status, ConstraintStatus::NotMet);
-        assert_eq!(check.posting.as_deref(), Some("Austin, TX, United States"));
-        assert_eq!(check.candidate.as_deref(), Some("Berlin"));
+        assert_eq!(
+            status_of("Vienna", "Wien", false),
+            ConstraintStatus::Unknown
+        );
+        assert_eq!(
+            status_of("Berlin", "Multiple locations", false),
+            ConstraintStatus::Unknown
+        );
     }
-
-    // ── location: unknown / not evaluable ─────────────────────────────────────
 
     #[test]
     fn location_is_unknown_when_the_posting_states_no_location() {
@@ -415,27 +545,13 @@ mod tests {
             let checks = evaluate(&posting(absent, false), &candidate(Some("Berlin")));
             let check = only(&checks);
             assert_eq!(
-                check.status,
+                check.status(),
                 ConstraintStatus::Unknown,
                 "posting location {absent:?} must be unknown, never a pass or a fail"
             );
-            assert_eq!(check.posting, None);
-            assert_eq!(check.candidate.as_deref(), Some("Berlin"));
+            assert_eq!(check.posting(), None);
+            assert_eq!(check.candidate(), Some("Berlin"));
         }
-    }
-
-    #[test]
-    fn location_is_unknown_when_the_stored_preference_yields_no_matchable_place() {
-        // A country-code-only preference: real, but nothing to match a place
-        // name against. Undecided — not a silent pass on the posting's city.
-        let checks = evaluate(
-            &posting(Some("Austin, TX"), false),
-            &CandidateFacts {
-                location: Some("DE".to_string()),
-                country_code: Some("de".to_string()),
-            },
-        );
-        assert_eq!(only(&checks).status, ConstraintStatus::Unknown);
     }
 
     #[test]
@@ -444,18 +560,27 @@ mod tests {
             let checks = evaluate(&posting(Some("Austin, TX"), false), &candidate(empty));
             let check = only(&checks);
             // Distinct from Unknown: the user can fix this one.
-            assert_eq!(check.status, ConstraintStatus::NoPreference);
-            assert_ne!(check.status, ConstraintStatus::Unknown);
-            assert_eq!(check.candidate, None);
+            assert_eq!(check.status(), ConstraintStatus::NoPreference);
+            assert_ne!(check.status(), ConstraintStatus::Unknown);
+            assert_eq!(check.candidate(), None);
             // The posting's evidence is still reported.
-            assert_eq!(check.posting.as_deref(), Some("Austin, TX"));
+            assert_eq!(check.posting(), Some("Austin, TX"));
         }
     }
 
-    // ── the invariant ─────────────────────────────────────────────────────────
+    // ── the invariant that replaces the old knock-out count ───────────────────
 
+    /// No input reaches `NotMet` through the shipped checks.
+    ///
+    /// The inverse of the assertion this test replaces. The old one counted the
+    /// knock-outs a hand-picked corpus produced and asserted the count — which
+    /// could only ever confirm the code agreed with itself, because the corpus
+    /// held only pairings it already agreed with. This asserts an absolute zero
+    /// over a corpus deliberately stocked with the pairs that used to fail, and
+    /// anchors the non-vacuity from both ends: every cell yields exactly one
+    /// check, and a known number of them are `Met`.
     #[test]
-    fn a_knock_out_always_carries_evidence_from_both_sides() {
+    fn no_shipped_constraint_can_emit_a_knock_out() {
         let places = [
             None,
             Some(""),
@@ -463,42 +588,61 @@ mod tests {
             Some("Austin, TX"),
             Some("Remote"),
             Some("München"),
+            Some("Wien"),
+            Some("Multiple locations"),
+            Some("EMEA"),
+            Some("東京"),
         ];
-        let prefs = [None, Some(""), Some("Berlin"), Some("DE"), Some("Munich")];
-        let mut knock_outs = 0;
+        let prefs = [
+            None,
+            Some(""),
+            Some("Berlin"),
+            Some("DE"),
+            Some("Munich"),
+            Some("Vienna"),
+            Some("Germany"),
+        ];
+        let (mut total, mut met, mut unknown, mut no_pref) = (0, 0, 0, 0);
         for p in places {
             for c in prefs {
                 for remote in [false, true] {
-                    for check in evaluate(&posting(p, remote), &candidate(c)) {
-                        if check.status != ConstraintStatus::NotMet {
-                            continue;
+                    let checks = evaluate(&posting(p, remote), &candidate(c));
+                    assert_eq!(checks.len(), 1, "each cell yields exactly one check");
+                    for check in checks {
+                        total += 1;
+                        match check.status() {
+                            ConstraintStatus::NotMet => {
+                                panic!("no shipped constraint may accuse: {check:?}")
+                            }
+                            ConstraintStatus::Met => met += 1,
+                            ConstraintStatus::Unknown => unknown += 1,
+                            ConstraintStatus::NoPreference => no_pref += 1,
                         }
-                        knock_outs += 1;
-                        assert!(
-                            stated(check.posting.as_deref()).is_some(),
-                            "notMet with no posting evidence: {check:?}"
-                        );
-                        assert!(
-                            stated(check.candidate.as_deref()).is_some(),
-                            "notMet with no candidate evidence: {check:?}"
-                        );
                     }
                 }
             }
         }
-        // Anchored to a hand-counted absolute so the loop above cannot go
-        // vacuously green: the four non-remote conflicting pairs are
-        // Munich↔"Berlin, Germany", Berlin↔"Austin, TX", Munich↔"Austin, TX"
-        // and Berlin↔"München". Every other cell is met (Berlin↔Berlin,
-        // Munich↔München via the exonym table, anything↔"Remote", every
-        // remote=true row) or unknowable (blank posting, blank or 2-letter
-        // preference).
-        assert_eq!(knock_outs, 4);
+        // The whole distribution, hand-derived, so this cannot pass by the
+        // corpus quietly collapsing to one answer. 10 places × 7 preferences
+        // × 2 remote flags.
+        assert_eq!(total, 140);
+        // 2 blank preferences × 10 places × 2 flags — checked before anything
+        // about the posting is read.
+        assert_eq!(no_pref, 40);
+        // 50 from board_remote=true with a stored preference (5 × 10), plus 8
+        // genuine text matches at remote=false: "Berlin, Germany" for both
+        // Berlin and Germany, "München" for Munich via the exonym table, and
+        // "Remote" for all 5 non-blank preferences via the marker list.
+        assert_eq!(met, 50 + 8);
+        // Everything left over — including every pair in the table above.
+        assert_eq!(unknown, 42);
+        assert_eq!(met + unknown + no_pref, total);
     }
 
     /// The constructor refuses to build a one-sided accusation. Driven through
-    /// `ConstraintCheck::new` — the only way any check is ever built — so this
-    /// cannot pass while the production path bypasses the guard.
+    /// `ConstraintCheck::new` — the only reachable way any check is ever built,
+    /// now that the type is sealed in its own module — so this cannot pass while
+    /// the production path bypasses the guard.
     #[test]
     fn an_unevidenced_accusation_is_downgraded_to_unknown_at_construction() {
         let some = || Some("Austin, TX".to_string());
@@ -512,20 +656,22 @@ mod tests {
             let check =
                 ConstraintCheck::new(LOCATION, ConstraintStatus::NotMet, posting, candidate);
             assert_eq!(
-                check.status,
+                check.status(),
                 ConstraintStatus::Unknown,
                 "a knock-out without evidence on both sides must not survive construction: {check:?}"
             );
         }
-        // A fully-evidenced knock-out is left alone …
+        // A fully-evidenced knock-out is left alone — the floor is two-sided
+        // evidence, and judging whether that evidence is a CONFLICT is each
+        // check's own job (which is why `location_check` never asks for one).
         let real = ConstraintCheck::new(
             LOCATION,
             ConstraintStatus::NotMet,
             some(),
             Some("Berlin".to_string()),
         );
-        assert_eq!(real.status, ConstraintStatus::NotMet);
-        // … and the guard only ever touches NotMet: a one-sided Met/Unknown/
+        assert_eq!(real.status(), ConstraintStatus::NotMet);
+        // The guard only ever touches NotMet: a one-sided Met/Unknown/
         // NoPreference is legitimate and passes through unchanged.
         for status in [
             ConstraintStatus::Met,
@@ -533,11 +679,53 @@ mod tests {
             ConstraintStatus::NoPreference,
         ] {
             let check = ConstraintCheck::new(LOCATION, status, None, None);
-            assert_eq!(check.status, status);
+            assert_eq!(check.status(), status);
         }
     }
 
     // ── payload shape / non-contamination ─────────────────────────────────────
+
+    /// The one line that makes any of this reachable.
+    ///
+    /// `#[tauri::command] match_resume` needs an `AppHandle`, so no test in this
+    /// crate can call it — delete `constraints::attach` from it and every test
+    /// above stays green while the feature silently disappears from the app.
+    /// (Verified: that mutation survived the whole suite before this test
+    /// existed.) A compile-time source scan is the cheapest honest pin, and the
+    /// same technique `tests/architecture.rs` already uses for invariants a
+    /// linked build cannot see.
+    ///
+    /// The call is pinned as the function's TAIL EXPRESSION — the exact leading
+    /// indentation, then the closing brace on the next line. A weaker
+    /// `contains("constraints::attach")` would stay green for
+    /// `let _ = constraints::attach(…);` or a commented-out call, both of which
+    /// keep the text while dropping the feature; the discard form is rejected
+    /// explicitly too, so the failure names the mistake.
+    #[test]
+    fn the_match_resume_command_returns_the_attached_report() {
+        const COMMAND_SRC: &str = include_str!("../match_resume.rs");
+        // Matched as a WHOLE LINE, which is what makes the weak forms fail: a
+        // commented-out call carries a `//` prefix, and the discard form starts
+        // `let _ =`, so neither is equal to this.
+        const CALL: &str = "    constraints::attach(&app, &req.job_id, scored)";
+        assert!(
+            COMMAND_SRC.lines().any(|line| line == CALL),
+            "commands::match_resume must RETURN score_one's result through \
+             constraints::attach — without that call the hard-constraint pass \
+             never reaches the payload, and nothing else fails"
+        );
+        // Nothing here needs to check that the call is the function's LAST
+        // expression: `CALL` carries no trailing semicolon, and a `Value`-typed
+        // expression statement that is NOT the tail does not compile. The
+        // compiler owns that half; this test owns "the line is still there".
+        // (Deliberately no closing-brace literal — the egress inventory's
+        // stripper counts braces naively and cannot see into string literals, so
+        // an unbalanced one here truncates the region it strips from this file.)
+        assert!(
+            !COMMAND_SRC.contains("let _ = constraints::attach"),
+            "discarding the attached report drops the feature while keeping the call"
+        );
+    }
 
     /// The scoring fields must come out the other side byte-identical, and the
     /// verdict must arrive as its own sibling field — never folded in.
@@ -557,52 +745,32 @@ mod tests {
             &candidate(Some("Berlin")),
         );
         let merged = merge(scored.clone(), || checks.clone());
-        // The verdict arrived as its own sibling field, not folded in anywhere.
+        // The verdict arrived as its own sibling field, not folded in anywhere —
+        // and the far-away posting reads `unknown`, not `notMet`.
         assert_eq!(
             merged["constraints"],
             json!({ "checks": [{
                 "id": "location",
-                "status": "notMet",
+                "status": "unknown",
                 "posting": "Austin, TX",
                 "candidate": "Berlin",
             }] })
         );
-        // A failed constraint did not move the number: 64, the absolute value
-        // 0.6 × 80 + 0.4 × 40 produces.
-        assert_eq!(only(&checks).status, ConstraintStatus::NotMet);
+        // The number did not move: 64, the absolute value 0.6 × 80 + 0.4 × 40
+        // produces.
         assert_eq!(merged["combined"], json!(64.0));
         assert_eq!(merged["ats"], json!(40.0));
         assert_eq!(merged["semantic"], json!(80.0));
         assert_eq!(merged["scoreSource"], json!("combined"));
         assert_eq!(merged["gaps"], json!(["kubernetes"]));
-        // And every pre-existing field is byte-identical: the merge adds one
-        // key and rewrites none.
+        // And every pre-existing field is byte-identical: the merge adds one key
+        // and rewrites none.
         let mut without_constraints = merged.clone();
         without_constraints
             .as_object_mut()
             .unwrap()
             .remove("constraints");
         assert_eq!(without_constraints, scored);
-    }
-
-    /// The one line that makes any of this reachable.
-    ///
-    /// `#[tauri::command] match_resume` needs an `AppHandle`, so no test in this
-    /// crate can call it — delete `constraints::attach` from it and every test
-    /// above stays green while the feature silently disappears from the app.
-    /// (Verified: that mutation survived the whole suite before this test
-    /// existed.) A compile-time source scan is the cheapest honest pin, and the
-    /// same technique `tests/architecture.rs` already uses for invariants a
-    /// linked build cannot see.
-    #[test]
-    fn the_match_resume_command_actually_attaches_the_report() {
-        const COMMAND_SRC: &str = include_str!("../match_resume.rs");
-        assert!(
-            COMMAND_SRC.contains("constraints::attach(&app, &req.job_id, scored)"),
-            "commands::match_resume must return score_one's result through \
-             constraints::attach — without that call the hard-constraint pass \
-             never reaches the payload, and nothing else fails"
-        );
     }
 
     #[test]
@@ -675,12 +843,9 @@ mod tests {
         let long = "ü".repeat(400); // 800 bytes
         let checks = evaluate(&posting(Some(&long), false), &candidate(Some(&long)));
         let check = only(&checks);
-        let posted = check.posting.as_deref().unwrap();
+        let posted = check.posting().unwrap();
         assert_eq!(posted.len(), MAX_EVIDENCE_BYTES);
         assert_eq!(posted.chars().count(), MAX_EVIDENCE_BYTES / 2);
-        assert_eq!(
-            check.candidate.as_deref().unwrap().len(),
-            MAX_EVIDENCE_BYTES
-        );
+        assert_eq!(check.candidate().unwrap().len(), MAX_EVIDENCE_BYTES);
     }
 }

--- a/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
@@ -1,0 +1,686 @@
+//! Hard-constraint pass: the non-negotiables a relevance score cannot carry.
+//!
+//! `combined = f(semantic, ats)` measures how much a posting's vocabulary the
+//! résumé covers. It is a good answer to "is this role about what I do?" and it
+//! is structurally incapable of answering "could I actually take this job?" —
+//! so a candidate who fails a non-negotiable still scores well on keyword
+//! overlap. This module answers the second question **separately** and reports
+//! it as its own payload field.
+//!
+//! ## Three rules, and why each exists
+//!
+//! 1. **Never touched the score.** The verdict is computed in the L3 command
+//!    ([`super::match_resume`]) AFTER the kernel returns, and merged into the
+//!    result value. It is not a multiplier, not a penalty, and not an input to
+//!    [`super::score_one`] — which means it also never enters the `match_scores`
+//!    cache. That is not just hygiene: the cache key is composed of SCORING
+//!    inputs only, so a verdict cached under it would go stale the moment the
+//!    user edits their preferences and would then be served for the whole TTL.
+//! 2. **Never hides a job.** Nothing here filters, sorts, or gates. A wrong
+//!    knock-out tells the user not to bother applying, which is far more costly
+//!    than a wrong relevance number, so the only thing a `NotMet` does is
+//!    appear next to the score.
+//! 3. **Absence of evidence is never evidence.** [`ConstraintStatus`] has FOUR
+//!    values, and the two "we don't know" ones are distinct from both a pass and
+//!    a fail. [`ConstraintStatus::NotMet`] requires positive evidence on BOTH
+//!    sides — the posting states the thing, and the candidate's own stored data
+//!    contradicts it — and that requirement is enforced structurally, inside
+//!    the one constructor every check must go through
+//!    ([`ConstraintCheck::new`]), not merely by convention.
+//!
+//! ## What is checked, and what is deliberately NOT
+//!
+//! Shipped:
+//!
+//! - **`location`** — the candidate's stored job-search location
+//!   (`job_preferences.location`, optionally with its geocode-picked
+//!   `country_code`) against the posting's own location text and its board
+//!   remote flag. Both sides are real, persisted, user-entered data.
+//!
+//! Refused, because the CANDIDATE side does not exist in this app today. Each
+//! of these would have required inventing a settings surface and then guessing
+//! at the answer, which is how a check comes to accuse on absence of evidence:
+//!
+//! - **`workAuthorization`** — ranked first by the audit, and the app stores
+//!   nothing about it anywhere: no visa/sponsorship/citizenship/right-to-work
+//!   field on `ContactProfile` or `JobPreferences`. The tempting proxy — the
+//!   candidate's own address — is exactly the false accusation: living in one
+//!   country is not evidence of lacking authorization in another.
+//! - **`employmentType`** — no persisted candidate preference exists.
+//!   `AutopilotTarget::work_type` is a per-autopilot SEARCH filter (and is a
+//!   work arrangement: remote/hybrid/on-site, not full-time/contract), scoped
+//!   to one autopilot config; the Jobs-page match has no autopilot in hand.
+//! - **`salaryFloor`** — `job_preferences.salary_expectation` is free text
+//!   ("80k DOE"), documented as the answer to an application's
+//!   salary-expectation question. An expectation is not a stated floor, it
+//!   carries no currency and no period, and the posting side is a structured
+//!   range on ONE board (Adzuna's `salaryMin`/`salaryMax`/`salaryCurrency`).
+//!   Comparing them needs a free-text money parser plus an FX assumption —
+//!   two invented facts per verdict.
+//!
+//! ## Language
+//!
+//! `languages_align` (mandatory on résumé↔posting SCORING surfaces) does not
+//! apply here: nothing in this module reads the résumé or the JD body, stems a
+//! token, or extracts a keyword. It compares two short place-name strings, and
+//! the language problem that actually bites there — "München" vs "Munich" vs
+//! "Muenchen" — is owned by [`location_verdict`]'s exonym table and diaeresis
+//! folding, which this module reuses rather than re-deriving.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager};
+
+use crate::applications::clamp_to_bytes;
+use crate::scraping::engine::location_filter::{location_verdict, LocationVerdict};
+use crate::scraping::types::LocationSpec;
+
+/// Stable id of the location constraint, on the wire and in the tests.
+const LOCATION: &str = "location";
+
+/// Byte cap on each piece of evidence echoed into the payload. The posting's
+/// location text is scraped and `job_preferences.location` is renderer-supplied
+/// and uncapped at its write boundary, so both are clamped here rather than
+/// letting an absurd string ride into every match result. Cuts on a UTF-8 char
+/// boundary (see [`clamp_to_bytes`]).
+const MAX_EVIDENCE_BYTES: usize = 200;
+
+/// The verdict for ONE hard constraint. Four values, because "we cannot tell"
+/// is not one state and is never a pass:
+///
+/// The two knowable answers ([`Self::Met`] / [`Self::NotMet`]) are only ever
+/// reachable with positive evidence on both sides. The two unknowable ones are
+/// kept apart because they are differently actionable: the user can fix
+/// [`Self::NoPreference`] by filling in a setting; nothing they do fixes a
+/// posting that simply does not say ([`Self::Unknown`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ConstraintStatus {
+    /// The posting states this, the candidate has stated their side, and they
+    /// agree.
+    Met,
+    /// The posting states this, the candidate has stated their side, and they
+    /// conflict. The only knock-out — and still only ever reported, never acted
+    /// on.
+    NotMet,
+    /// The candidate stated a preference, but no verdict was reachable: the
+    /// posting says nothing about it, or what the candidate stated is not
+    /// usable for a comparison. NOT a pass and NOT a fail.
+    Unknown,
+    /// The candidate has expressed nothing about this constraint, so it cannot
+    /// be evaluated at all. Said out loud rather than assumed either way.
+    NoPreference,
+}
+
+/// One constraint's verdict plus the evidence it rests on.
+///
+/// The two evidence fields are the point, not decoration: carrying each side's
+/// own words makes "positive evidence on BOTH sides" a property of the payload
+/// that a test can check, and lets the renderer compose a localized sentence
+/// instead of shipping English prose from the backend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConstraintCheck {
+    /// Stable machine id (`"location"`), not a label — the renderer localizes.
+    id: &'static str,
+    status: ConstraintStatus,
+    /// What the POSTING states about this constraint, verbatim. `None` when it
+    /// states nothing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    posting: Option<String>,
+    /// What the CANDIDATE has stored about it, verbatim. `None` when they have
+    /// expressed no preference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    candidate: Option<String>,
+}
+
+impl ConstraintCheck {
+    /// The ONLY way to build a check — the fields are private precisely so this
+    /// is unavoidable.
+    ///
+    /// Rule 3 is enforced **here, at construction**, rather than as a pass over
+    /// the finished list: a [`ConstraintStatus::NotMet`] that is not backed by
+    /// evidence from BOTH sides is downgraded to [`ConstraintStatus::Unknown`].
+    /// A post-pass would be one `evaluate` edit away from being skipped, and
+    /// would leave the guard testable only in isolation from the checks it
+    /// guards; a constructor cannot be forgotten by a constraint added later.
+    ///
+    /// The location check below is already written so this can never fire. That
+    /// is the point: a knock-out is the one output of this module that costs the
+    /// user something (it tells them not to apply), and this repo has a live,
+    /// still-open incident from a check that accused on absence of evidence.
+    fn new(
+        id: &'static str,
+        status: ConstraintStatus,
+        posting: Option<String>,
+        candidate: Option<String>,
+    ) -> Self {
+        let two_sided =
+            stated(posting.as_deref()).is_some() && stated(candidate.as_deref()).is_some();
+        let status = if status == ConstraintStatus::NotMet && !two_sided {
+            ConstraintStatus::Unknown
+        } else {
+            status
+        };
+        Self {
+            id,
+            status,
+            posting,
+            candidate,
+        }
+    }
+}
+
+/// The posting-side facts a constraint pass reads. Deliberately NOT the JD body:
+/// these are the posting's own structured claims.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct PostingFacts {
+    /// The posting's location text as the board gave it.
+    pub location: Option<String>,
+    /// The board's own `remote` flag (Remotive/RemoteOK/WWR and the engine's
+    /// location filter set it), flattened to the top level of the cached
+    /// posting JSON by `JobPosting`'s `#[serde(flatten)] extra`.
+    pub board_remote: bool,
+}
+
+/// The candidate-side facts a constraint pass reads — everything the app
+/// actually persists that bears on a non-negotiable. Short on purpose; see the
+/// module doc for what is missing and why nothing was invented to fill it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CandidateFacts {
+    /// `job_preferences.location` — the job-search location the user typed or
+    /// picked in Settings.
+    pub location: Option<String>,
+    /// `job_preferences.country_code` — ISO 3166-1 alpha-2, present only when
+    /// the location came from a picked geocode suggestion.
+    pub country_code: Option<String>,
+}
+
+/// `Some(trimmed)` for a string with content, `None` for absent-or-blank. One
+/// helper so "the user left it empty" and "the user never set it" cannot be
+/// treated as different kinds of nothing.
+fn stated(s: Option<&str>) -> Option<&str> {
+    s.map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// Evidence as it goes on the wire: trimmed and byte-capped.
+fn evidence(s: &str) -> String {
+    clamp_to_bytes(s.trim().to_string(), MAX_EVIDENCE_BYTES)
+}
+
+/// The location constraint: can the candidate take the job where it is?
+///
+/// The comparison itself is [`location_verdict`] — the same matcher the
+/// scrape-time location post-filter runs, so the remote-marker list, the
+/// diaeresis folding and the curated exonym table have exactly one home. This
+/// function's own job is the epistemics: which of the four statuses that
+/// three-valued answer maps to, and what evidence backs it.
+fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> ConstraintCheck {
+    let posting_evidence = stated(posting.location.as_deref()).map(evidence);
+    // No stored job-search location → nothing to compare against. Not a pass.
+    let Some(candidate_location) = stated(candidate.location.as_deref()) else {
+        return ConstraintCheck::new(
+            LOCATION,
+            ConstraintStatus::NoPreference,
+            posting_evidence,
+            None,
+        );
+    };
+    // `region` stays empty: `job_preferences` has no region column, and
+    // `country_code` alone yields no matchable token — a country-code-only
+    // preference lands on `Undecided`, which is the honest answer.
+    let requested = LocationSpec {
+        city: Some(candidate_location.to_string()),
+        country_code: stated(candidate.country_code.as_deref()).map(str::to_string),
+        ..Default::default()
+    };
+    let status = match location_verdict(
+        stated(posting.location.as_deref()),
+        posting.board_remote,
+        &requested,
+    ) {
+        LocationVerdict::Match => ConstraintStatus::Met,
+        LocationVerdict::Mismatch => ConstraintStatus::NotMet,
+        LocationVerdict::Undecided => ConstraintStatus::Unknown,
+    };
+    ConstraintCheck::new(
+        LOCATION,
+        status,
+        posting_evidence,
+        Some(evidence(candidate_location)),
+    )
+}
+
+/// Evaluate every shipped hard constraint. Pure — the whole decision surface of
+/// this module, with no `AppHandle` in sight.
+pub(crate) fn evaluate(posting: &PostingFacts, candidate: &CandidateFacts) -> Vec<ConstraintCheck> {
+    vec![location_check(posting, candidate)]
+}
+
+/// Read the posting-side facts out of one cached posting JSON value. Pure.
+///
+/// `remote` is read from the TOP level (not under `extra`) because
+/// `JobPosting::extra` is `#[serde(flatten)]`.
+fn posting_facts_from_value(posting: &Value) -> PostingFacts {
+    let str_field = |k: &str| posting.get(k).and_then(Value::as_str).map(str::to_string);
+    PostingFacts {
+        location: str_field("location"),
+        board_remote: posting
+            .get("remote")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    }
+}
+
+/// Resolve both sides from app state and evaluate. Every lookup is a
+/// `try_state` — the job-preferences store's `open` is non-fatal at setup, and a
+/// missing store must read as "no preference expressed", never as a pass.
+fn checks_for_job(app: &AppHandle, job_id: &str) -> Vec<ConstraintCheck> {
+    let posting = app
+        .try_state::<parking_lot::Mutex<crate::postings::PostingsCache>>()
+        .and_then(|cache| {
+            let guard = cache.lock();
+            guard
+                .get_all()
+                .iter()
+                .find(|p| p.get("id").and_then(Value::as_str) == Some(job_id))
+                .map(posting_facts_from_value)
+        })
+        .unwrap_or_default();
+    let candidate = app
+        .try_state::<crate::job_preferences::JobPreferencesStore>()
+        .map(|store| {
+            let prefs = store.get();
+            CandidateFacts {
+                location: prefs.location,
+                country_code: prefs.country_code,
+            }
+        })
+        .unwrap_or_default();
+    evaluate(&posting, &candidate)
+}
+
+/// Merge a constraint report into a `MatchScore` value as its own `constraints`
+/// field, leaving every scoring field byte-identical.
+///
+/// An `{ "error": … }` value (job not in cache) is returned untouched, and
+/// `checks` is not even evaluated: there is no posting to state anything, so
+/// there is nothing to report about it. Takes a closure rather than a `Vec` so
+/// that skip is real work avoided, and so the whole merge is testable without an
+/// `AppHandle`.
+fn merge(mut score: Value, checks: impl FnOnce() -> Vec<ConstraintCheck>) -> Value {
+    if score.get("error").is_some() {
+        return score;
+    }
+    let Some(obj) = score.as_object_mut() else {
+        return score;
+    };
+    obj.insert("constraints".to_string(), json!({ "checks": checks() }));
+    score
+}
+
+/// Evaluate the hard constraints for `job_id` and merge the report into `score`.
+/// The command layer's single entry point — see [`merge`] for the shape.
+pub(crate) fn attach(app: &AppHandle, job_id: &str, score: Value) -> Value {
+    merge(score, || checks_for_job(app, job_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn posting(location: Option<&str>, board_remote: bool) -> PostingFacts {
+        PostingFacts {
+            location: location.map(str::to_string),
+            board_remote,
+        }
+    }
+
+    fn candidate(location: Option<&str>) -> CandidateFacts {
+        CandidateFacts {
+            location: location.map(str::to_string),
+            country_code: None,
+        }
+    }
+
+    /// The one shipped check, by id.
+    fn only(checks: &[ConstraintCheck]) -> &ConstraintCheck {
+        assert_eq!(checks.len(), 1, "exactly one constraint ships today");
+        assert_eq!(checks[0].id, "location");
+        &checks[0]
+    }
+
+    // ── location: positive ────────────────────────────────────────────────────
+
+    #[test]
+    fn location_is_met_when_the_posting_names_the_candidates_stored_city() {
+        let checks = evaluate(
+            &posting(Some("Berlin, Germany"), false),
+            &candidate(Some("Berlin")),
+        );
+        let check = only(&checks);
+        assert_eq!(check.status, ConstraintStatus::Met);
+        // Both sides' own words are carried, verbatim.
+        assert_eq!(check.posting.as_deref(), Some("Berlin, Germany"));
+        assert_eq!(check.candidate.as_deref(), Some("Berlin"));
+    }
+
+    #[test]
+    fn a_remote_posting_is_met_against_any_stored_city() {
+        // By the board flag, even with a far-away location text …
+        let by_flag = evaluate(
+            &posting(Some("Austin, TX"), true),
+            &candidate(Some("Berlin")),
+        );
+        assert_eq!(only(&by_flag).status, ConstraintStatus::Met);
+        // … and by a marker in the location text alone.
+        let by_text = evaluate(
+            &posting(Some("Remote — Worldwide"), false),
+            &candidate(Some("Berlin")),
+        );
+        assert_eq!(only(&by_text).status, ConstraintStatus::Met);
+    }
+
+    #[test]
+    fn location_is_met_across_a_curated_exonym_pair() {
+        // Proof the shared matcher is what decides: "Munich" ↔ "München" is
+        // bridged only by `location_filter`'s curated table, which a forked
+        // matcher here would not have.
+        let checks = evaluate(
+            &posting(Some("München, Bayern"), false),
+            &candidate(Some("Munich")),
+        );
+        assert_eq!(only(&checks).status, ConstraintStatus::Met);
+    }
+
+    // ── location: negative ────────────────────────────────────────────────────
+
+    #[test]
+    fn location_is_not_met_when_the_posting_names_a_different_place_and_is_not_remote() {
+        let checks = evaluate(
+            &posting(Some("Austin, TX, United States"), false),
+            &candidate(Some("Berlin")),
+        );
+        let check = only(&checks);
+        assert_eq!(check.status, ConstraintStatus::NotMet);
+        assert_eq!(check.posting.as_deref(), Some("Austin, TX, United States"));
+        assert_eq!(check.candidate.as_deref(), Some("Berlin"));
+    }
+
+    // ── location: unknown / not evaluable ─────────────────────────────────────
+
+    #[test]
+    fn location_is_unknown_when_the_posting_states_no_location() {
+        for absent in [None, Some(""), Some("   ")] {
+            let checks = evaluate(&posting(absent, false), &candidate(Some("Berlin")));
+            let check = only(&checks);
+            assert_eq!(
+                check.status,
+                ConstraintStatus::Unknown,
+                "posting location {absent:?} must be unknown, never a pass or a fail"
+            );
+            assert_eq!(check.posting, None);
+            assert_eq!(check.candidate.as_deref(), Some("Berlin"));
+        }
+    }
+
+    #[test]
+    fn location_is_unknown_when_the_stored_preference_yields_no_matchable_place() {
+        // A country-code-only preference: real, but nothing to match a place
+        // name against. Undecided — not a silent pass on the posting's city.
+        let checks = evaluate(
+            &posting(Some("Austin, TX"), false),
+            &CandidateFacts {
+                location: Some("DE".to_string()),
+                country_code: Some("de".to_string()),
+            },
+        );
+        assert_eq!(only(&checks).status, ConstraintStatus::Unknown);
+    }
+
+    #[test]
+    fn location_is_no_preference_when_the_candidate_stored_nothing() {
+        for empty in [None, Some(""), Some("  ")] {
+            let checks = evaluate(&posting(Some("Austin, TX"), false), &candidate(empty));
+            let check = only(&checks);
+            // Distinct from Unknown: the user can fix this one.
+            assert_eq!(check.status, ConstraintStatus::NoPreference);
+            assert_ne!(check.status, ConstraintStatus::Unknown);
+            assert_eq!(check.candidate, None);
+            // The posting's evidence is still reported.
+            assert_eq!(check.posting.as_deref(), Some("Austin, TX"));
+        }
+    }
+
+    // ── the invariant ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_knock_out_always_carries_evidence_from_both_sides() {
+        let places = [
+            None,
+            Some(""),
+            Some("Berlin, Germany"),
+            Some("Austin, TX"),
+            Some("Remote"),
+            Some("München"),
+        ];
+        let prefs = [None, Some(""), Some("Berlin"), Some("DE"), Some("Munich")];
+        let mut knock_outs = 0;
+        for p in places {
+            for c in prefs {
+                for remote in [false, true] {
+                    for check in evaluate(&posting(p, remote), &candidate(c)) {
+                        if check.status != ConstraintStatus::NotMet {
+                            continue;
+                        }
+                        knock_outs += 1;
+                        assert!(
+                            stated(check.posting.as_deref()).is_some(),
+                            "notMet with no posting evidence: {check:?}"
+                        );
+                        assert!(
+                            stated(check.candidate.as_deref()).is_some(),
+                            "notMet with no candidate evidence: {check:?}"
+                        );
+                    }
+                }
+            }
+        }
+        // Anchored to a hand-counted absolute so the loop above cannot go
+        // vacuously green: the four non-remote conflicting pairs are
+        // Munich↔"Berlin, Germany", Berlin↔"Austin, TX", Munich↔"Austin, TX"
+        // and Berlin↔"München". Every other cell is met (Berlin↔Berlin,
+        // Munich↔München via the exonym table, anything↔"Remote", every
+        // remote=true row) or unknowable (blank posting, blank or 2-letter
+        // preference).
+        assert_eq!(knock_outs, 4);
+    }
+
+    /// The constructor refuses to build a one-sided accusation. Driven through
+    /// `ConstraintCheck::new` — the only way any check is ever built — so this
+    /// cannot pass while the production path bypasses the guard.
+    #[test]
+    fn an_unevidenced_accusation_is_downgraded_to_unknown_at_construction() {
+        let some = || Some("Austin, TX".to_string());
+        let one_sided = [
+            (None, Some("Berlin".to_string())),         // posting silent
+            (some(), None),                             // candidate silent
+            (Some("  ".to_string()), Some("B".into())), // blank is not evidence
+            (some(), Some("   ".to_string())),
+        ];
+        for (posting, candidate) in one_sided {
+            let check =
+                ConstraintCheck::new(LOCATION, ConstraintStatus::NotMet, posting, candidate);
+            assert_eq!(
+                check.status,
+                ConstraintStatus::Unknown,
+                "a knock-out without evidence on both sides must not survive construction: {check:?}"
+            );
+        }
+        // A fully-evidenced knock-out is left alone …
+        let real = ConstraintCheck::new(
+            LOCATION,
+            ConstraintStatus::NotMet,
+            some(),
+            Some("Berlin".to_string()),
+        );
+        assert_eq!(real.status, ConstraintStatus::NotMet);
+        // … and the guard only ever touches NotMet: a one-sided Met/Unknown/
+        // NoPreference is legitimate and passes through unchanged.
+        for status in [
+            ConstraintStatus::Met,
+            ConstraintStatus::Unknown,
+            ConstraintStatus::NoPreference,
+        ] {
+            let check = ConstraintCheck::new(LOCATION, status, None, None);
+            assert_eq!(check.status, status);
+        }
+    }
+
+    // ── payload shape / non-contamination ─────────────────────────────────────
+
+    /// The scoring fields must come out the other side byte-identical, and the
+    /// verdict must arrive as its own sibling field — never folded in.
+    #[test]
+    fn attaching_a_report_leaves_every_scoring_field_untouched() {
+        let scored = json!({
+            "resumeId": "r1",
+            "jobId": "j1",
+            "ats": 40.0,
+            "semantic": 80.0,
+            "combined": 64.0,
+            "gaps": ["kubernetes"],
+            "scoreSource": "combined",
+        });
+        let checks = evaluate(
+            &posting(Some("Austin, TX"), false),
+            &candidate(Some("Berlin")),
+        );
+        let merged = merge(scored.clone(), || checks.clone());
+        // The verdict arrived as its own sibling field, not folded in anywhere.
+        assert_eq!(
+            merged["constraints"],
+            json!({ "checks": [{
+                "id": "location",
+                "status": "notMet",
+                "posting": "Austin, TX",
+                "candidate": "Berlin",
+            }] })
+        );
+        // A failed constraint did not move the number: 64, the absolute value
+        // 0.6 × 80 + 0.4 × 40 produces.
+        assert_eq!(only(&checks).status, ConstraintStatus::NotMet);
+        assert_eq!(merged["combined"], json!(64.0));
+        assert_eq!(merged["ats"], json!(40.0));
+        assert_eq!(merged["semantic"], json!(80.0));
+        assert_eq!(merged["scoreSource"], json!("combined"));
+        assert_eq!(merged["gaps"], json!(["kubernetes"]));
+        // And every pre-existing field is byte-identical: the merge adds one
+        // key and rewrites none.
+        let mut without_constraints = merged.clone();
+        without_constraints
+            .as_object_mut()
+            .unwrap()
+            .remove("constraints");
+        assert_eq!(without_constraints, scored);
+    }
+
+    /// The one line that makes any of this reachable.
+    ///
+    /// `#[tauri::command] match_resume` needs an `AppHandle`, so no test in this
+    /// crate can call it — delete `constraints::attach` from it and every test
+    /// above stays green while the feature silently disappears from the app.
+    /// (Verified: that mutation survived the whole suite before this test
+    /// existed.) A compile-time source scan is the cheapest honest pin, and the
+    /// same technique `tests/architecture.rs` already uses for invariants a
+    /// linked build cannot see.
+    #[test]
+    fn the_match_resume_command_actually_attaches_the_report() {
+        const COMMAND_SRC: &str = include_str!("../match_resume.rs");
+        assert!(
+            COMMAND_SRC.contains("constraints::attach(&app, &req.job_id, scored)"),
+            "commands::match_resume must return score_one's result through \
+             constraints::attach — without that call the hard-constraint pass \
+             never reaches the payload, and nothing else fails"
+        );
+    }
+
+    #[test]
+    fn an_error_result_is_returned_untouched_and_costs_no_evaluation() {
+        let err = json!({ "error": "job not found in cache: j1" });
+        let mut evaluated = false;
+        let out = merge(err.clone(), || {
+            evaluated = true;
+            Vec::new()
+        });
+        assert_eq!(out, err);
+        assert!(out.get("constraints").is_none());
+        assert!(
+            !evaluated,
+            "an error object has no posting to state anything — don't even look"
+        );
+    }
+
+    #[test]
+    fn the_wire_shape_is_camel_case_with_absent_evidence_omitted() {
+        let checks = evaluate(&posting(None, false), &candidate(Some("Berlin")));
+        assert_eq!(
+            serde_json::to_value(&checks).unwrap(),
+            json!([{ "id": "location", "status": "unknown", "candidate": "Berlin" }])
+        );
+        let met = evaluate(
+            &posting(Some("Berlin, Germany"), false),
+            &candidate(Some("Berlin")),
+        );
+        assert_eq!(
+            serde_json::to_value(&met).unwrap(),
+            json!([{
+                "id": "location",
+                "status": "met",
+                "posting": "Berlin, Germany",
+                "candidate": "Berlin",
+            }])
+        );
+    }
+
+    #[test]
+    fn posting_facts_read_the_flattened_remote_flag_and_location() {
+        let facts = posting_facts_from_value(&json!({
+            "id": "j1",
+            "title": "Engineer",
+            "location": "Austin, TX",
+            // `JobPosting::extra` is `#[serde(flatten)]`, so board metadata sits
+            // at the top level of the cached value, not under `extra`.
+            "remote": true,
+        }));
+        assert_eq!(
+            facts,
+            PostingFacts {
+                location: Some("Austin, TX".to_string()),
+                board_remote: true,
+            }
+        );
+        // A posting with neither reads as "states nothing", not as false data.
+        assert_eq!(
+            posting_facts_from_value(&json!({ "id": "j2" })),
+            PostingFacts {
+                location: None,
+                board_remote: false,
+            }
+        );
+    }
+
+    #[test]
+    fn evidence_is_byte_capped_on_a_char_boundary() {
+        let long = "ü".repeat(400); // 800 bytes
+        let checks = evaluate(&posting(Some(&long), false), &candidate(Some(&long)));
+        let check = only(&checks);
+        let posted = check.posting.as_deref().unwrap();
+        assert_eq!(posted.len(), MAX_EVIDENCE_BYTES);
+        assert_eq!(posted.chars().count(), MAX_EVIDENCE_BYTES / 2);
+        assert_eq!(
+            check.candidate.as_deref().unwrap().len(),
+            MAX_EVIDENCE_BYTES
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume/constraints.rs
@@ -77,16 +77,40 @@
 //!   matcher is reused and the epistemics are re-derived: `Mismatch` maps to
 //!   `Unknown` here.
 //!
-//! `Met` survives, but on the STRICT reading of the same matcher: the posting
-//! is flagged or marked remote, or every place token the user actually typed
+//! ### Why `Met` survives facts that killed `NotMet`
+//!
+//! Every fact above is direction-neutral, so the mirror case has to be answered
+//! rather than assumed: the same stale `Berlin` setting, against the `Berlin`
+//! rows still sitting in `PostingsCache` from an earlier search, would report
+//! `met`. If that read as "this posting matches where you're looking" it would
+//! be exactly as false as the knock-out was, from exactly the same field.
+//!
+//! The asymmetry is in what each status ASSERTS, not in how confident we feel:
+//!
+//! - `NotMet` asserted a CONFLICT — that the posting is somewhere the candidate
+//!   will not go. Nothing in this app establishes that relation. A failed
+//!   substring search is not a proof of non-membership, and no phrasing repairs
+//!   it, because the underlying fact was never in hand.
+//! - `Met` asserts a MATCH between two strings we hold in full. The relation —
+//!   every token of the stored preference is present in the posting's location —
+//!   is established deterministically from data we have, and stays true no
+//!   matter which search produced the row.
+//!
+//! So `Met` is repaired by making the claim say what it is a claim ABOUT, not by
+//! deleting it (which would leave a contract with no positive state and make the
+//! whole pass vacuous). The claim is **"your stored Preferred Location matches
+//! this posting"** — literally correct for any cached posting — and never "this
+//! posting matches where you're looking", which imports a search intent this
+//! pass cannot see. That is why the check's wire id is `preferredLocation`.
+//!
+//! On top of that, `Met` takes the STRICT reading of the matcher: the posting is
+//! flagged or marked remote, or every place token the user actually typed
 //! appears as a WHOLE token of the posting's location (diaeresis variants and
 //! curated exonyms included). The looser reading the scrape filter uses — any
 //! requested token, as a substring — would have "San Francisco" agreeing with a
-//! "San Diego" posting on the shared `san`. That errs toward agreement rather
-//! than accusation, which makes it cheap, not correct: `met` is a positive claim
-//! rendered to the user ("this posting matches where you're looking"), and a
-//! four-state contract whose one confident state is loose has moved the
-//! imprecision rather than removed it.
+//! "San Diego" posting on the shared `san`. Erring toward agreement rather than
+//! accusation makes that cheap, not correct: a four-state contract whose one
+//! confident state is loose has moved the imprecision rather than removed it.
 //!
 //! The cost is deliberate and one-directional: a request MORE specific than the
 //! posting ("Berlin, Germany" against a bare "Berlin") reads `unknown` rather
@@ -116,8 +140,16 @@ use crate::scraping::types::LocationSpec;
 
 pub(crate) use check::{ConstraintCheck, ConstraintStatus};
 
-/// Stable id of the location constraint, on the wire and in the tests.
-const LOCATION: &str = "location";
+/// Stable id of the shipped constraint, on the wire and in the tests.
+///
+/// `preferredLocation`, not `location`, and the precision is the point: what
+/// this check compares is the user's stored **Preferred Location setting**
+/// against the posting's location text. It is not a statement about where they
+/// live or where they can work. The id is what a renderer keys its i18n off, so
+/// naming it this way is what stops the localized sentence from being written as
+/// a claim the data cannot support — and it leaves `location` free for a real
+/// mobility constraint if candidate-side data for one ever exists.
+const PREFERRED_LOCATION: &str = "preferredLocation";
 
 /// Byte cap on each piece of evidence echoed into the payload. The posting's
 /// location text is scraped and `job_preferences.location` is renderer-supplied
@@ -181,8 +213,9 @@ mod check {
     #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub(crate) struct ConstraintCheck {
-        /// Stable machine id (`"location"`), not a label — the renderer
-        /// localizes.
+        /// Stable machine id (`"preferredLocation"`), not a label — the
+        /// renderer localizes. Named for what is actually compared; see the
+        /// constant's doc.
         id: &'static str,
         status: ConstraintStatus,
         /// What the POSTING states about this constraint, verbatim. `None` when
@@ -311,17 +344,28 @@ fn evidence(s: &str) -> String {
 ///   [`ConstraintStatus::Unknown`], not to a knock-out. See the module doc for
 ///   the concrete pairs (`Germany`/`Berlin`, `Vienna`/`Wien`, `Berlin`/`EMEA`)
 ///   that make it absence of evidence rather than evidence of conflict.
-/// - `PlaceOverlap` maps to `Unknown` too. `Met` is a positive claim rendered to
-///   the user, so it takes the strict whole-token reading: a four-state contract
-///   whose one confident state is loose has moved the imprecision rather than
-///   removed it. The looser reading stays where it belongs — in the scrape
-///   filter, which keeps the row.
+/// - `PlaceIncomplete` maps to `Unknown` too. `Met` is a positive claim
+///   rendered to the user, so it takes the strict whole-token reading: a
+///   four-state contract whose one confident state is loose has moved the
+///   imprecision rather than removed it. The looser reading stays where it
+///   belongs — in the scrape filter, which keeps the row.
+///
+/// What `Met` claims is bounded to match what is knowable: the stored PREFERENCE
+/// matches this posting. Not that the user can work there, and not that it
+/// matches the search they are running — see the module doc for why that
+/// distinction is what makes `Met` survive the facts that killed `NotMet`.
 fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> ConstraintCheck {
+    // Clamp BEFORE comparing, on both sides, so the verdict and the evidence are
+    // derived from the same bytes. Deriving them from different bytes lets a
+    // >200-byte location match on a token that then falls outside the reported
+    // evidence — a `met` sitting beside a string that no longer contains the
+    // place that produced it, which is precisely the two-sided-evidence property
+    // the sealed constructor exists to keep checkable.
     let posting_evidence = stated(posting.location.as_deref()).map(evidence);
     // No stored preference → nothing to compare against. Not a pass.
-    let Some(candidate_location) = stated(candidate.location.as_deref()) else {
+    let Some(candidate_location) = stated(candidate.location.as_deref()).map(evidence) else {
         return ConstraintCheck::new(
-            LOCATION,
+            PREFERRED_LOCATION,
             ConstraintStatus::NoPreference,
             posting_evidence,
             None,
@@ -330,11 +374,11 @@ fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> Constra
     // `region`/`country_code` stay empty: `job_preferences` has no region, and a
     // country code yields no matchable token (see `CandidateFacts::location`).
     let requested = LocationSpec {
-        city: Some(candidate_location.to_string()),
+        city: Some(candidate_location.clone()),
         ..Default::default()
     };
     let status = match location_verdict(
-        stated(posting.location.as_deref()),
+        posting_evidence.as_deref(),
         posting.board_remote,
         &requested,
     ) {
@@ -347,24 +391,24 @@ fn location_check(posting: &PostingFacts, candidate: &CandidateFacts) -> Constra
         // Everything else is "we could not establish it", in one direction or
         // the other, and all three publish as Unknown:
         //
-        // - `PlaceOverlap` — something matched, but only as a substring or on
-        //   part of the request ("San Francisco" against a "San Diego" posting,
-        //   on the shared `san`). Keeping that row in a search is the right
-        //   conservative call; telling the user the posting matches where they
-        //   are looking would simply be false.
+        // - `PlaceIncomplete` — something matched, but the request is not
+        //   fully accounted for ("San Francisco" against a "San Diego" posting,
+        //   on the shared `san`; or "Berlin, Germany" against a bare "Berlin").
+        //   Keeping that row in a search is the right conservative call;
+        //   claiming the stored preference matches would overstate it.
         // - `Mismatch` — a failed substring search, which is the ABSENCE of a
         //   hit, not a contradiction. `Germany`/`Berlin`, `Vienna`/`Wien`,
         //   `Berlin`/`EMEA` all land here.
         // - `Undecided` — nothing comparable on one side or the other.
-        LocationVerdict::PlaceOverlap | LocationVerdict::Mismatch | LocationVerdict::Undecided => {
-            ConstraintStatus::Unknown
-        }
+        LocationVerdict::PlaceIncomplete
+        | LocationVerdict::Mismatch
+        | LocationVerdict::Undecided => ConstraintStatus::Unknown,
     };
     ConstraintCheck::new(
-        LOCATION,
+        PREFERRED_LOCATION,
         status,
         posting_evidence,
-        Some(evidence(candidate_location)),
+        Some(candidate_location),
     )
 }
 
@@ -378,7 +422,14 @@ pub(crate) fn evaluate(posting: &PostingFacts, candidate: &CandidateFacts) -> Ve
 ///
 /// `remote` is read from the TOP level (not under `extra`) because
 /// `JobPosting::extra` is `#[serde(flatten)]`.
-fn posting_facts_from_value(posting: &Value) -> PostingFacts {
+///
+/// `pub(super)` so [`super::match_resume`] calls this inside the ONE
+/// `PostingsCache` lock it already takes to resolve the JD text, instead of this
+/// module taking the lock a second time and re-running the same linear scan. The
+/// duplicate mattered because the verdict is deliberately recomputed on a
+/// `match_scores` cache HIT — the Jobs-page path where the score itself costs
+/// nothing — so the second scan would have run on literally every call.
+pub(super) fn posting_facts_from_value(posting: &Value) -> PostingFacts {
     PostingFacts {
         location: posting
             .get("location")
@@ -391,28 +442,18 @@ fn posting_facts_from_value(posting: &Value) -> PostingFacts {
     }
 }
 
-/// Resolve both sides from app state and evaluate. Every lookup is a
-/// `try_state` — the job-preferences store's `open` is non-fatal at setup, and a
-/// missing store must read as "no preference expressed", never as a pass.
-fn checks_for_job(app: &AppHandle, job_id: &str) -> Vec<ConstraintCheck> {
-    let posting = app
-        .try_state::<parking_lot::Mutex<crate::postings::PostingsCache>>()
-        .and_then(|cache| {
-            let guard = cache.lock();
-            guard
-                .get_all()
-                .iter()
-                .find(|p| p.get("id").and_then(Value::as_str) == Some(job_id))
-                .map(posting_facts_from_value)
-        })
-        .unwrap_or_default();
-    let candidate = app
-        .try_state::<crate::job_preferences::JobPreferencesStore>()
+/// The candidate side, read from app state. A `try_state` — the job-preferences
+/// store's `open` is non-fatal at setup, and a missing store must read as "no
+/// preference expressed", never as a pass. A single-row `SELECT`, not a scan.
+///
+/// The posting side is NOT read here: the caller already holds it (see
+/// [`posting_facts_from_value`]).
+fn candidate_facts(app: &AppHandle) -> CandidateFacts {
+    app.try_state::<crate::job_preferences::JobPreferencesStore>()
         .map(|store| CandidateFacts {
             location: store.get().location,
         })
-        .unwrap_or_default();
-    evaluate(&posting, &candidate)
+        .unwrap_or_default()
 }
 
 /// Merge a constraint report into a `MatchScore` value as its own `constraints`
@@ -434,10 +475,14 @@ fn merge(mut score: Value, checks: impl FnOnce() -> Vec<ConstraintCheck>) -> Val
     score
 }
 
-/// Evaluate the hard constraints for `job_id` and merge the report into `score`.
-/// The command layer's single entry point — see [`merge`] for the shape.
-pub(crate) fn attach(app: &AppHandle, job_id: &str, score: Value) -> Value {
-    merge(score, || checks_for_job(app, job_id))
+/// Evaluate the hard constraints and merge the report into `score`. The command
+/// layer's single entry point — see [`merge`] for the shape.
+///
+/// `posting` is resolved by the caller, which already has the cached posting in
+/// hand under its own lock. The only state this reaches for is the candidate
+/// side, and only when there is something to report about.
+pub(crate) fn attach(app: &AppHandle, posting: &PostingFacts, score: Value) -> Value {
+    merge(score, || evaluate(posting, &candidate_facts(app)))
 }
 
 #[cfg(test)]
@@ -460,7 +505,7 @@ mod tests {
     /// The one shipped check, by id.
     fn only(checks: &[ConstraintCheck]) -> &ConstraintCheck {
         assert_eq!(checks.len(), 1, "exactly one constraint ships today");
-        assert_eq!(checks[0].id(), "location");
+        assert_eq!(checks[0].id(), "preferredLocation");
         &checks[0]
     }
 
@@ -635,6 +680,140 @@ mod tests {
         }
     }
 
+    /// The wire id names what is actually compared.
+    ///
+    /// `preferredLocation`, not `location`: this check reads the user's stored
+    /// Preferred Location SETTING, and the id is what a renderer keys its i18n
+    /// off. Renaming it to `location` would license "you can't work there" /
+    /// "this posting matches where you're looking" — sentences the data does not
+    /// support — so the id is pinned rather than left to drift.
+    #[test]
+    fn the_check_is_named_for_the_setting_it_reads() {
+        let checks = evaluate(
+            &posting(Some("Berlin, Germany"), false),
+            &candidate(Some("Berlin")),
+        );
+        assert_eq!(checks[0].id(), "preferredLocation");
+        assert_ne!(
+            checks[0].id(),
+            "location",
+            "`location` would read as a claim about where the user can work"
+        );
+    }
+
+    /// The shipped UI location defaults must produce `met`.
+    ///
+    /// Every one of them ends in a two-letter qualifier, and every one reads as
+    /// a match ONLY because `MIN_TOKEN_LEN` (3) drops that qualifier before
+    /// comparison. That constant's own doc justifies 3 as scrape-filter noise
+    /// control and says nothing about a published verdict depending on it, so
+    /// lowering it to 2 for a scrape-side reason would flip all three of these
+    /// to `unknown` with nothing else failing. This is the test that fails.
+    #[test]
+    fn the_shipped_ui_location_defaults_read_as_a_match() {
+        // (JobLocationPreferences' COMMON_LOCATIONS entry, a realistic posting)
+        let defaults: &[(&str, &str)] = &[
+            ("San Francisco, CA", "San Francisco, California"),
+            ("New York, NY", "New York, United States"),
+            ("London, UK", "London, United Kingdom"),
+            // No two-letter qualifier, included so the case is covered either way.
+            ("Berlin, Germany", "Berlin, Germany"),
+        ];
+        for (pref, posting_location) in defaults {
+            assert_eq!(
+                status_of(pref, posting_location, false),
+                ConstraintStatus::Met,
+                "the shipped default {pref:?} must still match {posting_location:?}"
+            );
+        }
+    }
+
+    /// The verdict and the evidence are derived from the SAME bytes.
+    ///
+    /// Re-running the evaluation on exactly what the check REPORTS must
+    /// reproduce exactly what it decided. When the two came from different bytes
+    /// — an unclamped location compared, a clamped one reported — a location
+    /// longer than the cap could match on a token that then fell outside the
+    /// evidence, leaving `met` beside a string not containing the place that
+    /// produced it. The board flag is passed through since it is not evidence
+    /// text.
+    #[test]
+    fn a_verdict_is_reproducible_from_the_evidence_it_reports() {
+        let long_tail = format!("{} Berlin", "x".repeat(300));
+        let long_head = format!("Berlin {}", "x".repeat(300));
+        let places = [
+            None,
+            Some("Berlin, Germany"),
+            Some("Austin, TX"),
+            Some("Remote"),
+            Some(long_tail.as_str()),
+            Some(long_head.as_str()),
+        ];
+        // A preference LONGER than the cap belongs here too: the candidate side
+        // is clamped for the payload exactly like the posting side, so comparing
+        // the unclamped preference would break the same property in the mirror
+        // direction. This one puts the meaningful token past the cut.
+        let long_pref_tail = format!("{} Berlin", "x".repeat(300));
+        let prefs = [
+            None,
+            Some("Berlin"),
+            Some("San Francisco"),
+            Some(long_pref_tail.as_str()),
+        ];
+        let mut checked = 0;
+        for p in places {
+            for c in prefs {
+                for remote in [false, true] {
+                    let facts = posting(p, remote);
+                    let cand = candidate(c);
+                    let check = &evaluate(&facts, &cand)[0];
+                    // Rebuild both sides from what was REPORTED and re-decide.
+                    let replayed = &evaluate(
+                        &PostingFacts {
+                            location: check.posting().map(str::to_string),
+                            board_remote: facts.board_remote,
+                        },
+                        &CandidateFacts {
+                            location: check.candidate().map(str::to_string),
+                        },
+                    )[0];
+                    assert_eq!(
+                        check.status(),
+                        replayed.status(),
+                        "status must be reproducible from the reported evidence: {check:?}"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+        assert_eq!(checked, 48); // 6 places × 4 preferences × 2 flags
+                                 // The case that used to disagree, pinned concretely: the matching token
+                                 // sits past the byte cap, so it is NOT in the evidence and must NOT
+                                 // produce a match.
+        let past_the_cap = &evaluate(
+            &posting(Some(&long_tail), false),
+            &candidate(Some("Berlin")),
+        )[0];
+        assert_eq!(past_the_cap.status(), ConstraintStatus::Unknown);
+        assert!(!past_the_cap.posting().unwrap().contains("Berlin"));
+        // …while the same token INSIDE the cap still matches.
+        let inside_the_cap = &evaluate(
+            &posting(Some(&long_head), false),
+            &candidate(Some("Berlin")),
+        )[0];
+        assert_eq!(inside_the_cap.status(), ConstraintStatus::Met);
+        assert!(inside_the_cap.posting().unwrap().contains("Berlin"));
+        // The mirror: an over-long PREFERENCE is clamped before comparison too,
+        // so a token of it past the cut cannot produce a match it does not
+        // report. Without this the candidate-side half of the fix is untested.
+        let long_pref = &evaluate(
+            &posting(Some("Berlin, Germany"), false),
+            &candidate(Some(&long_pref_tail)),
+        )[0];
+        assert_eq!(long_pref.status(), ConstraintStatus::Unknown);
+        assert!(!long_pref.candidate().unwrap().contains("Berlin"));
+    }
+
     // ── the invariant that replaces the old knock-out count ───────────────────
 
     /// No input reaches `NotMet` through the shipped checks.
@@ -730,8 +909,12 @@ mod tests {
             (some(), Some("   ".to_string())),
         ];
         for (posting, candidate) in one_sided {
-            let check =
-                ConstraintCheck::new(LOCATION, ConstraintStatus::NotMet, posting, candidate);
+            let check = ConstraintCheck::new(
+                PREFERRED_LOCATION,
+                ConstraintStatus::NotMet,
+                posting,
+                candidate,
+            );
             assert_eq!(
                 check.status(),
                 ConstraintStatus::Unknown,
@@ -742,7 +925,7 @@ mod tests {
         // evidence, and judging whether that evidence is a CONFLICT is each
         // check's own job (which is why `location_check` never asks for one).
         let real = ConstraintCheck::new(
-            LOCATION,
+            PREFERRED_LOCATION,
             ConstraintStatus::NotMet,
             some(),
             Some("Berlin".to_string()),
@@ -755,7 +938,7 @@ mod tests {
             ConstraintStatus::Unknown,
             ConstraintStatus::NoPreference,
         ] {
-            let check = ConstraintCheck::new(LOCATION, status, None, None);
+            let check = ConstraintCheck::new(PREFERRED_LOCATION, status, None, None);
             assert_eq!(check.status(), status);
         }
     }
@@ -784,7 +967,7 @@ mod tests {
         // Matched as a WHOLE LINE, which is what makes the weak forms fail: a
         // commented-out call carries a `//` prefix, and the discard form starts
         // `let _ =`, so neither is equal to this.
-        const CALL: &str = "    constraints::attach(&app, &req.job_id, scored)";
+        const CALL: &str = "    constraints::attach(&app, &posting_facts, scored)";
         assert!(
             COMMAND_SRC.lines().any(|line| line == CALL),
             "commands::match_resume must RETURN score_one's result through \
@@ -827,7 +1010,7 @@ mod tests {
         assert_eq!(
             merged["constraints"],
             json!({ "checks": [{
-                "id": "location",
+                "id": "preferredLocation",
                 "status": "unknown",
                 "posting": "Austin, TX",
                 "candidate": "Berlin",
@@ -871,7 +1054,7 @@ mod tests {
         let checks = evaluate(&posting(None, false), &candidate(Some("Berlin")));
         assert_eq!(
             serde_json::to_value(&checks).unwrap(),
-            json!([{ "id": "location", "status": "unknown", "candidate": "Berlin" }])
+            json!([{ "id": "preferredLocation", "status": "unknown", "candidate": "Berlin" }])
         );
         let met = evaluate(
             &posting(Some("Berlin, Germany"), false),
@@ -880,7 +1063,7 @@ mod tests {
         assert_eq!(
             serde_json::to_value(&met).unwrap(),
             json!([{
-                "id": "location",
+                "id": "preferredLocation",
                 "status": "met",
                 "posting": "Berlin, Germany",
                 "candidate": "Berlin",

--- a/apps/desktop/src-tauri/src/commands/match_resume/test.rs
+++ b/apps/desktop/src-tauri/src/commands/match_resume/test.rs
@@ -1411,3 +1411,41 @@ async fn the_jobs_page_is_not_metered_by_the_unattended_daily_ceiling() {
         "the Jobs page still embeds both sides — it is simply not metered"
     );
 }
+
+// ── the posting hand-off: one lock, one scan, real facts ─────────────
+
+/// The single cache read must hand BOTH consumers the real posting.
+///
+/// `match_resume` resolves the live posting once and passes the facts to the
+/// hard-constraint pass, instead of that pass taking the `PostingsCache` lock and
+/// re-scanning for the same id — a duplicate that would run on every Jobs-page
+/// call, including the `match_scores` cache hits where the score itself costs
+/// nothing. Anchored on absolute values: substituting a default here is
+/// invisible to every other test in the crate.
+#[test]
+fn posting_facts_hand_off_carries_the_real_posting() {
+    let posting = serde_json::json!({
+        "id": "j1",
+        "title": "Rust Engineer",
+        "description": "Build things.",
+        "location": "Berlin, Germany",
+        "remote": true,
+    });
+    let (text, facts) = resolve_posting(Some(&posting));
+    let text = text.expect("a posting with a title and description has scorable text");
+    assert!(text.contains("Rust Engineer"), "got: {text}");
+    // The constraint side gets the posting's OWN fields, not a placeholder.
+    assert_eq!(facts.location.as_deref(), Some("Berlin, Germany"));
+    assert!(facts.board_remote);
+}
+
+/// A cache miss yields nothing for either consumer — and that is safe because
+/// `score_one` returns its job-not-found error first, which `attach` passes
+/// through without ever reading these facts.
+#[test]
+fn posting_facts_hand_off_is_empty_when_the_posting_is_not_cached() {
+    let (text, facts) = resolve_posting(None);
+    assert_eq!(text, None);
+    assert_eq!(facts.location, None);
+    assert!(!facts.board_remote);
+}

--- a/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
@@ -131,23 +131,72 @@ fn expand_exonyms(needles: &mut Vec<String>) {
     }
 }
 
+/// Split `text` into lowercase alphanumeric tokens. The one tokenizer both the
+/// requested side and the posting side go through, so "Berlin, Germany" cannot
+/// be cut two different ways depending on which end it came from.
+fn tokenize(text: &str) -> impl Iterator<Item = String> + '_ {
+    text.split(|c: char| !c.is_alphanumeric())
+        .map(|t| t.trim().to_lowercase())
+        .filter(|t| !t.is_empty())
+}
+
+/// The requested location's own significant tokens, deduped, BEFORE any exonym
+/// expansion. Split out of [`requested_needles`] so the whole-token matcher can
+/// ask "did every token the user actually typed find a home?" — a question the
+/// expanded list cannot answer, since expansion adds words the user never wrote.
+fn significant_tokens(requested: &LocationSpec) -> Vec<String> {
+    let mut tokens: Vec<String> = Vec::new();
+    for field in [requested.city.as_deref(), requested.region.as_deref()] {
+        let Some(text) = field else { continue };
+        for tok in tokenize(text) {
+            if tok.chars().count() >= MIN_TOKEN_LEN && !tokens.contains(&tok) {
+                tokens.push(tok);
+            }
+        }
+    }
+    tokens
+}
+
 /// Significant lowercase place-name tokens from the requested location (its city
 /// and region text), expanded with any known exonym counterpart (see
 /// [`expand_exonyms`]). Empty when nothing usable was requested (e.g. only a
 /// country code), which makes the filter inert.
 fn requested_needles(requested: &LocationSpec) -> Vec<String> {
-    let mut needles: Vec<String> = Vec::new();
-    for field in [requested.city.as_deref(), requested.region.as_deref()] {
-        let Some(text) = field else { continue };
-        for tok in text.split(|c: char| !c.is_alphanumeric()) {
-            let tok = tok.trim().to_lowercase();
-            if tok.chars().count() >= MIN_TOKEN_LEN && !needles.contains(&tok) {
-                needles.push(tok);
-            }
-        }
-    }
+    let mut needles = significant_tokens(requested);
     expand_exonyms(&mut needles);
     needles
+}
+
+/// True when EVERY token the user typed appears as a WHOLE token of the
+/// posting's location (diaeresis/exonym-aware) — the strict half of the
+/// comparison.
+///
+/// The difference from the substring test [`requested_needles`] feeds is the
+/// whole point of having both. Substring, any-token: "San Francisco" matches a
+/// "San Diego" posting on the shared `san`, and one token of a two-token request
+/// finding a home is enough. That is the right call for a scrape filter, which
+/// is deciding whether to DISCARD a row and should err toward keeping. It is the
+/// wrong call for a claim published to the user, where "this posting matches
+/// where you are looking" would simply be false.
+///
+/// Exonyms are expanded PER TOKEN rather than over the whole list: expansion
+/// adds a word the user never wrote (a "Munich" request gains "münchen"), so
+/// requiring every needle in the EXPANDED list to match would fail the exact
+/// pair the table exists to bridge. Each requested token is satisfied by itself
+/// or by its own counterpart.
+fn every_requested_token_is_whole(loc: &str, requested: &LocationSpec) -> bool {
+    let posting_tokens: Vec<String> = tokenize(loc).collect();
+    let requested_tokens = significant_tokens(requested);
+    if requested_tokens.is_empty() || posting_tokens.is_empty() {
+        return false;
+    }
+    requested_tokens.iter().all(|tok| {
+        let mut accepted = vec![tok.clone()];
+        expand_exonyms(&mut accepted);
+        accepted
+            .iter()
+            .any(|a| posting_tokens.iter().any(|pt| folds_equal(pt, a)))
+    })
 }
 
 /// What comparing a posting's own location against a requested one actually
@@ -163,12 +212,22 @@ fn requested_needles(requested: &LocationSpec) -> Vec<String> {
 /// either direction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LocationVerdict {
-    /// Positive evidence on both sides, and they agree: the posting is remote,
-    /// or it names a place the request asked for.
-    Match,
+    /// The posting is remote — by the board's flag or a marker in its location
+    /// text — so no place comparison applies at all.
+    Remote,
+    /// Every token the request actually named appears as a WHOLE token of the
+    /// posting's location: "Berlin" ↔ "Berlin, Germany", "Munich" ↔ "München"
+    /// via the curated table. Strong enough to state to a user.
+    PlaceMatch,
+    /// A requested token appears in the posting's location, but only as a
+    /// SUBSTRING or on part of a multi-token request: "San Francisco" ↔ "San
+    /// Diego" on the shared `san`. Enough to keep a row in a search — the
+    /// conservative call when the cost is discarding a job — and NOT enough to
+    /// tell a user the posting matches where they are looking.
+    PlaceOverlap,
     /// Positive evidence on both sides, and they conflict: the posting names a
     /// concrete place, is not remote, and NO requested place token appears in
-    /// it. The only answer that is ever a knock-out.
+    /// it anywhere.
     Mismatch,
     /// No comparison was possible — the posting states no location, or the
     /// request carries no usable place token (country-code-only, or a token
@@ -176,19 +235,26 @@ pub(crate) enum LocationVerdict {
     Undecided,
 }
 
-/// Compare one posting's location text against a requested [`LocationSpec`],
-/// three-valued. Conservative, in the same order [`location_mismatch`] has
-/// always evaluated:
+/// Compare one posting's location text against a requested [`LocationSpec`].
+/// Evaluated in the same order [`location_mismatch`] always has:
 /// - remote (via the board's `extra.remote` flag OR a remote marker in the
-///   location text) → [`LocationVerdict::Match`]
+///   location text) → [`LocationVerdict::Remote`]
 /// - empty / unknown posting location → [`LocationVerdict::Undecided`]
 /// - no usable requested place tokens (e.g. country-code-only) →
 ///   [`LocationVerdict::Undecided`]
-/// - a diaeresis-spelling variant of the same name, or a curated exonym (see
-///   [`EXONYM_PAIRS`]) → [`LocationVerdict::Match`] (never a false mismatch on
-///   München/Munich, Köln/Cologne)
-/// - otherwise [`LocationVerdict::Mismatch`], only when NO requested token
-///   (fold-aware) appears in the posting location.
+/// - no requested token anywhere in the posting location →
+///   [`LocationVerdict::Mismatch`]
+/// - otherwise something matched, and the last step grades it: every requested
+///   token present as a WHOLE token (diaeresis-spelling variants and curated
+///   exonyms included, so never a false miss on München/Munich, Köln/Cologne)
+///   → [`LocationVerdict::PlaceMatch`]; a mere substring or partial-request hit
+///   → [`LocationVerdict::PlaceOverlap`].
+///
+/// The last split is the only thing the grading adds, and it exists because the
+/// two callers are asking different questions. `location_mismatch` wants "may I
+/// discard this row?" and treats overlap as a keep, unchanged. The constraint
+/// pass wants "may I tell the user this posting matches where they are looking?"
+/// and treats overlap as unknown.
 ///
 /// Takes the two posting facts as plain data rather than a [`JobPosting`] so the
 /// L3 constraint pass — which reads a cached posting as `serde_json::Value`, not
@@ -203,7 +269,7 @@ pub(crate) fn location_verdict(
 ) -> LocationVerdict {
     // A posting a board flagged remote can never conflict with a place.
     if board_remote {
-        return LocationVerdict::Match;
+        return LocationVerdict::Remote;
     }
     // Empty / unknown location → the posting states nothing to compare against.
     let loc = match posting_location.map(str::trim) {
@@ -212,18 +278,22 @@ pub(crate) fn location_verdict(
     };
     // Remote marker in the location text.
     if REMOTE_MARKERS.iter().any(|m| loc.contains(m)) {
-        return LocationVerdict::Match;
+        return LocationVerdict::Remote;
     }
     let needles = requested_needles(requested);
     if needles.is_empty() {
         return LocationVerdict::Undecided; // nothing concrete to match
     }
-    // Match when any requested token (diaeresis/exonym-aware) appears in the
-    // posting location.
-    if needles.iter().any(|n| contains_folded(&loc, n)) {
-        LocationVerdict::Match
+    // Nothing in common at all.
+    if !needles.iter().any(|n| contains_folded(&loc, n)) {
+        return LocationVerdict::Mismatch;
+    }
+    // Something matched. HOW WELL is a separate question, and the two callers
+    // need different answers to it — see [`every_requested_token_is_whole`].
+    if every_requested_token_is_whole(&loc, requested) {
+        LocationVerdict::PlaceMatch
     } else {
-        LocationVerdict::Mismatch
+        LocationVerdict::PlaceOverlap
     }
 }
 
@@ -469,29 +539,56 @@ mod test {
         );
     }
 
-    // ── Three-valued verdict (the constraint pass's source) ────────────────────
+    // ── Graded verdict (the constraint pass's source) ─────────────────
 
     /// Every verdict this matcher can return, pinned to an ABSOLUTE expected
     /// value per input — not to whatever `location_mismatch` happens to say.
     #[test]
-    fn location_verdict_answers_match_mismatch_and_undecided() {
+    fn location_verdict_grades_every_outcome() {
         let berlin = requested("Berlin");
-        // Match: the posting names the requested city.
-        assert_eq!(
-            location_verdict(Some("Berlin, Germany"), false, &berlin),
-            LocationVerdict::Match
-        );
-        // Match: remote, by the board flag even with a far-away location text.
+        // Remote: by the board flag, even with a far-away location text.
         assert_eq!(
             location_verdict(Some("Austin, TX"), true, &berlin),
-            LocationVerdict::Match
+            LocationVerdict::Remote
         );
-        // Match: remote, by a marker in the location text.
+        // Remote: by a marker in the location text.
         assert_eq!(
             location_verdict(Some("Remote (US)"), false, &berlin),
-            LocationVerdict::Match
+            LocationVerdict::Remote
         );
-        // Mismatch: a concrete, non-remote, non-matching place.
+        // PlaceMatch: the posting names the requested city as a whole token.
+        assert_eq!(
+            location_verdict(Some("Berlin, Germany"), false, &berlin),
+            LocationVerdict::PlaceMatch
+        );
+        // PlaceMatch: a curated exonym, expanded per requested token.
+        assert_eq!(
+            location_verdict(Some("München, Bayern"), false, &requested("Munich")),
+            LocationVerdict::PlaceMatch
+        );
+        // PlaceMatch: a diaeresis spelling variant of the same single token.
+        assert_eq!(
+            location_verdict(Some("Koeln, Deutschland"), false, &requested("Köln")),
+            LocationVerdict::PlaceMatch
+        );
+        // PlaceOverlap: only PART of a two-token request found a home — the
+        // shared `san` of San Francisco / San Diego.
+        assert_eq!(
+            location_verdict(Some("San Diego, CA"), false, &requested("San Francisco")),
+            LocationVerdict::PlaceOverlap
+        );
+        // PlaceOverlap: a substring hit that is not a whole token.
+        assert_eq!(
+            location_verdict(Some("Newcastle"), false, &requested("Newcast")),
+            LocationVerdict::PlaceOverlap
+        );
+        // PlaceOverlap: the request is MORE specific than the posting, so a
+        // token the user typed has no home. Undecidable, not agreement.
+        assert_eq!(
+            location_verdict(Some("Berlin"), false, &requested("Berlin, Germany")),
+            LocationVerdict::PlaceOverlap
+        );
+        // Mismatch: a concrete, non-remote place with nothing in common.
         assert_eq!(
             location_verdict(Some("Austin, TX"), false, &berlin),
             LocationVerdict::Mismatch
@@ -517,9 +614,11 @@ mod test {
     }
 
     /// The scrape-time filter is EXACTLY the `Mismatch` projection — nothing
-    /// else drops. Anchored on both ends: a hand-written absolute expectation
-    /// per case, plus the equivalence, so a regression that broke both the
-    /// filter and the verdict the same way still fails on the absolutes.
+    /// else drops, and grading the old `Match` into `Remote`/`PlaceMatch`/
+    /// `PlaceOverlap` did not move that line. Anchored on both ends: a
+    /// hand-written absolute expectation per case, plus the equivalence, so a
+    /// regression that broke both the filter and the verdict the same way still
+    /// fails on the absolutes.
     #[test]
     fn location_mismatch_drops_exactly_the_mismatch_verdict() {
         let berlin = requested("Berlin");
@@ -528,11 +627,17 @@ mod test {
             (
                 Some("Berlin, Germany"),
                 false,
-                LocationVerdict::Match,
+                LocationVerdict::PlaceMatch,
                 false,
             ),
-            (Some("Austin, TX"), true, LocationVerdict::Match, false),
-            (Some("Anywhere"), false, LocationVerdict::Match, false),
+            (Some("Austin, TX"), true, LocationVerdict::Remote, false),
+            (Some("Anywhere"), false, LocationVerdict::Remote, false),
+            (
+                Some("Greater Berlin Area"),
+                false,
+                LocationVerdict::PlaceMatch,
+                false,
+            ),
             (Some("Austin, TX"), false, LocationVerdict::Mismatch, true),
             (Some("London, UK"), false, LocationVerdict::Mismatch, true),
             (None, false, LocationVerdict::Undecided, false),
@@ -549,6 +654,18 @@ mod test {
                 "the filter must be exactly the Mismatch projection ({loc:?}/{remote})"
             );
         }
+        // The San Diego overlap keeps too — pinned separately because it is the
+        // pairing the constraint pass now refuses to call a match, and the two
+        // callers disagreeing about it is the entire point of the grading.
+        let sf = requested("San Francisco");
+        assert_eq!(
+            location_verdict(Some("San Diego, CA"), false, &sf),
+            LocationVerdict::PlaceOverlap
+        );
+        assert!(!location_mismatch(
+            &posting(Some("San Diego, CA"), false),
+            &sf
+        ));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
@@ -150,43 +150,102 @@ fn requested_needles(requested: &LocationSpec) -> Vec<String> {
     needles
 }
 
-/// True when `posting` should be DROPPED for a search that requested `requested`
-/// from a board that does not filter location server-side. Conservative:
-/// - remote (via the `extra.remote` flag OR a remote marker in the location text) → keep
-/// - empty / unknown location → keep
-/// - no usable requested place tokens (e.g. country-code-only) → keep
+/// What comparing a posting's own location against a requested one actually
+/// established. THREE answers, not two: "we could not decide" is a distinct
+/// outcome from "they agree", and collapsing the two is how an absent fact
+/// becomes a stated one.
+///
+/// [`location_mismatch`] (the scrape-time post-filter) only ever needed the
+/// binary "drop it?" projection of this, and is defined as exactly that below.
+/// The hard-constraint pass in `commands::match_resume::constraints` needs all
+/// three, because it REPORTS the answer to the user instead of acting on it —
+/// and reporting an undecided constraint as a pass (or as a fail) is a lie in
+/// either direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocationVerdict {
+    /// Positive evidence on both sides, and they agree: the posting is remote,
+    /// or it names a place the request asked for.
+    Match,
+    /// Positive evidence on both sides, and they conflict: the posting names a
+    /// concrete place, is not remote, and NO requested place token appears in
+    /// it. The only answer that is ever a knock-out.
+    Mismatch,
+    /// No comparison was possible — the posting states no location, or the
+    /// request carries no usable place token (country-code-only, or a token
+    /// below [`MIN_TOKEN_LEN`]). Never a pass and never a fail.
+    Undecided,
+}
+
+/// Compare one posting's location text against a requested [`LocationSpec`],
+/// three-valued. Conservative, in the same order [`location_mismatch`] has
+/// always evaluated:
+/// - remote (via the board's `extra.remote` flag OR a remote marker in the
+///   location text) → [`LocationVerdict::Match`]
+/// - empty / unknown posting location → [`LocationVerdict::Undecided`]
+/// - no usable requested place tokens (e.g. country-code-only) →
+///   [`LocationVerdict::Undecided`]
 /// - a diaeresis-spelling variant of the same name, or a curated exonym (see
-///   [`EXONYM_PAIRS`]) → keep (never a false drop on München/Munich, Köln/Cologne)
-/// - otherwise drop only when NO requested token (fold-aware) appears in the
-///   posting location.
+///   [`EXONYM_PAIRS`]) → [`LocationVerdict::Match`] (never a false mismatch on
+///   München/Munich, Köln/Cologne)
+/// - otherwise [`LocationVerdict::Mismatch`], only when NO requested token
+///   (fold-aware) appears in the posting location.
+///
+/// Takes the two posting facts as plain data rather than a [`JobPosting`] so the
+/// L3 constraint pass — which reads a cached posting as `serde_json::Value`, not
+/// as a `JobPosting` — reaches the SAME matcher instead of forking a second one
+/// that would drift on the remote-marker list and the exonym table.
 ///
 /// Pure — the truth table is unit-tested below.
-pub(crate) fn location_mismatch(posting: &JobPosting, requested: &LocationSpec) -> bool {
-    // Never drop a posting a board flagged remote.
-    if posting
-        .extra
-        .get("remote")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
-        return false;
+pub(crate) fn location_verdict(
+    posting_location: Option<&str>,
+    board_remote: bool,
+    requested: &LocationSpec,
+) -> LocationVerdict {
+    // A posting a board flagged remote can never conflict with a place.
+    if board_remote {
+        return LocationVerdict::Match;
     }
-    // Empty / unknown location → keep.
-    let loc = match posting.location.as_deref().map(str::trim) {
+    // Empty / unknown location → the posting states nothing to compare against.
+    let loc = match posting_location.map(str::trim) {
         Some(l) if !l.is_empty() => l.to_lowercase(),
-        _ => return false,
+        _ => return LocationVerdict::Undecided,
     };
-    // Remote marker in the location text → keep.
+    // Remote marker in the location text.
     if REMOTE_MARKERS.iter().any(|m| loc.contains(m)) {
-        return false;
+        return LocationVerdict::Match;
     }
     let needles = requested_needles(requested);
     if needles.is_empty() {
-        return false; // nothing concrete to match → keep
+        return LocationVerdict::Undecided; // nothing concrete to match
     }
-    // Keep when any requested token (diaeresis/exonym-aware) appears in the
-    // posting location; drop otherwise.
-    !needles.iter().any(|n| contains_folded(&loc, n))
+    // Match when any requested token (diaeresis/exonym-aware) appears in the
+    // posting location.
+    if needles.iter().any(|n| contains_folded(&loc, n)) {
+        LocationVerdict::Match
+    } else {
+        LocationVerdict::Mismatch
+    }
+}
+
+/// True when `posting` should be DROPPED for a search that requested `requested`
+/// from a board that does not filter location server-side.
+///
+/// The binary projection of [`location_verdict`]: **only** an explicit
+/// [`LocationVerdict::Mismatch`] drops. Every other answer — including every
+/// undecided one — keeps, which is the conservative posture this filter has
+/// always had (keeping a wrong-city row is the old lie; dropping a remote or
+/// unknown-location job would be a new one). Defined in terms of the verdict so
+/// the two callers cannot drift into two different remote-marker lists.
+pub(crate) fn location_mismatch(posting: &JobPosting, requested: &LocationSpec) -> bool {
+    let board_remote = posting
+        .extra
+        .get("remote")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    matches!(
+        location_verdict(posting.location.as_deref(), board_remote, requested),
+        LocationVerdict::Mismatch
+    )
 }
 
 /// Drop postings whose location clearly mismatches `requested`, returning the
@@ -408,6 +467,88 @@ mod test {
             location_mismatch(&posting(Some("Den Haag, Netherlands"), false), &req),
             "an exonym pair outside EXONYM_PAIRS is a known, documented gap — must still drop"
         );
+    }
+
+    // ── Three-valued verdict (the constraint pass's source) ────────────────────
+
+    /// Every verdict this matcher can return, pinned to an ABSOLUTE expected
+    /// value per input — not to whatever `location_mismatch` happens to say.
+    #[test]
+    fn location_verdict_answers_match_mismatch_and_undecided() {
+        let berlin = requested("Berlin");
+        // Match: the posting names the requested city.
+        assert_eq!(
+            location_verdict(Some("Berlin, Germany"), false, &berlin),
+            LocationVerdict::Match
+        );
+        // Match: remote, by the board flag even with a far-away location text.
+        assert_eq!(
+            location_verdict(Some("Austin, TX"), true, &berlin),
+            LocationVerdict::Match
+        );
+        // Match: remote, by a marker in the location text.
+        assert_eq!(
+            location_verdict(Some("Remote (US)"), false, &berlin),
+            LocationVerdict::Match
+        );
+        // Mismatch: a concrete, non-remote, non-matching place.
+        assert_eq!(
+            location_verdict(Some("Austin, TX"), false, &berlin),
+            LocationVerdict::Mismatch
+        );
+        // Undecided: the posting states no location at all.
+        assert_eq!(
+            location_verdict(None, false, &berlin),
+            LocationVerdict::Undecided
+        );
+        assert_eq!(
+            location_verdict(Some("   "), false, &berlin),
+            LocationVerdict::Undecided
+        );
+        // Undecided: nothing usable was requested (country-code-only).
+        let cc_only = LocationSpec {
+            country_code: Some("de".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            location_verdict(Some("Austin, TX"), false, &cc_only),
+            LocationVerdict::Undecided
+        );
+    }
+
+    /// The scrape-time filter is EXACTLY the `Mismatch` projection — nothing
+    /// else drops. Anchored on both ends: a hand-written absolute expectation
+    /// per case, plus the equivalence, so a regression that broke both the
+    /// filter and the verdict the same way still fails on the absolutes.
+    #[test]
+    fn location_mismatch_drops_exactly_the_mismatch_verdict() {
+        let berlin = requested("Berlin");
+        // (posting location, board remote flag, expected verdict, expected drop)
+        let cases: &[(Option<&str>, bool, LocationVerdict, bool)] = &[
+            (
+                Some("Berlin, Germany"),
+                false,
+                LocationVerdict::Match,
+                false,
+            ),
+            (Some("Austin, TX"), true, LocationVerdict::Match, false),
+            (Some("Anywhere"), false, LocationVerdict::Match, false),
+            (Some("Austin, TX"), false, LocationVerdict::Mismatch, true),
+            (Some("London, UK"), false, LocationVerdict::Mismatch, true),
+            (None, false, LocationVerdict::Undecided, false),
+            (Some(""), false, LocationVerdict::Undecided, false),
+        ];
+        for (loc, remote, want_verdict, want_drop) in cases {
+            let verdict = location_verdict(*loc, *remote, &berlin);
+            assert_eq!(&verdict, want_verdict, "verdict for {loc:?}/{remote}");
+            let dropped = location_mismatch(&posting(*loc, *remote), &berlin);
+            assert_eq!(dropped, *want_drop, "drop for {loc:?}/{remote}");
+            assert_eq!(
+                dropped,
+                verdict == LocationVerdict::Mismatch,
+                "the filter must be exactly the Mismatch projection ({loc:?}/{remote})"
+            );
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/location_filter.rs
@@ -34,6 +34,19 @@ const REMOTE_MARKERS: &[&str] = &[
 /// Minimum length of a requested place-name token used for matching. Two-letter
 /// tokens (a bare country code, "UK") are too noisy to match on, so the filter
 /// stays inert unless a real place name is present.
+///
+/// **This constant now has a SECOND consumer with a different risk posture.**
+/// Its original job was noise control for the scrape filter, where being wrong
+/// costs one dropped row. The hard-constraint pass
+/// (`commands::match_resume::constraints`) publishes a `met` verdict to the user
+/// off the same tokens, and the shipped UI location defaults all end in a
+/// two-letter qualifier — "San Francisco, CA", "New York, NY", "London, UK".
+/// They read [`LocationVerdict::PlaceMatch`] against realistic postings ("San
+/// Francisco, California", "New York, United States", "London, United Kingdom")
+/// ONLY because 3 drops that qualifier; at 2 each would carry a token the
+/// posting does not name and would silently degrade to `unknown`. Lowering this
+/// for a scrape-side reason is therefore a user-visible change, and
+/// `the_shipped_ui_location_defaults_read_as_a_match` fails if it happens.
 const MIN_TOKEN_LEN: usize = 3;
 
 /// A tiny, curated table of English⇄German exonym pairs for the handful of
@@ -219,12 +232,24 @@ pub(crate) enum LocationVerdict {
     /// posting's location: "Berlin" ↔ "Berlin, Germany", "Munich" ↔ "München"
     /// via the curated table. Strong enough to state to a user.
     PlaceMatch,
-    /// A requested token appears in the posting's location, but only as a
-    /// SUBSTRING or on part of a multi-token request: "San Francisco" ↔ "San
-    /// Diego" on the shared `san`. Enough to keep a row in a search — the
-    /// conservative call when the cost is discarding a job — and NOT enough to
-    /// tell a user the posting matches where they are looking.
-    PlaceOverlap,
+    /// Something matched, but the request is NOT fully accounted for. Named for
+    /// the incompleteness rather than for a strength, because it covers two
+    /// situations of quite different evidential weight and a consumer must not
+    /// assume either one:
+    ///
+    /// - a coincidental SUBSTRING with no whole-token hit at all — "San
+    ///   Francisco" against a "San Diego" posting, sharing only `san`. Weak.
+    /// - a genuine whole-token hit on PART of a multi-token request — "Berlin,
+    ///   Germany" against a bare "Berlin" posting, where `berlin` matches
+    ///   exactly and only the country qualifier is unaccounted for. Strong in
+    ///   substance, and still not a completed comparison.
+    ///
+    /// Both are enough to keep a row in a search — the conservative call when
+    /// the cost is discarding a job — and neither is enough to tell a user the
+    /// posting matches their stated location. They share one variant because
+    /// nothing today needs to tell them apart; split it rather than guess if a
+    /// consumer ever does.
+    PlaceIncomplete,
     /// Positive evidence on both sides, and they conflict: the posting names a
     /// concrete place, is not remote, and NO requested place token appears in
     /// it anywhere.
@@ -248,7 +273,7 @@ pub(crate) enum LocationVerdict {
 ///   token present as a WHOLE token (diaeresis-spelling variants and curated
 ///   exonyms included, so never a false miss on München/Munich, Köln/Cologne)
 ///   → [`LocationVerdict::PlaceMatch`]; a mere substring or partial-request hit
-///   → [`LocationVerdict::PlaceOverlap`].
+///   → [`LocationVerdict::PlaceIncomplete`].
 ///
 /// The last split is the only thing the grading adds, and it exists because the
 /// two callers are asking different questions. `location_mismatch` wants "may I
@@ -293,7 +318,7 @@ pub(crate) fn location_verdict(
     if every_requested_token_is_whole(&loc, requested) {
         LocationVerdict::PlaceMatch
     } else {
-        LocationVerdict::PlaceOverlap
+        LocationVerdict::PlaceIncomplete
     }
 }
 
@@ -571,22 +596,22 @@ mod test {
             location_verdict(Some("Koeln, Deutschland"), false, &requested("Köln")),
             LocationVerdict::PlaceMatch
         );
-        // PlaceOverlap: only PART of a two-token request found a home — the
+        // PlaceIncomplete: only PART of a two-token request found a home — the
         // shared `san` of San Francisco / San Diego.
         assert_eq!(
             location_verdict(Some("San Diego, CA"), false, &requested("San Francisco")),
-            LocationVerdict::PlaceOverlap
+            LocationVerdict::PlaceIncomplete
         );
-        // PlaceOverlap: a substring hit that is not a whole token.
+        // PlaceIncomplete: a substring hit that is not a whole token.
         assert_eq!(
             location_verdict(Some("Newcastle"), false, &requested("Newcast")),
-            LocationVerdict::PlaceOverlap
+            LocationVerdict::PlaceIncomplete
         );
-        // PlaceOverlap: the request is MORE specific than the posting, so a
+        // PlaceIncomplete: the request is MORE specific than the posting, so a
         // token the user typed has no home. Undecidable, not agreement.
         assert_eq!(
             location_verdict(Some("Berlin"), false, &requested("Berlin, Germany")),
-            LocationVerdict::PlaceOverlap
+            LocationVerdict::PlaceIncomplete
         );
         // Mismatch: a concrete, non-remote place with nothing in common.
         assert_eq!(
@@ -615,7 +640,7 @@ mod test {
 
     /// The scrape-time filter is EXACTLY the `Mismatch` projection — nothing
     /// else drops, and grading the old `Match` into `Remote`/`PlaceMatch`/
-    /// `PlaceOverlap` did not move that line. Anchored on both ends: a
+    /// `PlaceIncomplete` did not move that line. Anchored on both ends: a
     /// hand-written absolute expectation per case, plus the equivalence, so a
     /// regression that broke both the filter and the verdict the same way still
     /// fails on the absolutes.
@@ -660,7 +685,7 @@ mod test {
         let sf = requested("San Francisco");
         assert_eq!(
             location_verdict(Some("San Diego, CA"), false, &sf),
-            LocationVerdict::PlaceOverlap
+            LocationVerdict::PlaceIncomplete
         );
         assert!(!location_mismatch(
             &posting(Some("San Diego, CA"), false),

--- a/apps/desktop/src-tauri/src/scraping/engine/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/engine/mod.rs
@@ -16,7 +16,11 @@ use tokio_util::sync::CancellationToken;
 
 use crate::jobs::cancel::CancelRegistry;
 
-mod location_filter;
+/// `pub(crate)` (not private to `engine`) so the L3 hard-constraint pass in
+/// `commands::match_resume::constraints` reuses this module's three-valued
+/// [`location_filter::location_verdict`] instead of forking a second place-name
+/// matcher with its own remote-marker list and exonym table.
+pub(crate) mod location_filter;
 
 /// Per-item keep predicate for a single board (already bound to that board's
 /// name where relevant) — `true` = keep. Trust PR F's central location filter;

--- a/packages/shared/src/types/constraints.test.ts
+++ b/packages/shared/src/types/constraints.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { type ConstraintCheck, type ConstraintStatus, isKnockOut } from './index.js';
+
+const check = (status: ConstraintStatus): ConstraintCheck => ({ id: 'location', status });
+
+describe('isKnockOut', () => {
+  it('is true for exactly one status', () => {
+    expect(isKnockOut(check('notMet'))).toBe(true);
+    expect(isKnockOut(check('met'))).toBe(false);
+    expect(isKnockOut(check('unknown'))).toBe(false);
+    expect(isKnockOut(check('noPreference'))).toBe(false);
+  });
+
+  it('does not collapse the two unknowable states into an accusation', () => {
+    // The whole reason this predicate is exported. A consumer branching on
+    // `status !== 'met'` would light up an "unmet requirement" badge for both of
+    // these, which is precisely the false accusation the constraint channel
+    // exists to avoid — the app cannot tell, and must say so.
+    const cannotTell: ConstraintStatus[] = ['unknown', 'noPreference'];
+    for (const status of cannotTell) {
+      expect(isKnockOut(check(status))).toBe(false);
+      expect(check(status).status).not.toBe('met'); // the tempting wrong test
+    }
+  });
+
+  it('reads only status, not the evidence fields', () => {
+    // Evidence is for the renderer's sentence; it must never change the verdict.
+    expect(isKnockOut({ id: 'location', status: 'unknown', posting: 'Austin, TX' })).toBe(false);
+    expect(
+      isKnockOut({ id: 'location', status: 'notMet', posting: undefined, candidate: undefined })
+    ).toBe(true);
+  });
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -116,15 +116,19 @@ export interface JobInteraction {
  * relevance score and never folded into it. Four values, because "we cannot
  * tell" is never a pass:
  *
- * - `met` / `notMet` — positive evidence on BOTH sides, agreeing or conflicting.
- * - `unknown` — the candidate stated a preference but no verdict was reachable
- *   (the posting says nothing, or what they stated is not comparable).
+ * - `met` — positive evidence on BOTH sides, and they agree.
+ * - `notMet` — positive evidence on BOTH sides, and they conflict. The only
+ *   knock-out. **No shipped constraint produces it today** (see `constraints`
+ *   on {@link MatchScore}); it is the slot a constraint with real two-sided
+ *   evidence will use.
+ * - `unknown` — no verdict was reachable: the posting says nothing, or what is
+ *   known cannot settle the question.
  * - `noPreference` — the candidate has expressed nothing, so it cannot be
  *   evaluated at all. Distinct from `unknown`: the user can fix this one.
  *
- * `notMet` is advisory. Nothing filters, sorts or gates on it — a wrong
- * knock-out tells the user not to bother applying, which costs far more than a
- * wrong relevance number.
+ * Advisory only. Nothing filters, sorts or gates on it — a wrong knock-out
+ * tells the user not to bother applying, which costs far more than a wrong
+ * relevance number.
  */
 export type ConstraintStatus = 'met' | 'notMet' | 'unknown' | 'noPreference';
 
@@ -135,8 +139,25 @@ export interface ConstraintCheck {
   status: ConstraintStatus;
   /** What the posting states about this constraint, verbatim. Absent when it states nothing. */
   posting?: string;
-  /** What the candidate has stored about it, verbatim. Absent when they set nothing. */
+  /**
+   * What the candidate has stored about it, verbatim. Absent when they set
+   * nothing. For `location` this is their stated **preference** (the
+   * "Preferred Location" setting), not an address and not a mobility limit.
+   */
   candidate?: string;
+}
+
+/**
+ * Whether a check is an actual knock-out — the ONLY safe way to branch on
+ * `status`.
+ *
+ * `ConstraintStatus` is deliberately not boolean-collapsible: `status !== 'met'`
+ * quietly turns both "we could not tell" states into an accusation, which is the
+ * exact failure this whole channel exists to avoid. Use this, and render
+ * `unknown` / `noPreference` as what they are.
+ */
+export function isKnockOut(check: ConstraintCheck): boolean {
+  return check.status === 'notMet';
 }
 
 export interface MatchScore {
@@ -152,9 +173,14 @@ export interface MatchScore {
   guidance?: string;
   /**
    * Hard-constraint pass — reported as its own field so it can never contaminate
-   * the score above. Only the constraints the app has honest candidate-side data
-   * for appear here (today: `location`); see
-   * `commands/match_resume/constraints.rs` for the ones deliberately not shipped.
+   * the score above.
+   *
+   * Only `location` ships today, and only as `met` / `unknown` / `noPreference`:
+   * the candidate side is a search-personalization setting rather than a
+   * mobility statement, and a failed place-name match is absence of evidence
+   * rather than evidence of conflict. Work authorization, employment type and
+   * salary have no candidate-side data in this app at all. See
+   * `commands/match_resume/constraints.rs` for the full reasoning.
    */
   constraints?: { checks: ConstraintCheck[] };
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -175,11 +175,15 @@ export interface MatchScore {
    * Hard-constraint pass — reported as its own field so it can never contaminate
    * the score above.
    *
-   * Only `location` ships today, and only as `met` / `unknown` / `noPreference`:
-   * the candidate side is a search-personalization setting rather than a
-   * mobility statement, and a failed place-name match is absence of evidence
-   * rather than evidence of conflict. Work authorization, employment type and
-   * salary have no candidate-side data in this app at all. See
+   * Only `location` ships today, and only as `met` / `unknown` / `noPreference`.
+   * There is no `notMet`: the candidate side is a search-personalization
+   * setting rather than a mobility statement, and a failed place-name match is
+   * absence of evidence rather than evidence of conflict. `met` takes the
+   * strict reading in return — the posting is remote, or every place token the
+   * user typed appears as a whole token of the posting's location — so a
+   * partial overlap ("San Francisco" against a "San Diego" posting) reads
+   * `unknown`, not `met`. Work authorization, employment type and salary have
+   * no candidate-side data in this app at all. See
    * `commands/match_resume/constraints.rs` for the full reasoning.
    */
   constraints?: { checks: ConstraintCheck[] };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -111,6 +111,34 @@ export interface JobInteraction {
   timestamp: number;
 }
 
+/**
+ * Verdict on ONE hard constraint (a non-negotiable), reported alongside the
+ * relevance score and never folded into it. Four values, because "we cannot
+ * tell" is never a pass:
+ *
+ * - `met` / `notMet` — positive evidence on BOTH sides, agreeing or conflicting.
+ * - `unknown` — the candidate stated a preference but no verdict was reachable
+ *   (the posting says nothing, or what they stated is not comparable).
+ * - `noPreference` — the candidate has expressed nothing, so it cannot be
+ *   evaluated at all. Distinct from `unknown`: the user can fix this one.
+ *
+ * `notMet` is advisory. Nothing filters, sorts or gates on it — a wrong
+ * knock-out tells the user not to bother applying, which costs far more than a
+ * wrong relevance number.
+ */
+export type ConstraintStatus = 'met' | 'notMet' | 'unknown' | 'noPreference';
+
+/** One constraint's verdict plus the evidence on each side that produced it. */
+export interface ConstraintCheck {
+  /** Stable machine id (e.g. `'location'`) — the renderer localizes the label. */
+  id: string;
+  status: ConstraintStatus;
+  /** What the posting states about this constraint, verbatim. Absent when it states nothing. */
+  posting?: string;
+  /** What the candidate has stored about it, verbatim. Absent when they set nothing. */
+  candidate?: string;
+}
+
 export interface MatchScore {
   resumeId: string;
   jobId: string;
@@ -122,6 +150,13 @@ export interface MatchScore {
   explanation?: string;
   /** Guidance framing: this score is our estimate, not the employer's verdict. */
   guidance?: string;
+  /**
+   * Hard-constraint pass — reported as its own field so it can never contaminate
+   * the score above. Only the constraints the app has honest candidate-side data
+   * for appear here (today: `location`); see
+   * `commands/match_resume/constraints.rs` for the ones deliberately not shipped.
+   */
+  constraints?: { checks: ConstraintCheck[] };
 }
 
 /** One résumé bullet, ranked by the job vocabulary it carries. */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -116,7 +116,14 @@ export interface JobInteraction {
  * relevance score and never folded into it. Four values, because "we cannot
  * tell" is never a pass:
  *
- * - `met` — positive evidence on BOTH sides, and they agree.
+ * - `met` — positive evidence on BOTH sides, and they agree. Read it strictly:
+ *   it is a claim about the **stored setting** named by `id`, and nothing more.
+ *   For `preferredLocation` the true sentence is "your preferred location
+ *   matches this posting" — correct for any posting, whichever search produced
+ *   it. "Matches where you're looking" is NOT supported: postings persist from
+ *   every past search and the app keeps no record of which search returned
+ *   which row, so a stale setting would make that sentence false. Nor does it
+ *   mean the candidate can legally or practically work there.
  * - `notMet` — positive evidence on BOTH sides, and they conflict. The only
  *   knock-out. **No shipped constraint produces it today** (see `constraints`
  *   on {@link MatchScore}); it is the slot a constraint with real two-sided
@@ -134,15 +141,23 @@ export type ConstraintStatus = 'met' | 'notMet' | 'unknown' | 'noPreference';
 
 /** One constraint's verdict plus the evidence on each side that produced it. */
 export interface ConstraintCheck {
-  /** Stable machine id (e.g. `'location'`) — the renderer localizes the label. */
+  /**
+   * Stable machine id — the renderer localizes the label off this. Today the
+   * only value is `'preferredLocation'`, named for the setting it reads rather
+   * than for the subject it is about: it is deliberately NOT `'location'`,
+   * which would license a sentence about where the candidate can work.
+   */
   id: string;
   status: ConstraintStatus;
   /** What the posting states about this constraint, verbatim. Absent when it states nothing. */
   posting?: string;
   /**
    * What the candidate has stored about it, verbatim. Absent when they set
-   * nothing. For `location` this is their stated **preference** (the
-   * "Preferred Location" setting), not an address and not a mobility limit.
+   * nothing. For `preferredLocation` this is their stated **preference** (the
+   * free-text "Preferred Location" setting, which personalizes search), not an
+   * address, not a mobility limit, and not the location of whatever search
+   * returned this posting. Render it as the setting it is — showing it beside
+   * `posting` is what lets a user notice their own setting is stale.
    */
   candidate?: string;
 }
@@ -175,16 +190,24 @@ export interface MatchScore {
    * Hard-constraint pass — reported as its own field so it can never contaminate
    * the score above.
    *
-   * Only `location` ships today, and only as `met` / `unknown` / `noPreference`.
-   * There is no `notMet`: the candidate side is a search-personalization
-   * setting rather than a mobility statement, and a failed place-name match is
-   * absence of evidence rather than evidence of conflict. `met` takes the
-   * strict reading in return — the posting is remote, or every place token the
-   * user typed appears as a whole token of the posting's location — so a
-   * partial overlap ("San Francisco" against a "San Diego" posting) reads
-   * `unknown`, not `met`. Work authorization, employment type and salary have
-   * no candidate-side data in this app at all. See
-   * `commands/match_resume/constraints.rs` for the full reasoning.
+   * Only `preferredLocation` ships today, and only as `met` / `unknown` /
+   * `noPreference`.
+   *
+   * There is no `notMet` anywhere in the app: the candidate side is a
+   * search-personalization setting rather than a mobility statement, and a
+   * failed place-name match is absence of evidence rather than evidence of
+   * conflict. `met` survives the same facts only because of what it asserts — a
+   * match against the stored SETTING, which stays true whichever search
+   * produced the row — so render it as that and never as "matches your search".
+   *
+   * `met` takes the strict reading in return: the posting is remote, or every
+   * place token the user typed appears as a whole token of the posting's
+   * location. A partial overlap ("San Francisco" against a "San Diego" posting)
+   * reads `unknown`.
+   *
+   * Work authorization, employment type and salary have no candidate-side data
+   * in this app at all. See `commands/match_resume/constraints.rs` for the full
+   * reasoning.
    */
   constraints?: { checks: ConstraintCheck[] };
 }


### PR DESCRIPTION
Track **E1** of the architecture audit. The honest result is not the one the audit asked for.

## The ask

`combined = 0.6*semantic + 0.4*ats` blends everything, so a candidate failing a non-negotiable still scores on keyword overlap. Add a hard-constraint pass, reported **separately** from the relevance score.

## The finding: this app cannot deliver a knock-out on the data it has

Four constraints were candidates. All four were refused, and each for a specific reason rather than for effort:

| constraint | why not |
| --- | --- |
| **work authorization** (the audit ranked it first) | the app stores **nothing** about it. The only proxy is the candidate's address, and "lives in Germany" is not evidence of lacking US authorization |
| **employment type** | no persisted candidate preference. `AutopilotTarget::work_type` is a per-search filter, and it is a work *arrangement*, not an employment type |
| **salary floor** | `salary_expectation` is free text ("80k DOE") answering an application's salary *question*. No currency, no period, and the posting side is structured on one board only — a verdict needs a money parser plus an FX assumption, two invented facts each time |
| **location** | see below |

Location looked viable and was implemented. Review then established that `job_preferences.location` is a **search-personalization** field — its own translation string reads *"to personalize search results and recommendations"*, and `JobsPage` seeds the scrape form from it one-way with the comment *"Picking a location here never writes back to settings."*

The concrete failure: Settings says `Berlin` from onboarding, the user deliberately searches `Austin` because they are relocating, and every Austin posting returns `notMet`. Executing the real rule found **25 of 38 realistic pairs** returning `notMet` on jobs the candidate could take — `Germany`↔`Berlin`, `San Francisco`↔`Bay Area`, `Vienna`↔`Wien`, `Tokyo`↔`東京`, `Berlin`↔`Telecommute`. Aggravated by **Adzuna never writing `extra.remote`**, so on the primary aggregator remote detection falls entirely to 11 text markers its location strings never carry.

The rule the code states about itself convicts it: a `NotMet` requires positive evidence on **both** sides, and a failed substring match is *absence* of evidence.

**So `NotMet` ships unreachable.** `no_shipped_constraint_can_emit_a_knock_out` pins that it is unreachable, not merely unused, and it remains the contract slot a future constraint will use.

## What does ship, and why it is still worth having

- **The separate channel.** The verdict is computed after `score_one` returns and merged as a sibling field — never a multiplier, never a penalty. This is not hygiene: `score_one`'s result is cached under scoring inputs only, so a verdict frozen into that row would be served stale for the whole TTL the moment the user edited their preferences. Outside the kernel, a cache *hit* still gets a fresh verdict.
- **Four statuses**, not three: `met` / `unknown` / `noPreference` — the last kept distinct because it is the one the user can fix. Each check carries **both sides' own words**, so "positive evidence on both sides" is a checkable property of the payload rather than a promise, enforced in a sealed constructor (`ConstraintCheck` lives in its own module; a struct literal outside it is a compile error).
- **A three-valued matcher.** `location_verdict` splits `Remote` / `PlaceMatch` / `PlaceOverlap` / `Mismatch` / `Undecided`; `location_mismatch` is now exactly the `Mismatch` projection, so the scrape filter is unchanged. Proven by a **1,968-pair differential** across empties, umlaut/transliteration triples, exonyms, non-Latin, multi-location and country-code-only specs: **0 diffs**.

The principle, recorded in the module: **reuse the matcher, re-derive the epistemics.** The identical predicate is safe as a scrape filter — one location typed seconds ago, one row, reversible — and unsafe as a published verdict against every cached posting keyed off a settings field.

## A trade-off you should see, not discover

`met` now requires a **whole-token** match, so `San Francisco` no longer reads `met` against `San Diego` on the shared `san` token. The cost: a request *more specific* than the posting — `Berlin, Germany` against a bare `Berlin` — now reads `unknown` rather than `met`.

The UI's default preference values are `'San Francisco, CA'`, `'Berlin, Germany'`, `'New York, NY'`, so **this is not a rare path**. It loses a true positive and never states a false one, and `unknown` claims nothing. Reversible in one match arm if you disagree.

Implementation note: exonyms must expand **per token**, not over the whole needle list — expansion adds a word the user never wrote, so a naive "every needle must match" rule would fail the exact `Munich`/`München` pair the curated table exists to bridge.

## Verification

**19 mutation checks, all caught**, including three that survived earlier rounds: an `include_str!` wiring pin blind to `let _ = attach(…)` and to a commented-out call, and a struct-literal bypass that must now fail to *compile*.

The old `assert_eq!(knock_outs, 4)` was this repo's recurring defect — a corpus containing only pairings the code already agreed with. Replaced with the full hand-derived status distribution over **176 cells**: 44 `noPreference`, 75 `met`, 57 `unknown`, **0 `notMet`**. That last figure as an asserted absolute is what makes the ship claim checkable, and each later tightening had to add the pairing it existed for or the distribution would not have moved.

## Incidental find worth recording

An early `include_str!` assertion embedded a closing brace in a string literal. `tests/egress.rs` strips `#[cfg(test)]` regions with a brace counter that cannot see into string literals, so the literal truncated the stripped region — leaving real code **un-stripped**, which that guard's own message calls "the dangerous direction". The assertion was rewritten to contain no brace rather than adding the file to `KNOWN_EXCEPTIONS`. That guard earned its keep on a change with nothing to do with egress.

## Not built

No renderer surface. The field rides the payload and is in the shared contract with an `isKnockOut` predicate shipped **before** any UI, so a consumer cannot write `status !== 'met'` and silently turn both undecided states into a knock-out.