### PR TITLE
fix(resume-pipeline): resolve a fabrication remove by its anchored line

### DIFF
--- a/apps/desktop/src/renderer/lib/generate/fabrications.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/fabrications.test.ts
@@ -109,6 +109,31 @@ describe('presentFabrication', () => {
   it('treats empty evidence as orphaned, not as matching everything', () => {
     expect(presentFabrication({ ...VALID, evidence: '   ' }, document)).toBe('orphaned');
   });
+
+  // Coherence with `isFabricationResolved`: for a `remove` verdict, this must
+  // return 'resolved' in EXACTLY the cases the other function calls resolved
+  // — same line-anchored bug scenario, checked from the presentation side.
+  describe('line-anchored Remove — coherent with isFabricationResolved', () => {
+    const anchored: Fabrication = {
+      issueKey: 'factual.unsourced_certification#0',
+      code: 'factual.unsourced_certification',
+      evidence: 'CKA',
+      line: 'Certified Kubernetes Administrator (CKA).',
+      decision: 'remove',
+    };
+
+    it('reads resolved once the anchored line is gone, span or no span elsewhere', () => {
+      const edited = 'PROFESSIONAL SUMMARY\nA payments engineer.\n\nPROJECTS\n- CKA prep tool.\n';
+      expect(presentFabrication(anchored, edited)).toBe('resolved');
+      expect(isFabricationResolved(anchored, edited)).toBe(true);
+    });
+
+    it('reads markedForRemoval while the anchored line is still there', () => {
+      const untouched = 'PROFESSIONAL SUMMARY\nCertified Kubernetes Administrator (CKA).\n';
+      expect(presentFabrication(anchored, untouched)).toBe('markedForRemoval');
+      expect(isFabricationResolved(anchored, untouched)).toBe(false);
+    });
+  });
 });
 
 describe('isFabricationResolved', () => {
@@ -122,10 +147,56 @@ describe('isFabricationResolved', () => {
     expect(isFabricationResolved({ ...VALID, decision: 'keep' }, document)).toBe(true);
   });
 
-  it('is true for Remove ONLY once the evidence is gone', () => {
+  it('is true for Remove ONLY once the evidence is gone (legacy entry, no line)', () => {
     const removed = { ...VALID, decision: 'remove' } as const;
     expect(isFabricationResolved(removed, document)).toBe(false);
     expect(isFabricationResolved(removed, 'Summary\nLed the migration.')).toBe(true);
+  });
+
+  // ── THE bug (reported on PR #1024): removing the flagged LINE must resolve
+  // the entry even when the bare evidence span legitimately recurs elsewhere
+  // in the document — a certification acronym also in a skills line, a date
+  // fragment that is also a phone-number substring. An evidence-only check
+  // (searching `documentText` for `entry.evidence`) stays stuck forever here;
+  // the fix reads the anchored `line` instead, mirroring Rust's
+  // `entry_resolved`.
+  //
+  // Mutation check: revert to `!evidencePresent(entry, documentText)` (the
+  // pre-fix body) and this fails — see the report for the executed run.
+  it('resolves a Remove once the anchored LINE is gone, even when the bare evidence span survives elsewhere', () => {
+    const anchored: Fabrication = {
+      issueKey: 'factual.unsourced_certification#0',
+      code: 'factual.unsourced_certification',
+      evidence: 'CKA',
+      line: 'Certified Kubernetes Administrator (CKA).',
+      decision: 'remove',
+    };
+    // The flagged bullet is gone; an unrelated project note still names the
+    // same bare acronym.
+    const edited = [
+      'PROFESSIONAL SUMMARY',
+      'A payments engineer.',
+      '',
+      'PROJECTS',
+      '- Built a CKA exam prep tool for study groups.',
+    ].join('\n');
+    expect(edited).toContain('CKA'); // the span still exists in the document…
+    expect(isFabricationResolved(anchored, edited)).toBe(true); // …but the entry must read resolved.
+  });
+
+  // The mirror: the anchored line is STILL in the document (the removal
+  // never actually happened), so the entry must stay unresolved even though
+  // nothing about the evidence check changed.
+  it('does not resolve a Remove while the anchored line is still in the document', () => {
+    const anchored: Fabrication = {
+      issueKey: 'factual.unsourced_certification#0',
+      code: 'factual.unsourced_certification',
+      evidence: 'CKA',
+      line: 'Certified Kubernetes Administrator (CKA).',
+      decision: 'remove',
+    };
+    const untouched = 'PROFESSIONAL SUMMARY\nCertified Kubernetes Administrator (CKA).\n';
+    expect(isFabricationResolved(anchored, untouched)).toBe(false);
   });
 });
 

--- a/apps/desktop/src/renderer/lib/generate/fabrications.ts
+++ b/apps/desktop/src/renderer/lib/generate/fabrications.ts
@@ -125,6 +125,10 @@ export function parseFabrications(value: unknown): Fabrication[] {
  * a `section: None` finding by its evidence. Cheap enough to run at render
  * time; an empty evidence string can't be located and reads as absent rather
  * than as a match against everything.
+ *
+ * This is a PRESENTATION signal only (pending vs. orphaned, below) — never
+ * the resolution check for a `remove` verdict. See {@link removalTakenEffect}
+ * for why those two questions read different fields.
  */
 function evidencePresent(entry: Fabrication, documentText: string): boolean {
   const span = entry.evidence.trim();
@@ -132,35 +136,80 @@ function evidencePresent(entry: Fabrication, documentText: string): boolean {
 }
 
 /**
+ * Has a recorded `remove` verdict actually taken effect against the document
+ * as it stands NOW? Mirrors Rust's `entry_resolved` exactly — same field
+ * priority, same fallback — because this is the predicate that decides
+ * `needsReview`, computed independently on both sides of the IPC boundary.
+ *
+ * **Reads the anchored `line` when the entry carries one, never `evidence`
+ * alone.** `evidence` is routinely a bare token — a certification acronym, a
+ * bare year, a bare figure — and a bare token can legitimately recur on a
+ * DIFFERENT line the user never touched (a different bullet, a project name
+ * quoting the same acronym). That is the exact bug this replaces: the user
+ * deletes the flagged line, the deletion succeeds, and because the span
+ * still exists elsewhere in the document, an evidence-only check kept the
+ * entry stuck at "unresolved" forever. Checking `line` instead asks the same
+ * question `removeEvidenceLines` answered when it deleted — "is the flagged
+ * BULLET gone" — not "does this substring exist somewhere".
+ *
+ * Deliberately does NOT require both signals (line gone AND evidence gone).
+ * ANDing them reintroduces the bug above: the flagged line is deleted, the
+ * bare token legitimately survives elsewhere, and `evidence gone` would be
+ * false forever. The accepted cost is the opposite edge — the user
+ * cosmetically edits the flagged line (rewords it) while literally keeping
+ * the flagged span inside it — which reads as resolved because the ORIGINAL
+ * line text is no longer found verbatim anywhere. There is no honest anchor
+ * that survives an in-place edit: relocating the line by searching for the
+ * bare span is the forbidden move `removeEvidenceLines` refuses for the same
+ * reason. Matches Rust's `entry_resolved`, which takes the identical
+ * trade-off — the two must agree, not just each be independently defensible.
+ *
+ * Only falls back to `evidence` when the entry carries no `line` at all: a
+ * report persisted before the field existed, or a span with no honest
+ * single-line anchor to begin with. An empty/blank line or span reads as
+ * absent rather than as a match against everything.
+ */
+function removalTakenEffect(entry: Fabrication, documentText: string): boolean {
+  const line = entry.line?.trim();
+  if (line !== undefined) return line === '' || !documentText.includes(line);
+  return !evidencePresent(entry, documentText);
+}
+
+/**
  * How to present one entry against the document as it stands NOW.
  *
  * A recorded `remove` is NOT enough to call the entry finished: the verdict is
  * a record of intent, and the document is the record of fact. They agree only
- * once the span is gone.
+ * once the flagged occurrence is gone ({@link removalTakenEffect}).
  */
 export function presentFabrication(
   entry: Fabrication,
   documentText: string
 ): FabricationPresentation {
-  const present = evidencePresent(entry, documentText);
   if (entry.decision === 'keep') return 'resolved';
-  if (entry.decision === 'remove') return present ? 'markedForRemoval' : 'resolved';
-  return present ? 'pending' : 'orphaned';
+  if (entry.decision === 'remove') {
+    return removalTakenEffect(entry, documentText) ? 'resolved' : 'markedForRemoval';
+  }
+  return evidencePresent(entry, documentText) ? 'pending' : 'orphaned';
 }
 
 /**
  * Is this entry genuinely settled?
  *
  * A decision alone is not enough. `keep` settles it outright (nothing has to
- * change). `remove` settles it only when the flagged span is actually ABSENT
- * from the current text — counting a recorded-but-unapplied removal as resolved
- * is what lets the badge turn green over text that is still, verbatim, in the
- * document.
+ * change). `remove` settles it only once {@link removalTakenEffect} agrees —
+ * counting a recorded-but-unapplied removal as resolved is what lets the
+ * badge turn green over text that is still, verbatim, in the document.
+ *
+ * Kept coherent with {@link presentFabrication} on purpose: for a `remove`
+ * verdict, this is `true` exactly when that function returns `'resolved'`
+ * rather than `'markedForRemoval'` — same predicate, so the badge and the
+ * per-bullet row can never disagree about whether one entry is finished.
  */
 export function isFabricationResolved(entry: Fabrication, documentText: string): boolean {
   if (!entry.decision) return false;
   if (entry.decision === 'keep') return true;
-  return !evidencePresent(entry, documentText);
+  return removalTakenEffect(entry, documentText);
 }
 
 /** How many entries still need a verdict OR an applied removal — what keeps a


### PR DESCRIPTION
The renderer half of the Major finding CodeRabbit raised on #1024. The Rust half
shipped with that PR; this closes the TS side, which merged into `main` still
wrong.

## The defect

`fabrications.ts` was internally inconsistent about how it identifies an entry.

`removeEvidenceLines` is anchored on `entry.line`, by exact whitespace-trimmed
line equality, and its doc comment says outright **"never by searching for
`evidence`"** — with the reasoning spelled out: a short span matches lines it
was never about, so a substring search deletes the wrong thing.

But `evidencePresent`, which `isFabricationResolved`, `presentFabrication` and
`unresolvedCount` all decide on, did exactly what that doc forbids:

```ts
return !!span && documentText.includes(span);
```

So the app **deleted** by line anchor and **decided resolution** by bare
substring. The user removes the flagged line, the removal succeeds, and if the
span occurs anywhere else in the document the entry never reads resolved — the
integrity chip stays off green and the run stays `needsReview` over work that is
genuinely done. Short spans make that routine: a certification acronym that also
appears in a skills list, or a two-character language code sitting inside
ordinary words.

## The rule

A `remove` verdict now prefers the anchored `line` — resolved once that exact
trimmed line is no longer anywhere in the document — falling back to the
`evidence` substring only when the entry carries no `line`. That absence is a
**supported state**, not a bug: reports persisted before the field existed have
none.

Same field priority as Rust's `entry_resolved`, deliberately, because a
heuristic duplicated across Rust and TS that then drifts is its own recurring
defect class in this repo.

`evidencePresent` is unchanged and still drives the `pending`/`orphaned` split
for undecided entries — that is a rendering question ("can we show the flagged
span"), not a resolution question.

## The alternative, and why it was rejected

The obvious-looking stronger rule is to require **both** signals: the line is
gone AND the evidence is gone. That was mutation-tested rather than argued
about, and it flips the regression test back to red — ANDing reintroduces the
exact bug, because the bare span legitimately survives elsewhere, so
"evidence gone" is false forever and the entry sticks unresolved.

The residual gap is real and worth stating: an entry whose line is **reworded in
place** while still containing the fabricated span reads as resolved. There is
no honest anchor that survives an in-place edit without relocating the line by
searching for the bare span, which is precisely the operation
`removeEvidenceLines` forbids. Rust's shipped fix takes the same cost.

## Verification

Two mutations executed by hand, each watched red then green: reverting
`fabrications.ts` to its pre-fix `main` content (both new regression tests fail),
and the AND variant above.

`tsc --noEmit` clean, ESLint `--max-warnings 0` clean with no disables added,
and 951/951 across `lib/generate`, `components/generation` and `TailorFlow`.

Every caller checked for dependence on the old semantics:
`FabricationReview.tsx`, `QualityBadge.tsx`, `useTailorPipeline.ts`, and
`QualityReportPanel.pipeline.test.tsx` — none of whose fixtures exercised the
"span recurs elsewhere" case, which is why none of them caught this.
