### PR TITLE
fix(landing): serve the /world clips from r2, which can send cors headers

### DIFF
--- a/apps/landing/src/app/world/world-config.test.ts
+++ b/apps/landing/src/app/world/world-config.test.ts
@@ -39,11 +39,15 @@ describe('world-config data integrity', () => {
 
   // Posters and clips are hosted differently on purpose: the stills are ~2 MB
   // total and ship in `public/` so the route paints before anything is fetched,
-  // while the 62 MB of clips live on a tagged GitHub release. Both halves are
-  // asserted against LITERALS rather than against the config's own base, so a
-  // regression that breaks the URL cannot move the expectation with it.
-  const CLIP_URL =
-    /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/releases\/download\/world-assets-v\d+\/[\w.-]+\.mp4$/;
+  // while the 62 MB of clips come from the R2 bucket behind cdn.aijobhunter.app.
+  //
+  // Asserted against LITERALS, not against the config's own base, so a
+  // regression that breaks the URL cannot move the expectation along with it.
+  // The host matters as much as the shape: `scrub-engine` loads clips with
+  // `fetch().then(r => r.blob())`, so they must come from an origin that sends
+  // `Access-Control-Allow-Origin`. A same-origin `/world/vid/...` path or a
+  // GitHub release URL both LOOK fine and both break the route.
+  const CLIP_URL = /^https:\/\/cdn\.aijobhunter\.app\/world\/vid\/[\w.-]+\.mp4$/;
 
   it('serves every poster still from /world/ in the deployed site', () => {
     for (const section of sections) {
@@ -52,26 +56,27 @@ describe('world-config data integrity', () => {
     }
   });
 
-  it('serves every clip from a pinned release tag, never from the site itself', () => {
+  it('serves every clip from the CORS-enabled asset host, never from the site itself', () => {
     for (const section of sections) {
       expect(section.clip).toMatch(CLIP_URL);
       expect(section.clipMobile).toMatch(CLIP_URL);
     }
   });
 
-  it('serves every connector from the same pinned release tag', () => {
+  it('serves every connector from that same host', () => {
     for (const path of [...connectors, ...connectorsMobile]) {
       expect(path).toMatch(CLIP_URL);
     }
   });
 
-  it('pins every clip to ONE release tag, so a partial bump cannot ship', () => {
-    const tags = new Set(
+  it('serves every clip from ONE origin, so a half-finished migration cannot ship', () => {
+    const origins = new Set(
       [...sections.flatMap((s) => [s.clip, s.clipMobile]), ...connectors, ...connectorsMobile].map(
-        (url) => url.split('/download/')[1]?.split('/')[0]
+        (url) => new URL(url).origin
       )
     );
-    expect(tags.size).toBe(1);
+    expect(origins.size).toBe(1);
+    expect([...origins][0]).toBe('https://cdn.aijobhunter.app');
   });
 });
 

--- a/apps/landing/src/app/world/world-config.ts
+++ b/apps/landing/src/app/world/world-config.ts
@@ -43,23 +43,31 @@ export interface WorldConfig {
   connectorsMobile: string[];
 }
 
-// Where the /world clips are served from. They live as assets on a tagged
-// GitHub release rather than in the repo or in `public/`, for two reasons:
-// release assets carry no bandwidth limit, while a Pages site has a 100 GB per
-// month soft one that this route's 20 MB device-set cap would reach at roughly
-// 5,000 visits; and video does not delta-compress, so keeping them in git makes
-// every re-encode cost its full size in permanent history forever.
+// Where the /world clips are served from: an R2 bucket behind
+// cdn.aijobhunter.app, not the repo and not `public/`.
 //
-// Pinned to one release TAG on purpose. Publishing `world-assets-v2` with a new
-// set and bumping this line is atomic; mutating the assets on an existing
-// release is not, and would leave cached clients disagreeing with fresh ones.
+// Two reasons they are not in git. Video does not delta-compress, so every
+// re-encode writes every byte again as permanent history; one re-encode round
+// had already cost ~38 MB. And serving them from `public/` put them on the
+// Pages site, spending its 100 GB/month soft bandwidth limit — about 5,000
+// visits at this route's 20 MB device-set cap.
 //
-// Override to use local files: `NEXT_PUBLIC_WORLD_VIDEO_BASE=/world/vid` with
-// the clips in `apps/landing/public/world/vid/` (gitignored). Next inlines this
-// at build time, which is what the static export needs.
+// Why R2 specifically, and not the GitHub release they briefly lived on:
+// `scrub-engine.js` loads each clip with `fetch(url).then(r => r.blob())`, so
+// the response MUST carry `Access-Control-Allow-Origin`. GitHub release
+// downloads do not send it, and the route silently fell back to its poster
+// stills. R2 lets the bucket declare a CORS policy; this origin is on it.
+//
+// Egress from R2 is unmetered, so the bandwidth ceiling is gone rather than
+// moved. Objects are uploaded with `immutable` and a one-year max-age, which is
+// honest because a new clip set means a new key, never a mutated one.
+//
+// Override for offline work: `NEXT_PUBLIC_WORLD_VIDEO_BASE=/world/vid` with the
+// clips in `apps/landing/public/world/vid/` (gitignored). Next inlines this at
+// build time, which is what the static export needs. localhost:3000 is on the
+// bucket's CORS allowlist too, so plain `next dev` works without the override.
 const VIDEO_BASE =
-  process.env.NEXT_PUBLIC_WORLD_VIDEO_BASE ??
-  'https://github.com/saeedkolivand/ai-job-hunter-app/releases/download/world-assets-v1';
+  process.env.NEXT_PUBLIC_WORLD_VIDEO_BASE ?? 'https://cdn.aijobhunter.app/world/vid';
 
 /** URL for one /world clip. `file` is the bare name, e.g. `slump.mp4`. */
 const vid = (file: string): string => `${VIDEO_BASE}/${file}`;


### PR DESCRIPTION
Fixes the `/world` route, which #1031 broke. It is live and degraded right now:
poster stills render, no video.

## What went wrong, and why the check missed it

`scrub-engine.js` loads each clip with:

```js
fetch(url).then((r) => (r.ok ? r.blob() : ...)).then((blob) => { v.src = URL.createObjectURL(blob); })
```

That is a **cross-origin `fetch`**, so the response must carry
`Access-Control-Allow-Origin`. **GitHub release downloads do not send it.** Every
clip fetch threw, the engine's fetch-failure path swallowed it, and the route
silently fell back to poster stills.

I verified #1031 with `curl`, which returned `302 → 200`. **`curl` sends no
`Origin` header, so it never exercises CORS at all.** That is the whole reason a
broken change looked verified.

## Why R2 rather than another workaround

The constraint is "the response needs a CORS header". Options:

| | |
|---|---|
| Same-origin (back into `public/`) | Works, but restores the Pages 100 GB/month ceiling — ~5,000 visits at this route's 20 MB device cap |
| Next.js `/api` proxy | **Impossible.** `output: 'export'` means no server; API Routes are a build error and Route Handlers must be `force-static` |
| Build-time fetch into `public/` | Works, but is same-origin again — identical bandwidth exposure |
| **R2 bucket + CORS policy** | Fixes the actual constraint, **and** egress is unmetered so the ceiling is gone rather than moved |

## Configuration applied

- Bucket `aijobhunter-assets`, **Standard** class (Infrequent Access bills separately and does not count toward the free tier)
- 33 objects under `world/vid/`, uploaded with
  `cache-control: public, max-age=31536000, immutable` — honest because a new
  clip set means new keys, never mutated ones
- CORS allowlist: the site origin, its `www`, and `localhost:3000` so plain
  `next dev` works with no override
- Custom domain `cdn.aijobhunter.app`, **min TLS raised 1.0 → 1.2**
- **`r2.dev` public URL left disabled** — it bypasses zone cache rules and WAF,
  so it is an unprotected path straight to the bucket

## Verified against the live origin this time

A real `fetch().then(r => r.blob())` executed on the deployed page:

```json
{ "origin": "https://aijobhunter.app", "status": 200,
  "blobBytes": 2503061, "blobType": "video/mp4",
  "ms": 237, "objectUrlOk": true }
```

Plus headers checked directly: the allow-origin header is **present** for this
origin and **absent** for a disallowed one (which still returns 200 — CORS is
enforced by the browser on the header's absence, another way this fails quietly).

## Tests pin the host, not the URL shape

That is where the defect lived: a same-origin `/world/vid/...` path and a GitHub
release URL both look correct and both break the route.

**Mutation-checked by execution against each of those two states in turn — each
turns three tests red.** Neither would have been caught by the previous
assertions.

## Follow-up

The `world-assets-v1` GitHub release stays until this merges and deploys, as a
fallback. It gets deleted after that.
