### PR TITLE
fix(scraping): wire the freehire params their spec never documented

### DIFF
--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/freehire.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/freehire.rs
@@ -31,14 +31,35 @@
 //!   MERGED behind the sparse keyed hits rather than replacing them, because
 //!   on a guessed market this tier is location-blind and those hits are not.
 //!
-//! **Degradation:** any non-2xx, timeout, or schema drift resolves to `Ok(empty)`,
-//! NOT `Err`. Every other provider reports its failure because a configured key
-//! means the user asked for that provider specifically. freehire is configured
-//! by nobody — it is always on — so surfacing its outage as a board error would
-//! turn a third party's downtime into an error banner on a search the user never
-//! pointed at them. There is no SLA, no rate-limit header of any kind, and no
-//! documented limit (verified: no `X-RateLimit-*`, no `Retry-After`,
-//! Cloudflare-fronted), so it must be treated as always-possibly-absent.
+//! **Degradation:** any non-2xx, timeout, schema drift, or ignored request
+//! parameter (see `fetch_freehire`'s doc) resolves to `Ok(empty)`, NOT `Err`.
+//! Every other provider reports its failure because a configured key means the
+//! user asked for that provider specifically. freehire is configured by
+//! nobody — it is always on — so surfacing its outage as a board error would
+//! turn a third party's downtime into an error banner on a search the user
+//! never pointed at them.
+//!
+//! **Rate limits (as of the maintainer's issue #1026 disclosure, live-verified
+//! 2026-08-18):** 600 req/min for ordinary reads, 300 req/min for
+//! `/agent/jobs/search` specifically (the endpoint this module calls). Every
+//! response — success included — carries `X-RateLimit-Limit/Remaining/Reset`;
+//! going over budget answers `429` with `Retry-After`. The limiter is a leaky
+//! bucket, not a counter (`Remaining` can trail this module's own request
+//! count by one — pace against it, never reconcile it exactly). No new
+//! rate-limiting code lives here: `scraping::http::fetch_text` already backs
+//! off on `429`/`503` honoring `Retry-After` when present, for every board
+//! that goes through it. This tier's own traffic (one request per aggregator
+//! search, only reached after every keyed tier has failed or come back
+//! empty) sits nowhere near either ceiling.
+//!
+//! **User-Agent:** every request carries an identifying UA
+//! (`freehire_user_agent`) — app name, crate version, and this repo's public
+//! URL, nothing else (no user data, no machine id, no locale). The
+//! maintainer's issue #1026 requests but does not enforce or validate it;
+//! nothing behaves differently without it. It buys advance notice before a
+//! field or limit changes, instead of a `429` being the first sign. This is
+//! per-request (`FetchOptions::user_agent`), not the shared client's default
+//! UA — other boards keep looking like an ordinary browser.
 //!
 //! Data rights: freehire's backend is MIT, but MIT covers the CODE and not the
 //! postings — they disclaim ownership of the data and grant no redistribution
@@ -66,10 +87,69 @@ const MAX_LIMIT: u32 = 100;
 /// pulling a page nobody reads".
 const DEFAULT_LIMIT: u32 = 50;
 
+/// Map a UI date-filter token to freehire's `posted_within_days` (whole days,
+/// `minimum: 1` per the live `openapi.yaml`). `None` (no filter chosen) omits
+/// the parameter entirely — freehire's own semantics for "omit" is "no
+/// freshness restriction" (`PostedWithinDays`'s description), so unlike
+/// Adzuna/JSearch (which always send SOME day cap, even with no filter) this
+/// floor tier's no-filter search stays genuinely unfiltered.
+///
+/// Same 3-day floor as `adzuna::adzuna_max_days_old` / `providers::jsearch_date_posted`
+/// for the identical reason: `posted_within_days` has no sub-day granularity —
+/// a whole day is its smallest unit, and the spec forbids `0` outright — and a
+/// naive same-day floor zeroed out autopilot "recent" filters on quiet days
+/// (see those two functions' doc comments). Reusing the exact established
+/// floor rather than inventing a new number keeps all three tiers' recency
+/// skew for sub-day tokens identical.
+pub(super) fn freehire_posted_within_days(date_filter: Option<&str>) -> Option<u32> {
+    match date_filter {
+        None => None,
+        Some("15m" | "30m" | "1h" | "2h" | "4h" | "8h" | "24h") => Some(3),
+        Some("week") => Some(7),
+        // "month" and any future/unrecognized token.
+        Some(_) => Some(30),
+    }
+}
+
+/// Identifying `User-Agent` the maintainer's issue #1026 now requests (never
+/// enforced, never validated, nothing behaves differently without it — see
+/// the module doc). Carries ONLY the app name, this crate's version, and the
+/// public repo URL — no user data, no machine id, no locale. Mirrors the
+/// existing `"ai-job-hunter/1.0"` convention `commands::geocoding` already
+/// uses for Photon, with a version that tracks releases instead of a
+/// hand-typed number that can rot.
+pub(super) fn freehire_user_agent() -> String {
+    format!(
+        "ai-job-hunter/{} (+https://github.com/saeedkolivand/ai-job-hunter-app)",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
 #[derive(Debug, Deserialize)]
 struct FreehireEnvelope {
     #[serde(default)]
     data: Vec<FreehireJob>,
+    #[serde(default)]
+    meta: FreehireMeta,
+}
+
+/// Only the field this mapping reads. `#[serde(default)]` + no
+/// `deny_unknown_fields`, matching [`FreehireJob`]'s contract — `meta` may
+/// carry `total`/`limit`/`offset` too, which nothing here needs.
+#[derive(Debug, Default, Deserialize)]
+struct FreehireMeta {
+    /// Present only when the request carried a parameter the search did not
+    /// read (`openapi.yaml`'s `PaginationMeta.ignored_params`) — see
+    /// `fetch_freehire`'s doc for what this module does about it.
+    #[serde(default)]
+    ignored_params: Vec<FreehireIgnoredParam>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FreehireIgnoredParam {
+    param: String,
+    #[serde(default)]
+    did_you_mean: Option<String>,
 }
 
 /// Only the fields this mapping consumes. `#[serde(default)]` throughout and no
@@ -193,18 +273,54 @@ fn map_freehire_job(j: FreehireJob, now: i64) -> Option<JobPosting> {
 /// including remote ones, which is worse than the country-level filter this
 /// tier already applies. City precision stays the keyed tiers' job; this one is
 /// a keyless floor, not a replacement for them.
+///
+/// Not adding `cities` either, though issue #1026 confirms it is real: geography
+/// is a single OR-group on this API (`countries=gb` → 89,211;
+/// `countries=gb&cities=London` → 89,617 — WIDER, not narrower, live-verified),
+/// so folding a city in would need a location-UI decision this change doesn't
+/// make. Left as a follow-up, not silently worked around here.
+///
+/// **`reality=fresh` is always sent, unconditionally.** freehire's `reality`
+/// facet (`fresh`/`stale`/`likely-evergreen`) is live-verified to cut the
+/// unfiltered catalogue roughly in half (1,477,440 → 662,112 in the same
+/// spot-check that verified `posted_within_days` below). No toggle for it:
+/// every other quality improvement this aggregator applies — `sort_by=date`
+/// (Adzuna/JSearch), `dedupe_by_url` (all tiers) — is likewise always-on and
+/// has no user-facing knob anywhere in this board, so a bespoke settings
+/// toggle for just this one facet, on just this one last-resort tier, would be
+/// the odd one out. This tier's own module doc already frames its purpose as
+/// "enough to be useful without pulling a page nobody reads" ([`DEFAULT_LIMIT`]);
+/// a `stale`/`likely-evergreen`-heavy result set (over half the unfiltered
+/// catalogue) undercuts exactly that, and the filter costs nothing extra to
+/// apply (already in the payload per the maintainer).
+///
+/// **`meta.ignored_params` is checked and treated as a failure, not a warning.**
+/// freehire ignores an unrecognized query key rather than rejecting it — a
+/// typo returns the WHOLE catalogue, indistinguishable from a legitimate broad
+/// result, unless the response is checked (issue #1026, live-verified: a
+/// `country=gb` typo comes back 200 with `meta.ignored_params:
+/// [{"param":"country","did_you_mean":"countries"}]` and the full unfiltered
+/// set in `data`). If any of THIS module's own params (`q`, `countries`,
+/// `posted_within_days`, `reality`, …) ever appear there — a future upstream
+/// rename would do it — this function returns `Err` instead of the response's
+/// `data`, so the silent-degradation boundary in `FreehireProvider::search`
+/// turns it into `Ok(empty)` for this tier, exactly like any other freehire
+/// failure. The one option NOT taken is returning `resp.data` anyway: that
+/// would silently hand back an unfiltered set dressed as a filtered one, which
+/// is the one thing issue #1026 calls out as unacceptable.
 pub(super) async fn fetch_freehire(
     base_url: &str,
     query: &str,
     country: &str,
     country_guessed: bool,
+    date_filter: Option<&str>,
     amount: Option<u32>,
     signal: tokio_util::sync::CancellationToken,
 ) -> anyhow::Result<Vec<JobPosting>> {
     let limit = amount.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
 
     let mut url = format!(
-        "{}/agent/jobs/search?limit={limit}&description_format=markdown",
+        "{}/agent/jobs/search?limit={limit}&description_format=markdown&reality=fresh",
         base_url.trim_end_matches('/')
     );
     // The spec's full-text parameter is `q`. (There is an undocumented
@@ -228,21 +344,50 @@ pub(super) async fn fetch_freehire(
     if !country_guessed && !country.is_empty() {
         url.push_str(&format!("&countries={}", urlencoding::encode(country)));
     }
+    if let Some(days) = freehire_posted_within_days(date_filter) {
+        url.push_str(&format!("&posted_within_days={days}"));
+    }
 
     let resp = fetch_json::<FreehireEnvelope>(
         &url,
         FetchOptions {
-            // One retry rather than the default two: no documented rate limit
-            // means no way to back off correctly, and this tier is optional by
-            // construction — being quiet is cheaper than being persistent.
+            // One retry rather than the default two: this tier is optional by
+            // construction (nobody configured it) and runs only after every
+            // keyed tier has already failed or come back empty, so being quiet
+            // is cheaper than being persistent — NOT because there is nowhere
+            // to learn how long to wait: `fetch_text` already backs off on
+            // 429/503 honoring `Retry-After` when the response carries one
+            // (see the module doc's rate-limit section).
             retries: 1,
             timeout: Some(std::time::Duration::from_secs(15)),
+            user_agent: Some(freehire_user_agent()),
             ..FetchOptions::default()
         },
         signal,
     )
     .await
     .map_err(|e| anyhow::anyhow!("freehire: {e}"))?;
+
+    if !resp.meta.ignored_params.is_empty() {
+        // See this function's doc for why this is `Err`, not a warning that
+        // still returns `resp.data`. Formatted by hand (not `{:?}`) so both
+        // `param` and `did_you_mean` are read directly — `#[derive(Debug)]`
+        // alone doesn't satisfy rustc's dead-code check on a struct's fields.
+        let detail = resp
+            .meta
+            .ignored_params
+            .iter()
+            .map(|p| match &p.did_you_mean {
+                Some(suggestion) => format!("{} (did you mean {suggestion}?)", p.param),
+                None => p.param.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(anyhow::anyhow!(
+            "freehire: upstream ignored request parameter(s), refusing to treat the response \
+             as filtered: {detail}"
+        ));
+    }
 
     let now = chrono::Utc::now().timestamp_millis();
     Ok(resp
@@ -298,7 +443,7 @@ impl JobProvider for FreehireProvider {
         _location: &str,
         country: &str,
         country_guessed: bool,
-        _date_filter: Option<&str>,
+        date_filter: Option<&str>,
         amount: Option<u32>,
         signal: tokio_util::sync::CancellationToken,
     ) -> anyhow::Result<Vec<JobPosting>> {
@@ -309,6 +454,7 @@ impl JobProvider for FreehireProvider {
             query,
             country,
             country_guessed,
+            date_filter,
             amount,
             signal,
         )

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/test.rs
@@ -4402,7 +4402,7 @@ async fn freehire_ok_response_maps_end_to_end() {
         .mount(&server)
         .await;
 
-    let items = fetch_freehire(&server.uri(), "rust", "de", false, None, make_token())
+    let items = fetch_freehire(&server.uri(), "rust", "de", false, None, None, make_token())
         .await
         .expect("a 2xx freehire response must map");
 
@@ -4433,8 +4433,10 @@ async fn freehire_ok_response_maps_end_to_end() {
 
 /// The request is built from the PUBLISHED spec: the documented
 /// `/agent/jobs/search` path, `q` as the full-text parameter (NOT the
-/// undocumented `/jobs/search`'s `query`), and `description_format=markdown` so
-/// scoring never needs a per-result detail fetch.
+/// undocumented `/jobs/search`'s `query`), `description_format=markdown` so
+/// scoring never needs a per-result detail fetch, and `reality=fresh` (issue
+/// #1026's quality filter — see `fetch_freehire`'s doc for why it is
+/// unconditional).
 ///
 /// Mutation check: changed `q=` to `query=` in `fetch_freehire` — RAN, went red
 /// here, restored. Same for dropping `description_format`.
@@ -4449,6 +4451,7 @@ async fn freehire_request_follows_the_published_spec() {
         .and(query_param("q", "rust engineer"))
         .and(query_param("description_format", "markdown"))
         .and(query_param("countries", "de"))
+        .and(query_param("reality", "fresh"))
         .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"data":[]}"#))
         .expect(1)
         .mount(&server)
@@ -4460,12 +4463,184 @@ async fn freehire_request_follows_the_published_spec() {
         "de",
         false,
         None,
+        None,
         make_token(),
     )
     .await
     .expect("the spec-shaped request must succeed");
     // MockServer verifies `.expect(1)` on drop: a request that missed any of the
     // matchers above leaves it unsatisfied and panics here.
+}
+
+/// The identifying `User-Agent` (issue #1026) is sent, and it is per-request —
+/// NOT the shared client's browser-shaped default (`net::http::DEFAULT_UA`,
+/// still used everywhere else in the fleet). Regression guard for the exact
+/// bug `FetchOptions::user_agent` exists to avoid: `headers` entries are
+/// applied via `RequestBuilder::header`, which APPENDS, so putting
+/// `user-agent` there instead would have sent it ALONGSIDE the default rather
+/// than in place of it.
+///
+/// Mutation check: reverted `fetch_freehire`'s `user_agent: Some(...)` back to
+/// the field's `None` default — RAN, went red (wiremock's `header` matcher no
+/// longer saw the expected value, since the request fell back to
+/// `DEFAULT_UA`), restored.
+#[tokio::test]
+async fn freehire_sends_the_identifying_user_agent_in_place_of_the_default() {
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(header(
+            "user-agent",
+            super::freehire::freehire_user_agent().as_str(),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"data":[]}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    fetch_freehire(&server.uri(), "rust", "de", false, None, None, make_token())
+        .await
+        .expect("the identifying-UA request must succeed");
+}
+
+/// `freehire_user_agent` carries only the app name, the crate version, and the
+/// public repo URL — nothing that could identify a specific user or machine.
+#[test]
+fn freehire_user_agent_carries_no_user_data() {
+    let ua = super::freehire::freehire_user_agent();
+    assert!(
+        ua.starts_with("ai-job-hunter/"),
+        "must lead with the app name; got {ua:?}"
+    );
+    assert!(
+        ua.contains(env!("CARGO_PKG_VERSION")),
+        "must carry the real crate version, not a hand-typed one; got {ua:?}"
+    );
+    assert!(
+        ua.contains("github.com/saeedkolivand/ai-job-hunter-app"),
+        "must carry the public repo URL; got {ua:?}"
+    );
+}
+
+/// `posted_within_days` mapping: every generated `date_filter` token maps to a
+/// real value (never silently dropped), `None` omits the parameter entirely
+/// (freehire's own "no restriction" semantics), and the sub-day tokens share
+/// the same 3-day floor as `adzuna_max_days_old`/`jsearch_date_posted` rather
+/// than a newly-invented number.
+///
+/// Mutation check: changed the sub-day arm's `Some(3)` to `Some(1)` — RAN,
+/// went red here, restored.
+#[test]
+fn freehire_posted_within_days_maps_every_generated_token() {
+    use super::freehire::freehire_posted_within_days;
+
+    assert_eq!(freehire_posted_within_days(None), None);
+    for token in ["15m", "30m", "1h", "2h", "4h", "8h", "24h"] {
+        assert_eq!(
+            freehire_posted_within_days(Some(token)),
+            Some(3),
+            "sub-day token {token:?} must floor at 3 days, matching Adzuna/JSearch"
+        );
+    }
+    assert_eq!(freehire_posted_within_days(Some("week")), Some(7));
+    assert_eq!(freehire_posted_within_days(Some("month")), Some(30));
+
+    for &token in crate::ipc_contracts::date_filters::DATE_FILTER_OPTIONS {
+        assert!(
+            freehire_posted_within_days(Some(token)).is_some(),
+            "generated date-filter token {token:?} has no freehire mapping"
+        );
+    }
+}
+
+/// `date_filter` reaches the wire as `posted_within_days`, the real bug issue
+/// #1026 reported (previously `_date_filter: Option<&str>` — accepted and
+/// thrown away).
+#[tokio::test]
+async fn freehire_wires_date_filter_to_posted_within_days() {
+    use wiremock::matchers::{method, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(query_param("posted_within_days", "7"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"data":[]}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    fetch_freehire(
+        &server.uri(),
+        "rust",
+        "de",
+        false,
+        Some("week"),
+        None,
+        make_token(),
+    )
+    .await
+    .expect("a date-filtered request must succeed");
+}
+
+/// A response the maintainer's `ignored_params` guard reports is treated as a
+/// FAILURE, not a warning that still returns `data` — see `fetch_freehire`'s
+/// doc for why. The one behavior under test that must NOT happen: getting
+/// `Ok` back with the (unfiltered) job the fixture's `data` array carries.
+///
+/// Mutation check: dropped the `!resp.meta.ignored_params.is_empty()` guard —
+/// RAN, went red here (the call returned `Ok` with the one fixture job),
+/// restored.
+#[tokio::test]
+async fn freehire_refuses_a_response_with_ignored_params() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"{"data":[{"title":"Should Not Surface","url":"https://example.com/j/1"}],
+                "meta":{"total":1,"ignored_params":[{"param":"country","did_you_mean":"countries"}]}}"#,
+        ))
+        .mount(&server)
+        .await;
+
+    let err = fetch_freehire(&server.uri(), "rust", "de", false, None, None, make_token())
+        .await
+        .expect_err("a response reporting an ignored param must not be treated as filtered");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ignored"),
+        "the error must say why it refused; got: {msg}"
+    );
+    assert!(
+        msg.contains("countries"),
+        "the ignored param's did_you_mean detail must reach the log-visible error; got: {msg}"
+    );
+}
+
+/// The companion half of the guard above: a CLEAN response (no `meta` block,
+/// or a `meta` with an empty/absent `ignored_params`) must map normally — the
+/// guard must not become a false-positive that drops every result.
+#[tokio::test]
+async fn freehire_maps_normally_when_no_params_are_ignored() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"{"data":[{"title":"Fine","url":"https://example.com/j/1"}],"meta":{"total":1}}"#,
+        ))
+        .mount(&server)
+        .await;
+
+    let items = fetch_freehire(&server.uri(), "rust", "de", false, None, None, make_token())
+        .await
+        .expect("a clean response (no ignored_params) must map normally");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].title, "Fine");
 }
 
 /// A GUESSED country must NOT become a `countries` filter. `AggregatorScraper`
@@ -4488,7 +4663,7 @@ async fn freehire_does_not_filter_by_a_guessed_country() {
         .mount(&server)
         .await;
 
-    fetch_freehire(&server.uri(), "rust", "de", true, None, make_token())
+    fetch_freehire(&server.uri(), "rust", "de", true, None, None, make_token())
         .await
         .expect("a guessed-country search must still run");
 }
@@ -4506,7 +4681,7 @@ async fn freehire_non_2xx_maps_to_prefixed_err() {
         .mount(&server)
         .await;
 
-    let msg = fetch_freehire(&server.uri(), "rust", "de", false, None, make_token())
+    let msg = fetch_freehire(&server.uri(), "rust", "de", false, None, None, make_token())
         .await
         .unwrap_err()
         .to_string();
@@ -4568,7 +4743,7 @@ async fn freehire_drops_unusable_rows_without_losing_the_page() {
         .mount(&server)
         .await;
 
-    let items = fetch_freehire(&server.uri(), "rust", "de", false, None, make_token())
+    let items = fetch_freehire(&server.uri(), "rust", "de", false, None, None, make_token())
         .await
         .expect("a page with unusable rows must still map the usable ones");
 
@@ -4594,7 +4769,7 @@ async fn freehire_slugless_rows_key_off_their_url_not_each_other() {
         .mount(&server)
         .await;
 
-    let items = fetch_freehire(&server.uri(), "rust", "de", false, None, make_token())
+    let items = fetch_freehire(&server.uri(), "rust", "de", false, None, None, make_token())
         .await
         .expect("slugless rows must map");
 
@@ -4636,6 +4811,7 @@ async fn freehire_clamps_limit_to_the_specs_range() {
         "rust",
         "de",
         false,
+        None,
         Some(5_000),
         make_token(),
     )

--- a/apps/desktop/src-tauri/src/scraping/http/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/mod.rs
@@ -58,6 +58,14 @@ pub struct FetchOptions {
     pub method: Option<reqwest::Method>,
     pub body: Option<String>,
     pub retries: u32,
+    /// Per-request `User-Agent` override. `None` keeps [`DEFAULT_UA`] (the
+    /// shared browser-shaped UA most boards rely on to look like an ordinary
+    /// browser). Set this — rather than putting `user-agent` in `headers` —
+    /// for a board that wants to identify itself: `headers` entries are
+    /// applied via `RequestBuilder::header`, which APPENDS rather than
+    /// replaces, so a `user-agent` there would ride alongside [`DEFAULT_UA`]
+    /// as a second header line instead of overriding it.
+    pub user_agent: Option<String>,
     /// Per-request byte cap. `None` falls back to the shared `MAX_BYTES` (8 MB).
     /// Use only for feeds known to exceed 8 MB (e.g. the GTJ RSS feed at ~10 MB).
     pub max_bytes: Option<usize>,
@@ -83,6 +91,7 @@ impl Default for FetchOptions {
             method: None,
             body: None,
             retries: 2,
+            user_agent: None,
             max_bytes: None,
             timeout: None,
             redact_path: false,
@@ -131,7 +140,10 @@ pub async fn fetch_text(
             _ => client.get(url),
         };
 
-        request = request.header("user-agent", DEFAULT_UA);
+        request = request.header(
+            "user-agent",
+            opts.user_agent.as_deref().unwrap_or(DEFAULT_UA),
+        );
 
         // Only add the broad HTML accept when the caller hasn't already set one.
         // This prevents a double `accept` header when fetch_json (which prepends

--- a/apps/desktop/src-tauri/src/scraping/http/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/test.rs
@@ -8,6 +8,9 @@ fn test_fetch_options_default() {
     assert!(opts.body.is_none());
     // Default retries raised to 2 to allow one 429/503 backoff before giving up.
     assert_eq!(opts.retries, 2);
+    // `None` keeps the shared browser-shaped DEFAULT_UA — a board opts INTO an
+    // identifying UA (e.g. freehire), it is never on by default.
+    assert!(opts.user_agent.is_none());
 }
 
 /// `FetchOptions.timeout` backward-safe contract (item 4):
@@ -326,6 +329,65 @@ async fn test_fetch_json_preserves_caller_headers() {
 
     let parsed = result.expect("fetch_json should succeed and deserialize the response");
     assert!(parsed.ok, "expected ok:true — X-API-Key header was dropped");
+}
+
+/// `FetchOptions::user_agent` REPLACES the shared client's default UA rather
+/// than riding alongside it — the exact bug it exists to close: putting
+/// `user-agent` in `opts.headers` instead would have appended a second header
+/// line (`RequestBuilder::header` appends, it does not replace), sending BOTH
+/// `DEFAULT_UA` and the override on the wire. Checked via
+/// `MockServer::received_requests` (not just a `header()` matcher, which only
+/// proves the override value is PRESENT, not that the default is ABSENT) so a
+/// regression back to `opts.headers` would show two header values, not one.
+///
+/// Mutation check: reverted `fetch_text`'s `user-agent` line back to the
+/// unconditional `request.header("user-agent", DEFAULT_UA)` (dropping the
+/// `opts.user_agent` branch) — RAN, went red (`values.len()` became 1 with
+/// the WRONG value: `DEFAULT_UA`, not the override — reqwest's client-default
+/// merge only backfills when the request sent NO value for the header, so an
+/// unconditional literal write, not an append, is what the un-fixed line
+/// actually did), restored.
+#[tokio::test]
+async fn test_fetch_text_user_agent_override_replaces_not_appends() {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock_server = MockServer::start().await;
+    let signal = tokio_util::sync::CancellationToken::new();
+
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&mock_server)
+        .await;
+
+    fetch_text(
+        &mock_server.uri(),
+        FetchOptions {
+            user_agent: Some("custom-agent/1.0".to_string()),
+            ..Default::default()
+        },
+        signal,
+    )
+    .await
+    .expect("the request must succeed");
+
+    let requests = mock_server.received_requests().await.expect(
+        "wiremock request recording must be on by default; if this fails, recording was \
+         disabled somewhere upstream of this test",
+    );
+    assert_eq!(requests.len(), 1);
+    let values: Vec<&str> = requests[0]
+        .headers
+        .get_all("user-agent")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+    assert_eq!(
+        values,
+        vec!["custom-agent/1.0"],
+        "exactly one user-agent value must reach the wire, and it must be the override — \
+         not the override alongside DEFAULT_UA, and not DEFAULT_UA alone"
+    );
 }
 
 /// fetch_text must abort the stream before fully buffering when the body exceeds


### PR DESCRIPTION
Acts on issue #1026, where the freehire maintainer disclosed that our PR #1008
"Known limits" section had found three defects in **their** published spec —
`openapi.yaml` documented 17 of ~35 real query parameters.

## The actual bug

`freehire.rs` took `_date_filter: Option<&str>` — underscore-prefixed, accepted
and thrown away, because the documented spec had no date parameter. It has one:
`posted_within_days`. Our date filter had nowhere to go and silently did
nothing.

## Verified against the live API, not taken on trust

Every claim in the issue was checked by hitting `/api/v1/agent/jobs/search`
directly and re-reading the live `openapi.yaml`:

| Claim | Result |
|---|---|
| `posted_within_days` exists | ✅ integer days, `minimum: 1`; `=1` cut 1,477,440 → 66,802 |
| `reality=fresh` exists | ✅ cut the catalogue to 662,112 (~45%) |
| `meta.ignored_params` shape | ✅ a `country=gb` typo returns **200** + the **full unfiltered set**, with `did_you_mean: "countries"`. A clean request omits the key entirely — not an empty array |
| `X-RateLimit-*` on success | ✅ `300/299/1` on the agent endpoint |

**Not** independently verified: the 600/300 req/min ceilings and the leaky-bucket
behaviour under sustained load. Load-testing someone else's production service to
confirm a courtesy disclosure would be rude. Taken on the maintainer's word —
which is why **no rate-limiter code was written**; `fetch_text`'s existing
`429`/`Retry-After` backoff already covers the requirement.

## A pre-existing latent bug found on the way

`fetch_text` wrote `user-agent: DEFAULT_UA` unconditionally and *then* applied
caller headers via `RequestBuilder::header`, which **appends rather than
replaces**. Any caller passing a `user-agent` would have sent **two header
lines**. Nothing did yet, so it had never fired.

Fixed properly with a `FetchOptions::user_agent` override — `None` leaves every
other board on the unchanged `DEFAULT_UA`, which matters because several boards
depend on looking like an ordinary browser. All ~15 `FetchOptions` construction
sites were checked for `..Default::default()` before adding the field.

## Two judgement calls

**`reality=fresh` is unconditional, with no setting.** Every other aggregator
quality lever here (`sort_by=date`, `dedupe_by_url`) is already always-on with no
user-facing knob; a bespoke toggle for one facet on one last-resort tier would be
the odd one out.

**`meta.ignored_params` is treated as an error, not a warning that still returns
data.** It reuses the existing silent-degradation boundary rather than inventing
a signalling path. This is the finding that worried me most: a mistyped filter
returns the whole catalogue and **looks exactly like a legitimate broad result**.
Silently presenting unfiltered results as filtered is the one outcome that is not
acceptable.

## Mutations executed

Five, each broken → run → confirmed red → restored → re-run green:
the `posted_within_days` floor, the identifying UA, the `fetch_text`
replace-not-append fix, the `ignored_params` guard, and `reality=fresh`.

## Out of scope

**`cities` is deliberately not added.** It is real, but geography is a single
**OR-group**: `countries=gb` → 89,211 while `countries=gb&cities=London` →
**89,617**. Adding a city to narrow a country makes results *grow*. That needs a
location-UI decision, not a parameter.

## Provenance note

These two commits were originally authored before today's history rewrite, lost
when I pruned unpushed local branches ahead of it, and recovered from the backup
bundle as patches replayed onto rewritten `main` — so the shas differ from the
originals. Re-verified after replay: 17 freehire tests, 41 http tests, clippy
clean with `-D warnings`.
