### PR TITLE
docs: repoint the audit-report sha after the history rewrite

### DIFF
--- a/docs/knowledge/decision-records/0005-network-egress-privacy-boundary.md
+++ b/docs/knowledge/decision-records/0005-network-egress-privacy-boundary.md
@@ -64,5 +64,7 @@ No runtime behavior changes: every current call already complies. The fix is to 
 - Machine-readable inventory: `apps/desktop/src-tauri/tests/egress.rs` (EGRESS const).
 - Audit finding: `p2-contra-cross-001`, §4 of the 2026-08-16 full-history audit.
   That report was a 1.5 MB one-off snapshot scoped to `v0.123.0` and is no longer in
-  the tree; read it with `git show 65ea4188c:AUDIT_REPORT.md`. Its `path:line` citations
+  the tree; read it with `git show cd1219ef7:AUDIT_REPORT.md`. That sha moved once
+  already, in the history rewrite of PR #1033 — if it stops resolving, find the
+  commit for PR #1000 and read the file there. Its `path:line` citations
   point at that commit's HEAD, not this one.

--- a/docs/knowledge/decision-records/0006-support-page-faq-only-diagnostics-removed.md
+++ b/docs/knowledge/decision-records/0006-support-page-faq-only-diagnostics-removed.md
@@ -73,5 +73,7 @@ need — not by resurrecting this speculative, backendless subtree.
 - Audit findings: `renderer-feat-3-001`, `p2-b1-ipc-chain-001`, `p2-b1-ipc-chain-002`,
   §4 of the 2026-08-16 full-history audit. That report was a 1.5 MB one-off snapshot
   scoped to `v0.123.0` and is no longer in the tree; read it with
-  `git show 65ea4188c:AUDIT_REPORT.md`. Its `path:line` citations point at that commit's
+  `git show cd1219ef7:AUDIT_REPORT.md`. That sha moved once already, in the history
+  rewrite of PR #1033 — if it stops resolving, find the commit for PR #1000 and read
+  the file there. Its `path:line` citations point at that commit's
   HEAD, not this one.


### PR DESCRIPTION
Cleanup after the history rewrite in #1033.

The rewrite renamed every commit, so the `git show <sha>:AUDIT_REPORT.md`
pointer that ADR-0005 and ADR-0006 carry went dead the moment it landed.

Translated through filter-repo's `commit-map`: **`65ea4188c` → `cd1219ef7`**,
verified to still hold all 1,588,368 bytes.

Both citations now also record that the sha **has already moved once** and name
PR #1000 as the durable anchor. A bare sha is exactly the kind of reference a
rewrite breaks; a reader who hits a dead one shouldn't have to guess what to do.

## Known and deliberately not fixed

`CHANGELOG.md` carries a commit link for every release — **all of them now point
at pre-rewrite shas.** That file is generated by semantic-release across 241
tags, so hand-editing it is neither feasible nor durable.

Those links keep resolving today because GitHub doesn't garbage collect on its
own and this repo has forks sharing the object store. They break if that ever
changes. Accepted: the alternative is rewriting generated release history to
chase link cosmetics.
