### PR TITLE
fix: make in-flight backend work survive navigation, and stop logs leaking paths

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -339,10 +339,22 @@ jobs:
           pnpm check:adr-citations
           echo "::endgroup::"
 
-      - name: ❌ Check for Failures
-        if: steps.eslint.outcome == 'failure' || steps.format.outcome == 'failure' || steps.gen_ipc.outcome == 'failure' || steps.gen_prompts.outcome == 'failure' || steps.landing_drift.outcome == 'failure' || steps.agent_system.outcome == 'failure' || steps.tech_radar.outcome == 'failure' || steps.toolchain_pin.outcome == 'failure' || steps.event_subscriptions.outcome == 'failure' || steps.adr_citations.outcome == 'failure'
+      # A bare `{e}` inside a log::{warn,error,info,debug}! call can leak an
+      # absolute path (rusqlite::Error::InvalidPath, a filesystem
+      # std::io::Error), a credential-bearing URL (reqwest::Error), or a
+      # host:port into the log — see scripts/check-log-error-leaks.mjs.
+      - name: 🔒 Check log error-message leaks
+        id: log_error_leaks
+        continue-on-error: true
         run: |
-          echo "::error file=package.json::Lint, format, IPC codegen, prompts codegen, landing-diagram, agent-system, tech-radar, toolchain-pin, event-subscription, or ADR-citation drift check failed. Run 'pnpm lint:fix', 'pnpm format', 'pnpm gen:ipc', 'pnpm gen:prompts', 'pnpm check:landing-drift', 'pnpm check:agent-system', 'pnpm check:tech-radar', 'pnpm check:toolchain-pin', 'pnpm check:event-subscriptions', and 'pnpm check:adr-citations' locally to fix."
+          echo "::group::Checking for path/URL/credential leaks in log:: error interpolation"
+          pnpm check:log-error-leaks
+          echo "::endgroup::"
+
+      - name: ❌ Check for Failures
+        if: steps.eslint.outcome == 'failure' || steps.format.outcome == 'failure' || steps.gen_ipc.outcome == 'failure' || steps.gen_prompts.outcome == 'failure' || steps.landing_drift.outcome == 'failure' || steps.agent_system.outcome == 'failure' || steps.tech_radar.outcome == 'failure' || steps.toolchain_pin.outcome == 'failure' || steps.event_subscriptions.outcome == 'failure' || steps.adr_citations.outcome == 'failure' || steps.log_error_leaks.outcome == 'failure'
+        run: |
+          echo "::error file=package.json::Lint, format, IPC codegen, prompts codegen, landing-diagram, agent-system, tech-radar, toolchain-pin, event-subscription, ADR-citation, or log-error-leak drift check failed. Run 'pnpm lint:fix', 'pnpm format', 'pnpm gen:ipc', 'pnpm gen:prompts', 'pnpm check:landing-drift', 'pnpm check:agent-system', 'pnpm check:tech-radar', 'pnpm check:toolchain-pin', 'pnpm check:event-subscriptions', 'pnpm check:adr-citations', and 'pnpm check:log-error-leaks' locally to fix."
           echo "::error::Please fix the issues above before merging."
           exit 1
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -289,6 +289,19 @@ jobs:
       - name: 🦀 cargo check (all targets)
         working-directory: apps/desktop/src-tauri
         run: cargo check --all-targets --locked
+      # This job is `check` only (see the comment above), so `std::fs::rename`
+      # over an EXISTING file (postings::InteractionStore::save's write-then-
+      # rename) was never actually EXECUTED on Windows — rename-over-existing
+      # has different underlying semantics per platform (MoveFileExW needs
+      # MOVEFILE_REPLACE_EXISTING; POSIX rename(2) replaces unconditionally),
+      # and this repo has a recorded history of platform-exclusive code
+      # compiling nowhere until release. One narrowly-targeted `cargo test`,
+      # not the whole suite — the point is this ONE rename call, not Windows
+      # test coverage generally, which would cost real runner minutes (billed
+      # at 2x) for no new signal on everything else already proven on Linux.
+      - name: 🪟 Atomic file-replace test (Windows rename-over-existing)
+        working-directory: apps/desktop/src-tauri
+        run: cargo test --lib postings::test::save_replaces_the_file_atomically_and_leaves_no_temp_file --locked
 
   # ── Rust test-quality (PR + manual; never on push-to-main) ───────────────────
   cargo-hack:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -310,6 +310,13 @@ node scripts/check-agent-system.mjs
 
 # ── Rust gate (CI `rust` filter) ───────────────────────────────────────────────
 if [ -n "$RUST" ]; then
+  # A bare `{e}` inside a log::{warn,error,info,debug}! call can leak an
+  # absolute path, a credential-bearing URL, or a host:port into the log —
+  # see scripts/check-log-error-leaks.mjs. Pure Node/text scan (no cargo), so
+  # it runs before the `cd` below.
+  echo "▶ Checking for path/URL/credential leaks in log:: error interpolation..."
+  node scripts/check-log-error-leaks.mjs
+
   cd apps/desktop/src-tauri
 
   echo "▶ Running cargo check..."

--- a/apps/desktop/src-tauri/src/applications/reminders.rs
+++ b/apps/desktop/src-tauri/src/applications/reminders.rs
@@ -17,6 +17,7 @@ use rusqlite::params;
 use super::{ApplicationStatus, ApplicationStore};
 use crate::db::{ts_from_db, ts_to_db};
 use crate::error::AppResult;
+use crate::observability::sanitize_reason;
 
 /// One Application's follow-up reminder state — the minimal projection
 /// [`crate::reminder_scheduler`] sweeps. Not a wire type: it is a query
@@ -67,7 +68,10 @@ impl ApplicationStore {
         ) {
             Ok(stmt) => stmt,
             Err(e) => {
-                log::warn!("[applications] follow-up query failed to prepare: {e}");
+                log::warn!(
+                    "[applications] follow-up query failed to prepare: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 return Vec::new();
             }
         };
@@ -85,12 +89,20 @@ impl ApplicationStore {
         match rows {
             Ok(rows) => rows
                 .filter_map(|r| {
-                    r.inspect_err(|e| log::warn!("[applications] skipped a follow-up row: {e}"))
-                        .ok()
+                    r.inspect_err(|e| {
+                        log::warn!(
+                            "[applications] skipped a follow-up row: {}",
+                            sanitize_reason(&e.to_string())
+                        )
+                    })
+                    .ok()
                 })
                 .collect(),
             Err(e) => {
-                log::warn!("[applications] follow-up query failed: {e}");
+                log::warn!(
+                    "[applications] follow-up query failed: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 Vec::new()
             }
         }

--- a/apps/desktop/src-tauri/src/autopilot/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot/mod.rs
@@ -82,6 +82,7 @@ where
 
 use crate::db::now_ms;
 use crate::error::AppResult;
+use crate::observability::sanitize_reason;
 
 // ── Data model ────────────────────────────────────────────────────────────────
 
@@ -779,7 +780,10 @@ impl AutopilotStore {
         // deliberately NOT a retry queue. Migrations that need to *observe* a
         // successful persist still call `write_to_disk` directly.
         if let Err(e) = self.write_to_disk(&map) {
-            log::error!("[autopilot] failed to persist autopilots.json: {e}");
+            log::error!(
+                "[autopilot] failed to persist autopilots.json: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
         *self.cache.lock() = Some(map);
     }

--- a/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
@@ -419,7 +419,10 @@ async fn run_notes_loop(
                 }
             }
             // Best-effort: one job's failure never aborts the rest or the run.
-            Err(e) => log::warn!("[autopilot] AI note generation failed: {e}"),
+            Err(e) => log::warn!(
+                "[autopilot] AI note generation failed: {}",
+                sanitize_reason(&e.to_string())
+            ),
         }
     }
     log::info!(

--- a/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
+++ b/apps/desktop/src-tauri/src/autopilot_helpers/mod.rs
@@ -148,7 +148,11 @@ pub async fn autopilot_scrape(
                     );
                 }
                 if let Some(ref err) = s.error {
-                    log::warn!("[autopilot] board '{}' failed (error='{}')", s.board, err);
+                    log::warn!(
+                        "[autopilot] board '{}' failed (error='{}')",
+                        s.board,
+                        sanitize_reason(err)
+                    );
                 }
             }
             (postings, summaries)

--- a/apps/desktop/src-tauri/src/autopilot_helpers/tests.rs
+++ b/apps/desktop/src-tauri/src/autopilot_helpers/tests.rs
@@ -284,6 +284,32 @@ fn full_url_with_credential_query_still_wins_url_branch() {
 }
 
 #[test]
+fn board_prefixed_posting_id_embedding_a_url_is_redacted() {
+    // `documents::posting_vector_or_embed`'s failed-upsert log line redacts
+    // `job_id` with `redact_token` (not `sanitize_reason` — a posting id is
+    // one token, never whitespace-split prose). Most boards build an opaque
+    // `board:external-id` (e.g. `"greenhouse:12345"`, left untouched below),
+    // but `breezy`/`pinpoint`/`themuse` build theirs as
+    // `format!("{BOARD_ID}:{url}")`, embedding the posting's full URL — this
+    // pins that shape actually redacts, closing the CodeRabbit-flagged gap.
+    let url_embedding_id = "pinpoint:https://boards.example.com/jobs/42?ref=abc";
+    let out = redact_token(url_embedding_id);
+    assert!(
+        out.contains("<url-redacted>"),
+        "a board:url-shaped posting id must be redacted; got: {out}"
+    );
+    assert!(
+        !out.contains("boards.example.com"),
+        "host must not survive: {out}"
+    );
+
+    // The common case — an opaque board:external-id — must pass through
+    // unchanged, or the fix would cost every OTHER board's log
+    // debuggability to close a leak only these three boards have.
+    assert_eq!(redact_token("greenhouse:12345"), "greenhouse:12345");
+}
+
+#[test]
 fn credential_marker_does_not_over_redact_benign_words() {
     // The `marker=` shape (the `=`) is required: bare words like `keyword` or a
     // prose `token` (no `=`) must survive verbatim — no false positives.

--- a/apps/desktop/src-tauri/src/commands/ai/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai/mod.rs
@@ -9,6 +9,7 @@ use crate::error::AppResult;
 use crate::events::{emit_event, JobEvent, JOBS_EVENT};
 use crate::ipc_contracts::ai::AiEmbedRequest;
 use crate::jobs::{JobStatus, JobTracker};
+use crate::observability::sanitize_reason;
 use crate::postings::PostingsCache;
 
 use super::ai_provider::{
@@ -1106,7 +1107,11 @@ async fn run_embed_job(
                         {
                             Ok(()) => done += 1,
                             Err(e) => {
-                                log::warn!("reembed write failed for {}: {e}", doc.id);
+                                log::warn!(
+                                    "reembed write failed for {}: {}",
+                                    doc.id,
+                                    sanitize_reason(&e.to_string())
+                                );
                                 first_error.get_or_insert_with(|| e.to_string());
                                 failed += 1;
                             }

--- a/apps/desktop/src-tauri/src/commands/ai/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai/mod.rs
@@ -8,7 +8,7 @@ use crate::documents::{embedding_space_changed, DocumentStore, EmbeddingConfig};
 use crate::error::{AppError, AppResult};
 use crate::events::{emit_event, JobEvent, JOBS_EVENT};
 use crate::ipc_contracts::ai::AiEmbedRequest;
-use crate::jobs::{JobStatus, JobTracker};
+use crate::jobs::{JobStatus, JobTracker, KeyedExclusiveStart};
 use crate::observability::sanitize_reason;
 use crate::postings::PostingsCache;
 
@@ -609,9 +609,11 @@ pub async fn ai_pull_model(app: AppHandle, model: String) -> AppResult<Value> {
         "model",
         &model,
     ) {
-        Ok(Some(existing)) => return Ok(json!({ "jobId": existing })),
-        Ok(None) => {}
-        Err(active_model) => {
+        KeyedExclusiveStart::Joined(existing) => {
+            return Ok(json!({ "jobId": existing }));
+        }
+        KeyedExclusiveStart::Started => {}
+        KeyedExclusiveStart::Busy(active_model) => {
             return Err(AppError::Validation(format!(
                 "Already downloading \"{active_model}\" — wait for it to finish before starting another model."
             )));

--- a/apps/desktop/src-tauri/src/commands/ai/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai/mod.rs
@@ -5,7 +5,7 @@ use tauri::{AppHandle, Manager};
 use crate::credentials::CredentialStore;
 use crate::db::new_job_id;
 use crate::documents::{embedding_space_changed, DocumentStore, EmbeddingConfig};
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::events::{emit_event, JobEvent, JOBS_EVENT};
 use crate::ipc_contracts::ai::AiEmbedRequest;
 use crate::jobs::{JobStatus, JobTracker};
@@ -592,20 +592,30 @@ pub async fn ai_lookup_salary(
 }
 
 #[tauri::command]
-pub async fn ai_pull_model(app: AppHandle, model: String) -> Value {
+pub async fn ai_pull_model(app: AppHandle, model: String) -> AppResult<Value> {
     let job_id = new_job_id();
-    // Exclusive, not `job_start`: a returning caller (a remounted onboarding
-    // step showing an idle Download button) must re-attach to a pull already
-    // in flight, not start a second multi-GB download of the same model —
-    // same check-then-act reasoning as `claim_embed_job`, over the one job
-    // kind this command ever starts.
-    if let Some(existing) = crate::commands::jobs::job_start_exclusive(
+    // Exclusive per (kind, model), not kind alone: a returning caller (a
+    // remounted onboarding step showing an idle Download button) must
+    // re-attach to a pull of the SAME model already in flight — same
+    // check-then-act reasoning as `claim_embed_job`. A pull of a DIFFERENT
+    // model already running is refused rather than silently joined: joining
+    // would hand the caller progress for a model it never asked for while its
+    // own request never ran at all, and two concurrent multi-GB downloads
+    // would compete for the same bandwidth and disk anyway.
+    match crate::commands::jobs::job_start_exclusive_keyed(
         &app,
         &job_id,
         "ai.pull_model",
-        &["ai.pull_model"],
+        "model",
+        &model,
     ) {
-        return json!({ "jobId": existing });
+        Ok(Some(existing)) => return Ok(json!({ "jobId": existing })),
+        Ok(None) => {}
+        Err(active_model) => {
+            return Err(AppError::Validation(format!(
+                "Already downloading \"{active_model}\" — wait for it to finish before starting another model."
+            )));
+        }
     }
 
     let job_id_clone = job_id.clone();
@@ -626,7 +636,7 @@ pub async fn ai_pull_model(app: AppHandle, model: String) -> Value {
         }
     });
 
-    json!({ "jobId": job_id })
+    Ok(json!({ "jobId": job_id }))
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/ai/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai/mod.rs
@@ -593,7 +593,19 @@ pub async fn ai_lookup_salary(
 #[tauri::command]
 pub async fn ai_pull_model(app: AppHandle, model: String) -> Value {
     let job_id = new_job_id();
-    crate::commands::jobs::job_start(&app, &job_id, "ai.pull_model");
+    // Exclusive, not `job_start`: a returning caller (a remounted onboarding
+    // step showing an idle Download button) must re-attach to a pull already
+    // in flight, not start a second multi-GB download of the same model —
+    // same check-then-act reasoning as `claim_embed_job`, over the one job
+    // kind this command ever starts.
+    if let Some(existing) = crate::commands::jobs::job_start_exclusive(
+        &app,
+        &job_id,
+        "ai.pull_model",
+        &["ai.pull_model"],
+    ) {
+        return json!({ "jobId": existing });
+    }
 
     let job_id_clone = job_id.clone();
     let app_clone = app.clone();

--- a/apps/desktop/src-tauri/src/commands/ai_generations.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_generations.rs
@@ -3,6 +3,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::ai_generations::sanitize_quality_report;
 use crate::ipc_contracts::ai::{AiGenerationSaveRequest, AiGenerationUpdateRequest};
+use crate::observability::sanitize_reason;
 
 #[tauri::command]
 pub async fn ai_generations_list(app: AppHandle) -> Value {
@@ -101,7 +102,10 @@ pub async fn ai_generations_save(app: AppHandle, req: AiGenerationSaveRequest) -
             // Non-fatal: a failed Application upsert must not lose the generation the
             // user just produced. The generation save below is the user-visible action;
             // the aggregate (and the FK, via boot-time backfill) can be re-derived.
-            Err(e) => log::warn!("[ai_generations] application upsert failed (non-fatal): {e}"),
+            Err(e) => log::warn!(
+                "[ai_generations] application upsert failed (non-fatal): {}",
+                sanitize_reason(&e.to_string())
+            ),
         }
     }
 

--- a/apps/desktop/src-tauri/src/commands/applications.rs
+++ b/apps/desktop/src-tauri/src/commands/applications.rs
@@ -16,7 +16,7 @@ use crate::applications::{
     ApplicationMeta, ApplicationStatus, ApplicationStore, MAX_JOB_DESCRIPTION_BYTES,
 };
 use crate::error::{AppError, AppResult};
-use crate::observability::Span;
+use crate::observability::{sanitize_reason, Span};
 
 // Generated from the Zod schemas in packages/shared by `pnpm gen:ipc`.
 pub use crate::ipc_contracts::applications::{ApplicationTrackRequest, ApplicationUpdateRequest};
@@ -345,13 +345,19 @@ pub async fn applications_delete(app: AppHandle, id: String, keep_documents: boo
     if !keep_documents {
         if let Some(gens) = app.try_state::<crate::ai_generations::AiGenerationStore>() {
             if let Err(e) = gens.remove_for_application(&id) {
-                log::warn!("[applications] failed to delete child generations (non-fatal): {e}");
+                log::warn!(
+                    "[applications] failed to delete child generations (non-fatal): {}",
+                    sanitize_reason(&e.to_string())
+                );
             }
         }
     } else if let Some(gens) = app.try_state::<crate::ai_generations::AiGenerationStore>() {
         // Keep documents: detach them so they survive as orphaned generations.
         if let Err(e) = gens.detach_application(&id) {
-            log::warn!("[applications] failed to detach child generations (non-fatal): {e}");
+            log::warn!(
+                "[applications] failed to detach child generations (non-fatal): {}",
+                sanitize_reason(&e.to_string())
+            );
         }
     }
 

--- a/apps/desktop/src-tauri/src/commands/autopilot.rs
+++ b/apps/desktop/src-tauri/src/commands/autopilot.rs
@@ -11,6 +11,7 @@ use crate::autopilot_helpers::autopilot_scrape;
 // pick) — shared with the manual scrape path since trust-fix #2.
 use crate::commands::geocoding::derive_country_code;
 use crate::db::{new_job_id, now_ms};
+use crate::observability::sanitize_reason;
 use crate::scraping::{JobPosting, ScraperEngine};
 use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
@@ -199,10 +200,16 @@ fn drop_orphaned_resume_cache(
     }
     let id = crate::commands::match_resume::autopilot_resume_id(text);
     if let Err(e) = docs.delete_posting_vector(&id) {
-        log::warn!("[autopilot] could not drop the résumé snapshot vector: {e}");
+        log::warn!(
+            "[autopilot] could not drop the résumé snapshot vector: {}",
+            sanitize_reason(&e.to_string())
+        );
     }
     if let Err(e) = docs.delete_match_scores_for_resume(&id) {
-        log::warn!("[autopilot] could not drop the résumé's cached match scores: {e}");
+        log::warn!(
+            "[autopilot] could not drop the résumé's cached match scores: {}",
+            sanitize_reason(&e.to_string())
+        );
     }
 }
 
@@ -576,7 +583,12 @@ pub async fn autopilot_run(app: AppHandle, autopilot_id: String) -> Value {
     // a bad/missing provider logs the reason a user needs to debug "notes never run".
     let completer = if autopilot.assistant {
         crate::pipeline::Completer::from_active(&app)
-            .inspect_err(|e| log::info!("[autopilot] AI notes skipped: no usable provider ({e})"))
+            .inspect_err(|e| {
+                log::info!(
+                    "[autopilot] AI notes skipped: no usable provider ({})",
+                    sanitize_reason(&e.to_string())
+                )
+            })
             .ok()
     } else {
         None

--- a/apps/desktop/src-tauri/src/commands/email_watch.rs
+++ b/apps/desktop/src-tauri/src/commands/email_watch.rs
@@ -24,6 +24,7 @@ use crate::db::now_ms;
 use crate::email_watch::imap_client::{validate_connection, DEFAULT_IMAP_HOST, DEFAULT_IMAP_PORT};
 use crate::email_watch::{EmailWatchStatus, EmailWatchStore, CREDENTIAL_SLOT};
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 /// Resolve the managed `EmailWatchStore`, or a typed error when it isn't
 /// managed (the boot-time `EmailWatchStore::open` failed — a non-fatal,
@@ -68,7 +69,10 @@ async fn validate_connection_blocking(
     {
         Ok(result) => result,
         Err(e) => {
-            log::warn!("[email_watch] connection check task against {host_for_log} panicked: {e}");
+            log::warn!(
+                "[email_watch] connection check task against {host_for_log} panicked: {}",
+                sanitize_reason(&e.to_string())
+            );
             Err(AppError::Message(
                 "connection check failed unexpectedly".to_string(),
             ))

--- a/apps/desktop/src-tauri/src/commands/jobs.rs
+++ b/apps/desktop/src-tauri/src/commands/jobs.rs
@@ -1,5 +1,5 @@
 use crate::events::{emit_event, JobEvent, JOBS_EVENT};
-use crate::jobs::JobTracker;
+use crate::jobs::{JobTracker, KeyedExclusiveStart};
 use crate::observability::sanitize_reason;
 use crate::scraping::ScraperEngine;
 use parking_lot::Mutex;
@@ -61,23 +61,20 @@ pub fn job_start_exclusive(
 /// caller-supplied `key` (e.g. the model being pulled) rather than `kind`
 /// alone — see [`JobTracker::start_exclusive_keyed`] for why kind-only
 /// exclusivity is wrong for a command whose kind never varies but whose
-/// target (the model) does.
-///
-/// `Ok(None)`: started, event emitted. `Ok(Some(id))`: a job of `kind` for
-/// the SAME key is already active — join it. `Err(other_key)`: a job of
-/// `kind` for a DIFFERENT key is active — the caller decides how to refuse.
+/// target (the model) does, and for what each [`KeyedExclusiveStart`]
+/// variant means to the caller.
 pub fn job_start_exclusive_keyed(
     app: &AppHandle,
     id: &str,
     kind: &str,
     key_field: &str,
     key: &str,
-) -> Result<Option<String>, String> {
+) -> KeyedExclusiveStart {
     let outcome = app
         .state::<Mutex<JobTracker>>()
         .lock()
         .start_exclusive_keyed(id, kind, key_field, key);
-    if matches!(outcome, Ok(None)) {
+    if matches!(outcome, KeyedExclusiveStart::Started) {
         emit_job_event(app, "job.started", id, None);
     }
     outcome

--- a/apps/desktop/src-tauri/src/commands/jobs.rs
+++ b/apps/desktop/src-tauri/src/commands/jobs.rs
@@ -1,5 +1,6 @@
 use crate::events::{emit_event, JobEvent, JOBS_EVENT};
 use crate::jobs::JobTracker;
+use crate::observability::sanitize_reason;
 use crate::scraping::ScraperEngine;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
@@ -93,12 +94,48 @@ pub fn job_complete(app: &AppHandle, id: &str, result: Value) {
     emit_job_event(app, "job.completed", id, Some(result));
 }
 
+/// The AppHandle-free half of [`job_fail`]/[`job_fail_with_data`]: sanitize
+/// the tracked error message, write it into the tracker, and hand back the
+/// `job.failed` event payload the caller should still emit.
+///
+/// Split out so the sanitize step is testable without a `tauri::test` mock
+/// app — this crate has none (see `documents::Embedder`'s doc comment for
+/// why AppHandle-taking code goes through a seam like this one instead).
+///
+/// `error` is sanitized here, once, at the single mutator boundary — it
+/// reaches the renderer through THREE surfaces (`jobs_get`, `jobs_list`, and
+/// the `job.failed` event), and callers pass raw `e.to_string()` from
+/// `reqwest`/`rusqlite`/keyring errors that can carry URLs, filesystem paths,
+/// or hostnames. Sanitizing here catches every existing AND future caller
+/// instead of relying on each one to remember. [`sanitize_reason`] is
+/// conservative about plain English prose (see its own doc) so an
+/// already-friendly message like
+/// [`crate::commands::resume_pipeline::hooks::timeout_message`] passes
+/// through unchanged.
+///
+/// `event_data` overrides what rides as the event payload (see
+/// [`job_fail_with_data`]'s doc for why) — `None` reuses the sanitized error
+/// string, mirroring the plain [`job_fail`] shape.
+fn fail_in_tracker(
+    tracker: &mut JobTracker,
+    id: &str,
+    error: String,
+    event_data: Option<Value>,
+) -> Value {
+    let error = sanitize_reason(&error);
+    tracker.fail(id, error.clone());
+    event_data.unwrap_or(Value::String(error))
+}
+
 /// Mark a job failed and emit `job.failed` (the error string rides as `data`).
 pub fn job_fail(app: &AppHandle, id: &str, error: String) {
-    app.state::<Mutex<JobTracker>>()
-        .lock()
-        .fail(id, error.clone());
-    emit_job_event(app, "job.failed", id, Some(Value::String(error)));
+    let data = fail_in_tracker(
+        &mut app.state::<Mutex<JobTracker>>().lock(),
+        id,
+        error,
+        None,
+    );
+    emit_job_event(app, "job.failed", id, Some(data));
 }
 
 /// Like [`job_fail`], for a caller that can say more than the message text.
@@ -112,9 +149,15 @@ pub fn job_fail(app: &AppHandle, id: &str, error: String) {
 /// [`crate::commands::resume_pipeline::hooks::timeout_failure_data`]) can
 /// render something better than the raw string — a localized message built
 /// from structured fields, rather than an internal stage key spliced into
-/// English prose.
+/// English prose. `data` is a structured payload with its own meaning and is
+/// NOT sanitized here — only `message`, the free-text half, is.
 pub fn job_fail_with_data(app: &AppHandle, id: &str, message: String, data: Value) {
-    app.state::<Mutex<JobTracker>>().lock().fail(id, message);
+    let data = fail_in_tracker(
+        &mut app.state::<Mutex<JobTracker>>().lock(),
+        id,
+        message,
+        Some(data),
+    );
     emit_job_event(app, "job.failed", id, Some(data));
 }
 
@@ -159,5 +202,91 @@ pub fn jobs_retry(app: AppHandle, job_id: String) -> Value {
             "note": "renderer should re-dispatch this kind with the original payload",
         }),
         None => json!({ "success": false, "reason": "job id not found" }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A `reqwest`/keyring-shaped failure: a full URL carrying a query-string
+    // credential, plus a Windows path an unwound filesystem error tacked on.
+    // This is the PR #1036 leak class — sanitized in every `log::` call site,
+    // but `job_fail` reached the renderer raw through `jobs_get`/`jobs_list`
+    // and the `job.failed` event, a channel that sweep never touched.
+    const RAW_ERROR: &str = r"error sending request to https://api.example.com/v1?api_key=SECRET123: connection reset while reading C:\Users\alice\AppData\Local\ajh\cache";
+
+    #[test]
+    fn job_fail_sanitizes_before_it_reaches_the_tracker_or_the_event() {
+        let mut tracker = JobTracker::default();
+        tracker.start("job-1", "test.kind");
+
+        let event_data = fail_in_tracker(&mut tracker, "job-1", RAW_ERROR.to_string(), None);
+
+        // The tracker's own `error` field — what `jobs_get`/`jobs_list` return.
+        let tracked = tracker.get("job-1").and_then(|r| r.error.as_deref());
+        for leaked in ["SECRET123", "api.example.com", "alice"] {
+            assert!(
+                !tracked.unwrap_or_default().contains(leaked),
+                "tracker.error must not carry {leaked:?}: {tracked:?}"
+            );
+        }
+
+        // The `job.failed` event payload.
+        let emitted = event_data.as_str().unwrap_or_default();
+        for leaked in ["SECRET123", "api.example.com", "alice"] {
+            assert!(
+                !emitted.contains(leaked),
+                "job.failed data must not carry {leaked:?}: {emitted}"
+            );
+        }
+
+        // MUTATION GUARD: a no-op passthrough (`error` written/emitted raw)
+        // would leave both destinations byte-identical to `RAW_ERROR` — this
+        // only passes when sanitization actually ran.
+        assert_ne!(tracked, Some(RAW_ERROR));
+        assert_ne!(emitted, RAW_ERROR);
+    }
+
+    #[test]
+    fn job_fail_with_data_sanitizes_the_message_but_leaves_the_structured_data_alone() {
+        let mut tracker = JobTracker::default();
+        tracker.start("job-2", "test.kind");
+
+        let structured = json!({ "kind": "timeout", "stage": "resume", "seconds": 45 });
+        let event_data = fail_in_tracker(
+            &mut tracker,
+            "job-2",
+            RAW_ERROR.to_string(),
+            Some(structured.clone()),
+        );
+
+        let tracked = tracker.get("job-2").and_then(|r| r.error.as_deref());
+        assert!(
+            !tracked.unwrap_or_default().contains("SECRET123"),
+            "tracker.error must not carry the credential: {tracked:?}"
+        );
+        // `data` rides as the event payload UNTOUCHED — it's a structured
+        // payload with its own meaning, not free text.
+        assert_eq!(event_data, structured);
+    }
+
+    #[test]
+    fn job_fail_leaves_an_already_friendly_message_unchanged() {
+        // `resume_pipeline::hooks::timeout_message`'s shape: plain English
+        // prose with no path/URL/credential tokens. Sanitizing at the
+        // `job_fail` boundary must not mangle it.
+        let mut tracker = JobTracker::default();
+        tracker.start("job-3", "test.kind");
+        let msg = "The \"resume\" step didn't get a response within 45s. Try a faster model or \
+                    a lower effort level.";
+
+        let event_data = fail_in_tracker(&mut tracker, "job-3", msg.to_string(), None);
+
+        assert_eq!(
+            tracker.get("job-3").and_then(|r| r.error.as_deref()),
+            Some(msg)
+        );
+        assert_eq!(event_data.as_str(), Some(msg));
     }
 }

--- a/apps/desktop/src-tauri/src/commands/jobs.rs
+++ b/apps/desktop/src-tauri/src/commands/jobs.rs
@@ -57,6 +57,32 @@ pub fn job_start_exclusive(
     existing
 }
 
+/// Like [`job_start_exclusive`], but the exclusion group is `kind` PLUS a
+/// caller-supplied `key` (e.g. the model being pulled) rather than `kind`
+/// alone — see [`JobTracker::start_exclusive_keyed`] for why kind-only
+/// exclusivity is wrong for a command whose kind never varies but whose
+/// target (the model) does.
+///
+/// `Ok(None)`: started, event emitted. `Ok(Some(id))`: a job of `kind` for
+/// the SAME key is already active — join it. `Err(other_key)`: a job of
+/// `kind` for a DIFFERENT key is active — the caller decides how to refuse.
+pub fn job_start_exclusive_keyed(
+    app: &AppHandle,
+    id: &str,
+    kind: &str,
+    key_field: &str,
+    key: &str,
+) -> Result<Option<String>, String> {
+    let outcome = app
+        .state::<Mutex<JobTracker>>()
+        .lock()
+        .start_exclusive_keyed(id, kind, key_field, key);
+    if matches!(outcome, Ok(None)) {
+        emit_job_event(app, "job.started", id, None);
+    }
+    outcome
+}
+
 /// Park a job behind the concurrency limiter: status → `queued`, emitting
 /// `job.queued` with how many callers are ahead of it.
 ///

--- a/apps/desktop/src-tauri/src/commands/notifications.rs
+++ b/apps/desktop/src-tauri/src/commands/notifications.rs
@@ -26,6 +26,7 @@ use crate::events::{emit_event, NOTIFICATIONS_CHANGED, NOTIFICATIONS_OPEN, NOTIF
 use crate::notifications::{
     AppNotification, NewNotification, NotificationOpen, NotificationRoute, NotificationStore,
 };
+use crate::observability::sanitize_reason;
 
 fn store(app: &AppHandle) -> tauri::State<'_, NotificationStore> {
     app.state::<NotificationStore>()
@@ -134,7 +135,10 @@ fn show_clickable_banner(
                 Ok(())
             });
         if let Err(e) = toast.show() {
-            log::warn!("[notifications] windows toast failed: {e}");
+            log::warn!(
+                "[notifications] windows toast failed: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
     }
 
@@ -171,7 +175,10 @@ fn show_clickable_banner(
                          showing this one without a click handler"
                     ),
                 },
-                Err(e) => log::warn!("[notifications] os banner failed: {e}"),
+                Err(e) => log::warn!(
+                    "[notifications] os banner failed: {}",
+                    sanitize_reason(&e.to_string())
+                ),
             }
         });
     }

--- a/apps/desktop/src-tauri/src/commands/privacy.rs
+++ b/apps/desktop/src-tauri/src/commands/privacy.rs
@@ -19,6 +19,7 @@ use crate::email_watch::EmailWatchStore;
 use crate::job_preferences::JobPreferencesStore;
 use crate::jobs::JobTracker;
 use crate::notifications::NotificationStore;
+use crate::observability::sanitize_reason;
 use crate::pipeline::cache::KvCache;
 use crate::pipeline::runs::PipelineRunStore;
 use crate::postings::{InteractionStore, PostingsCache};
@@ -307,7 +308,10 @@ pub fn privacy_reset_app(app: AppHandle) -> Value {
     let data_dir = match app.path().app_data_dir() {
         Ok(dir) => dir,
         Err(e) => {
-            log::error!("[privacy] factory reset aborted: could not resolve app data dir: {e}");
+            log::error!(
+                "[privacy] factory reset aborted: could not resolve app data dir: {}",
+                sanitize_reason(&e.to_string())
+            );
             return json!({ "success": false, "error": "could not resolve app data directory" });
         }
     };
@@ -368,7 +372,8 @@ pub fn privacy_reset_app(app: AppHandle) -> Value {
     if browser_state.exists() {
         if let Err(e) = std::fs::remove_dir_all(&browser_state) {
             log::warn!(
-                "[privacy] factory reset could not remove browser-state (may be locked): {e}"
+                "[privacy] factory reset could not remove browser-state (may be locked): {}",
+                sanitize_reason(&e.to_string())
             );
             browser_state_cleared = false;
         }

--- a/apps/desktop/src-tauri/src/commands/resume_pipeline/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/resume_pipeline/mod.rs
@@ -736,11 +736,13 @@ fn persist_document(
     match store.save_application(record) {
         Ok(_) => Some(wrapper),
         Err(e) => {
-            // Non-fatal, and logged rather than swallowed: the run itself
-            // succeeded and its text is already in the renderer's hands via the
-            // stream, so failing the run here would discard a good document
-            // because a merge-upsert lost a race.
-            log::warn!("[pipeline] could not persist the generated résumé (non-fatal): {e}");
+            // Non-fatal, and logged rather than swallowed: the run's text is
+            // already in the renderer's hands via the stream, so failing here
+            // would discard a good document because a merge-upsert lost a race.
+            log::warn!(
+                "[pipeline] could not persist the generated résumé (non-fatal): {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
             None
         }
     }

--- a/apps/desktop/src-tauri/src/crash_reporting/mod.rs
+++ b/apps/desktop/src-tauri/src/crash_reporting/mod.rs
@@ -67,6 +67,7 @@ use std::sync::OnceLock;
 use serde::{Deserialize, Serialize};
 
 use crate::commands::support::redact_lines;
+use crate::observability::sanitize_reason;
 
 mod transport;
 
@@ -192,7 +193,10 @@ fn save_to(data_dir: &Path, settings: Settings) {
         std::fs::write(data_dir.join(FILE_NAME), json)
     };
     if let Err(e) = write() {
-        log::warn!("[crash-reporting] could not persist consent state: {e}");
+        log::warn!(
+            "[crash-reporting] could not persist consent state: {}",
+            sanitize_reason(&e.to_string())
+        );
     }
 }
 

--- a/apps/desktop/src-tauri/src/credentials/mod.rs
+++ b/apps/desktop/src-tauri/src/credentials/mod.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::db::now_ms;
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 pub(crate) const SERVICE: &str = "com.ajh.tauri";
 
@@ -76,7 +77,10 @@ pub struct CredentialStore {
 impl CredentialStore {
     pub fn new(data_dir: &PathBuf) -> Self {
         if let Err(e) = std::fs::create_dir_all(data_dir) {
-            log::warn!("[credentials] failed to create data dir (metadata writes may fail): {e}");
+            log::warn!(
+                "[credentials] failed to create data dir (metadata writes may fail): {}",
+                sanitize_reason(&e.to_string())
+            );
         }
         Self {
             meta_file: data_dir.join("credential-meta.json"),
@@ -185,7 +189,7 @@ impl CredentialStore {
             // Report empty to this read-only caller, but do NOT cache it — a later
             // `set` must not mistake an unreadable index for an empty one.
             Err(e) => {
-                log::error!("[credentials] {e}");
+                log::error!("[credentials] {}", sanitize_reason(&e.to_string()));
                 HashMap::new()
             }
         }

--- a/apps/desktop/src-tauri/src/dedup/mod.rs
+++ b/apps/desktop/src-tauri/src/dedup/mod.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::data_store::DataStore;
 use crate::db::{now_ms, run_migrations, ts_from_db, ts_to_db, Migration};
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 /// One persisted "not a duplicate" verdict. `key_a < key_b` by construction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,8 +113,9 @@ impl DedupStore {
             Ok(stmt) => stmt,
             Err(e) => {
                 log::warn!(
-                    "[dedup] failed to prepare tombstone read ({e}); degrading to no \
-                     splits — previously-split clusters may re-merge this ingest"
+                    "[dedup] failed to prepare tombstone read ({}); degrading to no \
+                     splits — previously-split clusters may re-merge this ingest",
+                    sanitize_reason(&e.to_string())
                 );
                 return HashSet::new();
             }
@@ -124,8 +126,9 @@ impl DedupStore {
             Ok(rows) => rows,
             Err(e) => {
                 log::warn!(
-                    "[dedup] failed to query tombstones ({e}); degrading to no splits \
-                     — previously-split clusters may re-merge this ingest"
+                    "[dedup] failed to query tombstones ({}); degrading to no splits \
+                     — previously-split clusters may re-merge this ingest",
+                    sanitize_reason(&e.to_string())
                 );
                 return HashSet::new();
             }

--- a/apps/desktop/src-tauri/src/discovered/harvest.rs
+++ b/apps/desktop/src-tauri/src/discovered/harvest.rs
@@ -7,6 +7,7 @@
 //! harness.
 
 use super::DiscoveredCompanyStore;
+use crate::observability::sanitize_reason;
 
 /// Passively harvest ATS company slugs from a batch of `(url, company)` posting
 /// pairs (parse-only, zero network) into `store` under `source`. Each posting's
@@ -32,7 +33,10 @@ where
         return;
     }
     if let Err(e) = store.upsert_batch(&refs) {
-        log::warn!("[discovered] harvest upsert failed ({e}); slugs not recorded this ingest");
+        log::warn!(
+            "[discovered] harvest upsert failed ({}); slugs not recorded this ingest",
+            sanitize_reason(&e.to_string())
+        );
     }
 }
 

--- a/apps/desktop/src-tauri/src/discovered/mod.rs
+++ b/apps/desktop/src-tauri/src/discovered/mod.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::data_store::DataStore;
 use crate::db::{now_ms, run_migrations, ts_from_db, ts_to_db, Migration};
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 mod harvest;
 pub use harvest::harvest_ats_refs;
@@ -171,7 +172,10 @@ impl DiscoveredCompanyStore {
         ) {
             Ok(s) => s,
             Err(e) => {
-                log::warn!("[discovered] search prepare failed ({e}); returning empty");
+                log::warn!(
+                    "[discovered] search prepare failed ({}); returning empty",
+                    sanitize_reason(&e.to_string())
+                );
                 return Vec::new();
             }
         };
@@ -179,7 +183,10 @@ impl DiscoveredCompanyStore {
         match rows {
             Ok(rows) => rows.filter_map(Result::ok).collect(),
             Err(e) => {
-                log::warn!("[discovered] search query failed ({e}); returning empty");
+                log::warn!(
+                    "[discovered] search query failed ({}); returning empty",
+                    sanitize_reason(&e.to_string())
+                );
                 Vec::new()
             }
         }
@@ -232,7 +239,10 @@ impl DiscoveredCompanyStore {
         ) {
             Ok(s) => s,
             Err(e) => {
-                log::warn!("[discovered] watched prepare failed ({e}); returning empty");
+                log::warn!(
+                    "[discovered] watched prepare failed ({}); returning empty",
+                    sanitize_reason(&e.to_string())
+                );
                 return Vec::new();
             }
         };
@@ -242,7 +252,10 @@ impl DiscoveredCompanyStore {
         match rows {
             Ok(rows) => rows.filter_map(Result::ok).collect(),
             Err(e) => {
-                log::warn!("[discovered] watched query failed ({e}); returning empty");
+                log::warn!(
+                    "[discovered] watched query failed ({}); returning empty",
+                    sanitize_reason(&e.to_string())
+                );
                 Vec::new()
             }
         }
@@ -262,7 +275,10 @@ impl DiscoveredCompanyStore {
         ) {
             Ok(s) => s,
             Err(e) => {
-                log::warn!("[discovered] watched_companies prepare failed ({e}); returning empty");
+                log::warn!(
+                    "[discovered] watched_companies prepare failed ({}); returning empty",
+                    sanitize_reason(&e.to_string())
+                );
                 return Vec::new();
             }
         };
@@ -270,7 +286,10 @@ impl DiscoveredCompanyStore {
         match rows {
             Ok(rows) => rows.filter_map(Result::ok).collect(),
             Err(e) => {
-                log::warn!("[discovered] watched_companies query failed ({e}); returning empty");
+                log::warn!(
+                    "[discovered] watched_companies query failed ({}); returning empty",
+                    sanitize_reason(&e.to_string())
+                );
                 Vec::new()
             }
         }

--- a/apps/desktop/src-tauri/src/documents/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/mod.rs
@@ -1202,10 +1202,18 @@ pub(crate) async fn posting_vector_or_embed<E: Embedder + ?Sized>(
     // must not fail the score — it only means the NEXT call re-embeds (and
     // re-charges) this posting. Logged rather than dropped, because a
     // persistently failing write is invisible otherwise and reads downstream as
-    // "the cache never hits". Content-free: the id and the error, never the text.
+    // "the cache never hits". Never the text — but `job_id` is NOT always the
+    // opaque `board:external-id` shape it looks like: `breezy`/`pinpoint`/
+    // `themuse` build their [`crate::scraping::JobPosting::id`] as
+    // `format!("{BOARD_ID}:{url}")`, embedding the posting's full URL. Redact
+    // it with the same shape-based classifier the error already goes through,
+    // rather than hashing — that would cost every OTHER board's (the
+    // majority) debuggable `greenhouse:12345`-style id to close a leak only
+    // these three have.
     if let Err(e) = store.upsert_posting_vector(job_id, &hash, &v) {
         log::warn!(
-            "[documents] posting vector not cached for {job_id}: {}",
+            "[documents] posting vector not cached for {}: {}",
+            crate::observability::redact_token(job_id),
             sanitize_reason(&e.to_string())
         );
     }

--- a/apps/desktop/src-tauri/src/documents/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/mod.rs
@@ -20,6 +20,7 @@ use crate::commands::ai_provider::{
 use crate::data_store::DataStore;
 use crate::db::{column_exists, now_ms, run_migrations, ts_from_db, ts_to_db, Migration};
 use crate::error::AppResult;
+use crate::observability::sanitize_reason;
 
 use sql::{
     get_match_score_with_conn, get_vector_with_conn, prune_due, prune_table_locked,
@@ -1203,7 +1204,10 @@ pub(crate) async fn posting_vector_or_embed<E: Embedder + ?Sized>(
     // persistently failing write is invisible otherwise and reads downstream as
     // "the cache never hits". Content-free: the id and the error, never the text.
     if let Err(e) = store.upsert_posting_vector(job_id, &hash, &v) {
-        log::warn!("[documents] posting vector not cached for {job_id}: {e}");
+        log::warn!(
+            "[documents] posting vector not cached for {job_id}: {}",
+            sanitize_reason(&e.to_string())
+        );
     }
     Some(v)
 }
@@ -1345,7 +1349,8 @@ impl DataStore for DocumentStore {
                     // Skip the one vector (it re-embeds on demand) and keep going.
                     if let Err(e) = self.upsert_vector(&record.id, vector) {
                         log::warn!(
-                            "[documents] import: skipping the embedding of one restored document ({e})"
+                            "[documents] import: skipping the embedding of one restored document ({})",
+                            sanitize_reason(&e.to_string())
                         );
                     }
                 }

--- a/apps/desktop/src-tauri/src/email_watch/imap_client.rs
+++ b/apps/desktop/src-tauri/src/email_watch/imap_client.rs
@@ -42,6 +42,7 @@ use std::time::Duration;
 use native_tls::TlsConnector;
 
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 /// Default IMAP host/port — v1's Settings UI is Gmail-branded, but the value
 /// is DATA (stored in `EmailWatchStore`'s `account` row), not hardcoded into
@@ -449,7 +450,10 @@ fn connect_with_timeout(
         let tls = match connector.connect(host, tcp) {
             Ok(tls) => tls,
             Err(e) => {
-                log::warn!("[email_watch] TLS handshake with {host}:{port} failed: {e}");
+                log::warn!(
+                    "[email_watch] TLS handshake with {host}:{port} failed: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 last_err = AppError::Network("could not connect to the mail server".to_string());
                 continue;
             }

--- a/apps/desktop/src-tauri/src/email_watch_scheduler.rs
+++ b/apps/desktop/src-tauri/src/email_watch_scheduler.rs
@@ -39,6 +39,7 @@ use crate::db::now_ms;
 use crate::email_watch::imap_client::{self, DEFAULT_IMAP_HOST, DEFAULT_IMAP_PORT};
 use crate::email_watch::{poller, EmailWatchStatus, EmailWatchStore, CREDENTIAL_SLOT};
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 /// Internal check cadence — how often the loop wakes up to ask "is a real
 /// IMAP check due yet". NOT the interval between real checks (that is
@@ -212,7 +213,10 @@ pub async fn run_check(app: &AppHandle) -> AppResult<EmailWatchStatus> {
 
     let outcome = run_check_inner(app, &store).await;
     if let Err(e) = store.record_check(now_ms()) {
-        log::warn!("[email_watch] failed to record the check timestamp: {e}");
+        log::warn!(
+            "[email_watch] failed to record the check timestamp: {}",
+            sanitize_reason(&e.to_string())
+        );
     }
     outcome?;
     Ok(store.status())

--- a/apps/desktop/src-tauri/src/extension_bridge/answers_save.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/answers_save.rs
@@ -199,7 +199,10 @@ pub(super) fn resolve_answers_save(
     let saved = store.merge_answers(&app.id, incoming).map_err(|e| {
         // Wire-error discipline: never let a raw store error (path/SQL detail)
         // reach `answers_result_reply` — log it, reply a fixed sentinel.
-        log::warn!("[extension_bridge] answers.save store error: {e}");
+        log::warn!(
+            "[extension_bridge] answers.save store error: {}",
+            crate::observability::sanitize_reason(&e.to_string())
+        );
         AppError::Storage("could not save these answers".to_string())
     })?;
 

--- a/apps/desktop/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/auth.rs
@@ -208,10 +208,11 @@ pub(super) fn log_handshake_failure(e: &tokio_tungstenite::tungstenite::Error) {
     use tokio_tungstenite::tungstenite::Error;
 
     let forbidden = matches!(e, Error::Http(r) if r.status() == StatusCode::FORBIDDEN);
+    let reason = crate::observability::sanitize_reason(&e.to_string());
     if forbidden {
-        log::debug!("[extension_bridge] handshake refused (forbidden origin): {e}");
+        log::debug!("[extension_bridge] handshake refused (forbidden origin): {reason}");
     } else {
-        log::warn!("[extension_bridge] handshake rejected/failed: {e}");
+        log::warn!("[extension_bridge] handshake rejected/failed: {reason}");
     }
 }
 

--- a/apps/desktop/src-tauri/src/extension_bridge/auth.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/auth.rs
@@ -177,21 +177,67 @@ pub(super) fn warn_rejected_origin_once(origin: &str) {
         Ok(g) => g,
         Err(poisoned) => poisoned.into_inner(),
     };
+    // Shape-constrain once, up front — every branch below logs this same
+    // value. `sanitize_reason` (credential-token redaction) is the wrong tool
+    // here: the origin is the ONE piece of diagnostic information a developer
+    // needs, verbatim, to add to `extensionDevOrigins`, so the value itself
+    // must survive; only its *shape* (length, control chars) is constrained.
+    let logged = sanitize_log_origin(origin);
     if seen.len() >= MAX_REMEMBERED && !seen.contains(origin) {
-        log::debug!("[extension_bridge] rejected handshake from origin: {origin:?} (cap reached)");
+        log::debug!("[extension_bridge] rejected handshake from origin: {logged:?} (cap reached)");
         return;
     }
     if seen.insert(origin.to_string()) {
         // First time only, and deliberately actionable: an unpaired extension is
         // otherwise indistinguishable from a desktop that simply isn't running.
         log::warn!(
-            "[extension_bridge] rejected handshake from origin: {origin:?} — not an allowed \
+            "[extension_bridge] rejected handshake from origin: {logged:?} — not an allowed \
              extension origin. A development build needs its origin in the \
              `extensionDevOrigins` config; a store build should already match. \
              Further rejections from this origin are logged at debug."
         );
     } else {
-        log::debug!("[extension_bridge] rejected handshake from origin: {origin:?}");
+        log::debug!("[extension_bridge] rejected handshake from origin: {logged:?}");
+    }
+}
+
+/// Ceiling on a logged origin's length, after control-character stripping. The
+/// `Origin` header is attacker-supplied and unbounded (HTTP puts no length
+/// cap on a header value beyond the server's own buffer size); every
+/// legitimate origin this bridge ever compares against
+/// (`chrome-extension://<32-char id>`, `moz-extension://<36-char uuid>`,
+/// `null`, the native-host sentinel) is well under this, so nothing genuine is
+/// ever truncated.
+const MAX_LOGGED_ORIGIN_LEN: usize = 128;
+
+/// Shape-constrain an attacker-supplied `Origin` before it enters a log line
+/// support bundles ship verbatim: strip control characters (newline, CR, tab,
+/// ESC/ANSI, NUL, …) so the origin cannot forge a second log line or an
+/// escape-sequence trick, then cap the length so it cannot flood the log.
+///
+/// `sanitize_reason` (this module's sibling in [`crate::observability`]) is
+/// deliberately NOT reused here: it redacts credential-*shaped* tokens, which
+/// would risk mangling a legitimate-looking origin the developer needs to
+/// read back exactly. Only the log-injection SHAPE is the concern for an
+/// origin, not its content, so a narrower, dedicated filter is the correct
+/// tool — see the review note this fixes.
+///
+/// Note: the current call site's `origin` already passed through
+/// `http::HeaderValue::to_str()` (visible-ASCII only; the underlying HTTP
+/// header parser also can never carry a raw CR/LF inside a header value —
+/// that byte pair is what terminates the header line), so a raw newline
+/// cannot reach here via that path today. This filter is kept anyway as a
+/// caller-independent safety net — cheap, and correct even if a future
+/// call site feeds it an origin from a different transport — while the
+/// length cap is the concern that IS live today: nothing bounds how long an
+/// `Origin` header itself can be.
+fn sanitize_log_origin(origin: &str) -> String {
+    let stripped: String = origin.chars().filter(|c| !c.is_control()).collect();
+    if stripped.chars().count() > MAX_LOGGED_ORIGIN_LEN {
+        let truncated: String = stripped.chars().take(MAX_LOGGED_ORIGIN_LEN).collect();
+        format!("{truncated}…")
+    } else {
+        stripped
     }
 }
 
@@ -377,5 +423,52 @@ mod tests {
             "https://boards.greenhouse.io/acme/jobs/1"
         ));
         assert!(is_safe_import_url("http://jobs.example.com/posting/42"));
+    }
+
+    // ── Rejected-origin log sanitization ───────────────────────────────────
+
+    #[test]
+    fn sanitize_log_origin_strips_control_chars_but_keeps_the_rest() {
+        // Newline/CR/ESC are exactly the shapes that forge a second log line
+        // (CR/LF) or an ANSI escape-sequence trick in a log file support
+        // bundles ship verbatim — this is what a hostile `Origin` header can
+        // never smuggle through.
+        let hostile = "chrome-extension://evil\nWARN fake line\r\x1b[31mred\x1b[0m\0end";
+        let cleaned = sanitize_log_origin(hostile);
+        assert!(
+            cleaned.chars().all(|c| !c.is_control()),
+            "control character survived: {cleaned:?}"
+        );
+        assert!(!cleaned.contains('\n'));
+        assert!(!cleaned.contains('\r'));
+        assert!(!cleaned.contains('\x1b'));
+        assert!(!cleaned.contains('\0'));
+        // The diagnostic value must survive: the developer still needs to
+        // read the real origin back to add it to `extensionDevOrigins`.
+        assert!(cleaned.contains("chrome-extension://evil"));
+        assert!(cleaned.contains("WARN fake line"));
+        assert!(cleaned.contains("red"));
+        assert!(cleaned.contains("end"));
+    }
+
+    #[test]
+    fn sanitize_log_origin_caps_length() {
+        // The `Origin` header is attacker-supplied and unbounded — this is
+        // the live protection (see the doc comment: a raw newline can't reach
+        // this call site through the current HTTP-header path, but nothing
+        // bounds the header's length).
+        let huge = "a".repeat(MAX_LOGGED_ORIGIN_LEN + 500);
+        let cleaned = sanitize_log_origin(&huge);
+        assert_eq!(cleaned.chars().count(), MAX_LOGGED_ORIGIN_LEN + 1); // + truncation marker
+        assert!(cleaned.ends_with('…'));
+    }
+
+    #[test]
+    fn sanitize_log_origin_leaves_a_short_clean_origin_untouched() {
+        // A real Origin never gets mangled — length-cap and control-char
+        // stripping are both no-ops on the legitimate shapes this bridge
+        // actually sees.
+        let origin = "chrome-extension://oaoekkgkhmgdfnpmfkpphgiikliaicll";
+        assert_eq!(sanitize_log_origin(origin), origin);
     }
 }

--- a/apps/desktop/src-tauri/src/extension_bridge/autotrack.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/autotrack.rs
@@ -39,7 +39,10 @@ impl BridgeState {
     pub fn set_autotrack_enabled(&self, enabled: bool) {
         self.autotrack_enabled.store(enabled, Ordering::Relaxed);
         if let Err(e) = persist_autotrack_optin(&self.data_dir, enabled) {
-            log::warn!("[extension_bridge] failed to persist auto-track opt-in (non-fatal): {e}");
+            log::warn!(
+                "[extension_bridge] failed to persist auto-track opt-in (non-fatal): {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
         }
     }
 }

--- a/apps/desktop/src-tauri/src/extension_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/mod.rs
@@ -59,6 +59,12 @@ use tokio_tungstenite::tungstenite::Message;
 
 use crate::error::{AppError, AppResult};
 use crate::events::{emit_event, EXTENSION_BRIDGE_CHANGED};
+use crate::observability::sanitize_reason;
+
+use self::persist::{
+    load_ai_assist_optin, load_autofill_optin, load_or_create_token, new_token,
+    persist_ai_assist_optin, persist_autofill_optin, persist_token,
+};
 
 mod answer_assist;
 mod answer_rewrite;
@@ -77,6 +83,7 @@ mod match_live;
 /// Wire `type` constants (the TS-mirrored protocol table) — see its module doc.
 pub mod msg;
 pub mod native_host;
+mod persist;
 pub mod register;
 /// The `token.revoked` wire surface + its no-oracle gate — see its module doc.
 mod revoke;
@@ -304,7 +311,8 @@ impl BridgeState {
             *token = fresh.clone();
         }
         if let Err(e) = persist_token(&self.data_dir, &fresh) {
-            log::warn!("[extension_bridge] failed to persist regenerated token (non-fatal): {e}");
+            let reason = sanitize_reason(&e.to_string());
+            log::warn!("[extension_bridge] failed to persist regenerated token: {reason}");
         }
         fresh
     }
@@ -329,7 +337,8 @@ impl BridgeState {
     pub fn set_autofill_enabled(&self, enabled: bool) {
         self.autofill_enabled.store(enabled, Ordering::Relaxed);
         if let Err(e) = persist_autofill_optin(&self.data_dir, enabled) {
-            log::warn!("[extension_bridge] failed to persist autofill opt-in (non-fatal): {e}");
+            let reason = sanitize_reason(&e.to_string());
+            log::warn!("[extension_bridge] failed to persist autofill opt-in: {reason}");
         }
     }
 
@@ -349,7 +358,8 @@ impl BridgeState {
     pub fn set_ai_assist(&self, enabled: bool) {
         self.ai_assist_enabled.store(enabled, Ordering::Relaxed);
         if let Err(e) = persist_ai_assist_optin(&self.data_dir, enabled) {
-            log::warn!("[extension_bridge] failed to persist ai-assist opt-in (non-fatal): {e}");
+            let reason = sanitize_reason(&e.to_string());
+            log::warn!("[extension_bridge] failed to persist ai-assist opt-in: {reason}");
         }
     }
 
@@ -429,88 +439,6 @@ impl crate::data_store::Resettable for BridgeState {
         self.set_ai_assist(false);
         self.set_autotrack_enabled(false);
     }
-}
-
-/// A 32-byte random token, lowercase hex (64 chars).
-fn new_token() -> String {
-    use rand::Rng;
-    let mut bytes = [0u8; 32];
-    rand::rng().fill_bytes(&mut bytes);
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-/// Read the persisted token, or create + persist a fresh one on first run (or
-/// if the stored value is corrupt/empty).
-fn load_or_create_token(data_dir: &Path) -> String {
-    let path = data_dir.join(TOKEN_FILE);
-    if let Ok(s) = std::fs::read_to_string(&path) {
-        let trimmed = s.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_string();
-        }
-    }
-    let fresh = new_token();
-    if let Err(e) = persist_token(data_dir, &fresh) {
-        log::warn!("[extension_bridge] failed to persist initial token (non-fatal): {e}");
-    }
-    fresh
-}
-
-/// Read the persisted autofill opt-in (`"1"` ⇒ on). Absent / any other value ⇒
-/// OFF, so a first run and a corrupt flag both default to the safe (off) state.
-fn load_autofill_optin(data_dir: &Path) -> bool {
-    std::fs::read_to_string(data_dir.join(AUTOFILL_OPTIN_FILE))
-        .map(|s| s.trim() == "1")
-        .unwrap_or(false)
-}
-
-fn persist_autofill_optin(data_dir: &Path, enabled: bool) -> std::io::Result<()> {
-    std::fs::create_dir_all(data_dir)?;
-    std::fs::write(
-        data_dir.join(AUTOFILL_OPTIN_FILE),
-        if enabled { "1" } else { "0" },
-    )
-}
-
-/// Read the persisted AI-answer-assist opt-in. Absent file / parse failure →
-/// OFF (the safe state), mirroring [`load_autofill_optin`]'s degrade-to-off
-/// discipline. Only the `enabled` flag is honored: an OLD file that also
-/// carried a `provider`/`model`/`base_url` snapshot is still read fine — the
-/// extra fields are ignored, so a user who opted in before task #16 stays
-/// opted in (the active provider is resolved from the backend
-/// [`crate::ai_config::AiConfigStore`] at answer-time, never that stale
-/// snapshot).
-fn load_ai_assist_optin(data_dir: &Path) -> bool {
-    std::fs::read_to_string(data_dir.join(AI_ASSIST_OPTIN_FILE))
-        .ok()
-        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
-        .and_then(|v| v.get("enabled").and_then(Value::as_bool))
-        .unwrap_or(false)
-}
-
-fn persist_ai_assist_optin(data_dir: &Path, enabled: bool) -> std::io::Result<()> {
-    std::fs::create_dir_all(data_dir)?;
-    std::fs::write(
-        data_dir.join(AI_ASSIST_OPTIN_FILE),
-        json!({ "enabled": enabled }).to_string(),
-    )
-}
-
-fn persist_token(data_dir: &Path, token: &str) -> std::io::Result<()> {
-    std::fs::create_dir_all(data_dir)?;
-    std::fs::write(data_dir.join(TOKEN_FILE), token)?;
-    // Restrict the token file to the owner (best-effort) on unix so a
-    // multi-user box can't read the pairing secret. Applies on both
-    // first-create and rotate.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(
-            data_dir.join(TOKEN_FILE),
-            std::fs::Permissions::from_mode(0o600),
-        );
-    }
-    Ok(())
 }
 
 /// Spawn the bridge server via the Tauri async runtime. Fire-and-forget: a
@@ -796,7 +724,8 @@ async fn handle_connection(app: AppHandle, stream: TcpStream) {
         let msg = match frame {
             Ok(m) => m,
             Err(e) => {
-                log::warn!("[extension_bridge] read error: {e}");
+                let reason = sanitize_reason(&e.to_string());
+                log::warn!("[extension_bridge] read error: {reason}");
                 break;
             }
         };

--- a/apps/desktop/src-tauri/src/extension_bridge/persist.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/persist.rs
@@ -1,0 +1,97 @@
+//! Pairing-token + consent-opt-in persistence — split out of `mod.rs` to stay
+//! under the R8 hard LOC cap (`tests/architecture.rs`), the same discipline
+//! `autotrack.rs`'s split already documents. Holds the on-disk read/write for
+//! the token file and the two boolean opt-in files; the `BridgeState`
+//! accessors, the `Resettable` wiring, and each mutator's own failure log
+//! stay in the parent module — this is the pure fs layer underneath them.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+
+use crate::observability::sanitize_reason;
+
+use super::{AI_ASSIST_OPTIN_FILE, AUTOFILL_OPTIN_FILE, TOKEN_FILE};
+
+/// A 32-byte random token, lowercase hex (64 chars).
+pub(super) fn new_token() -> String {
+    use rand::Rng;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Read the persisted token, or create + persist a fresh one on first run (or
+/// if the stored value is corrupt/empty).
+pub(super) fn load_or_create_token(data_dir: &Path) -> String {
+    let path = data_dir.join(TOKEN_FILE);
+    if let Ok(s) = std::fs::read_to_string(&path) {
+        let trimmed = s.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let fresh = new_token();
+    if let Err(e) = persist_token(data_dir, &fresh) {
+        let reason = sanitize_reason(&e.to_string());
+        log::warn!("[extension_bridge] failed to persist initial token (non-fatal): {reason}");
+    }
+    fresh
+}
+
+/// Read the persisted autofill opt-in (`"1"` ⇒ on). Absent / any other value ⇒
+/// OFF, so a first run and a corrupt flag both default to the safe (off) state.
+pub(super) fn load_autofill_optin(data_dir: &Path) -> bool {
+    std::fs::read_to_string(data_dir.join(AUTOFILL_OPTIN_FILE))
+        .map(|s| s.trim() == "1")
+        .unwrap_or(false)
+}
+
+pub(super) fn persist_autofill_optin(data_dir: &Path, enabled: bool) -> std::io::Result<()> {
+    std::fs::create_dir_all(data_dir)?;
+    std::fs::write(
+        data_dir.join(AUTOFILL_OPTIN_FILE),
+        if enabled { "1" } else { "0" },
+    )
+}
+
+/// Read the persisted AI-answer-assist opt-in. Absent file / parse failure →
+/// OFF (the safe state), mirroring [`load_autofill_optin`]'s degrade-to-off
+/// discipline. Only the `enabled` flag is honored: an OLD file that also
+/// carried a `provider`/`model`/`base_url` snapshot is still read fine — the
+/// extra fields are ignored, so a user who opted in before task #16 stays
+/// opted in (the active provider is resolved from the backend
+/// [`crate::ai_config::AiConfigStore`] at answer-time, never that stale
+/// snapshot).
+pub(super) fn load_ai_assist_optin(data_dir: &Path) -> bool {
+    std::fs::read_to_string(data_dir.join(AI_ASSIST_OPTIN_FILE))
+        .ok()
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+        .and_then(|v| v.get("enabled").and_then(Value::as_bool))
+        .unwrap_or(false)
+}
+
+pub(super) fn persist_ai_assist_optin(data_dir: &Path, enabled: bool) -> std::io::Result<()> {
+    std::fs::create_dir_all(data_dir)?;
+    std::fs::write(
+        data_dir.join(AI_ASSIST_OPTIN_FILE),
+        json!({ "enabled": enabled }).to_string(),
+    )
+}
+
+pub(super) fn persist_token(data_dir: &Path, token: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(data_dir)?;
+    std::fs::write(data_dir.join(TOKEN_FILE), token)?;
+    // Restrict the token file to the owner (best-effort) on unix so a
+    // multi-user box can't read the pairing secret. Applies on both
+    // first-create and rotate.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(
+            data_dir.join(TOKEN_FILE),
+            std::fs::Permissions::from_mode(0o600),
+        );
+    }
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/extension_bridge/persist.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/persist.rs
@@ -79,19 +79,143 @@ pub(super) fn persist_ai_assist_optin(data_dir: &Path, enabled: bool) -> std::io
     )
 }
 
+/// Persist the pairing token to `data_dir` — the single write path both
+/// first-create ([`load_or_create_token`]) and rotation
+/// ([`super::BridgeState::regenerate_token`]) share, so a permissions fix
+/// here covers both.
+///
+/// On unix the file is opened with `0o600` baked into the *creation* syscall
+/// itself (`OpenOptions::mode`), not applied afterward: the mode is part of
+/// the same `open(2)` call that creates the inode, so a brand-new token file
+/// is owner-only from its very first byte on disk — there is no window where
+/// it briefly exists at the process umask (which is what a separate
+/// `fs::write` then `set_permissions` call leaves open, and on a multi-user
+/// box the umask can be group- or world-readable).
+///
+/// `OpenOptions::mode` only takes effect when the file is actually CREATED —
+/// unix `open(2)` ignores the mode argument for a file that already exists
+/// (only `O_TRUNC` applies). So an already-existing file with the wrong
+/// permissions (e.g. one written before this fix shipped) would keep them
+/// across the `truncate(true)` open; the explicit trailing
+/// `set_permissions` call below corrects that case too, on every write —
+/// first-create AND rotate self-heal a stale wrong-permission file, not just
+/// a fresh one.
 pub(super) fn persist_token(data_dir: &Path, token: &str) -> std::io::Result<()> {
     std::fs::create_dir_all(data_dir)?;
-    std::fs::write(data_dir.join(TOKEN_FILE), token)?;
-    // Restrict the token file to the owner (best-effort) on unix so a
-    // multi-user box can't read the pairing secret. Applies on both
-    // first-create and rotate.
+    let path = data_dir.join(TOKEN_FILE);
+
     #[cfg(unix)]
     {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(token.as_bytes())?;
+        // Re-assert 0o600 even on the just-created-correctly path (a no-op
+        // there) so the ONE call also corrects a pre-existing file the
+        // create-mode couldn't touch (see the doc above). A box where this
+        // fails silently would keep a readable pairing secret — that is a
+        // real credential leak, not a cosmetic failure, so it is logged loud
+        // and propagated rather than swallowed with `let _ =`.
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(
-            data_dir.join(TOKEN_FILE),
-            std::fs::Permissions::from_mode(0o600),
+        if let Err(e) = file.set_permissions(std::fs::Permissions::from_mode(0o600)) {
+            let reason = sanitize_reason(&e.to_string());
+            log::warn!(
+                "[extension_bridge] pairing token file could not be locked down to \
+                 owner-only (0o600): {reason}"
+            );
+            return Err(e);
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, token)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // ── Mutation-check note ──────────────────────────────────────────────
+    // The two `#[cfg(unix)]` tests below were mutation-checked in a
+    // standalone repro against the PRE-FIX shape (`std::fs::write` then a
+    // best-effort `set_permissions` afterward, `let _ =`-swallowed): BOTH
+    // still PASS against that old code. Its final on-disk state — including
+    // the pre-existing-file self-heal — is identical to the fix's, because
+    // the old code's `set_permissions` call, though its failure was
+    // discarded, still ran and still succeeded on every ordinary run. A
+    // concurrent-poller race test (permissive umask, a 2,000,000-iteration
+    // busy-poll thread racing the write, 4 independent runs) also never
+    // observed the old code's create-then-chmod window even once — it is
+    // real (two separate syscalls) but far too short (no I/O wait between
+    // them) for a black-box test to reliably land inside. So: these tests
+    // verify END-STATE correctness (and guard a future refactor that drops
+    // the trailing `set_permissions` call entirely, which WOULD fail them)
+    // — they do NOT, and structurally cannot, prove the TOCTOU window is
+    // closed. That property is undetectable by test; it is verified by
+    // reading `persist_token`'s doc comment above (the mode is now part of
+    // the `open(2)` call itself, not a later chmod).
+
+    #[test]
+    fn persist_token_writes_readable_content() {
+        let dir = TempDir::new().unwrap();
+        persist_token(dir.path(), "abc123").unwrap();
+        let read = std::fs::read_to_string(dir.path().join(TOKEN_FILE)).unwrap();
+        assert_eq!(read, "abc123");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_token_creates_file_owner_only_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        persist_token(dir.path(), "abc123").unwrap();
+        let mode = std::fs::metadata(dir.path().join(TOKEN_FILE))
+            .unwrap()
+            .permissions()
+            .mode();
+        // Mask off the file-type bits `st_mode` packs alongside the
+        // permission bits — only the permission bits are under test.
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "pairing token file must be owner-only (0o600), got {:o}",
+            mode & 0o777
         );
     }
-    Ok(())
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_token_corrects_a_preexisting_wrong_permission_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(TOKEN_FILE);
+        // Simulate a token file that predates this fix — or was created on a
+        // filesystem/umask combination that widened it — group- and
+        // world-readable.
+        std::fs::write(&path, "stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        persist_token(dir.path(), "fresh").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "a pre-existing wide-permission token file must self-heal on the next persist"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "fresh");
+    }
 }

--- a/apps/desktop/src-tauri/src/extension_bridge/register.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/register.rs
@@ -74,12 +74,18 @@ fn manifest_json(exe: &Path, firefox: bool) -> Vec<u8> {
 fn write_manifest(label: &str, path: &Path, bytes: &[u8]) {
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
-            log::warn!("[native_host] mkdir for {label} manifest failed (non-fatal): {e}");
+            log::warn!(
+                "[native_host] mkdir for {label} manifest failed (non-fatal): {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
             return;
         }
     }
     if let Err(e) = std::fs::write(path, bytes) {
-        log::warn!("[native_host] write {label} manifest failed (non-fatal): {e}");
+        log::warn!(
+            "[native_host] write {label} manifest failed (non-fatal): {}",
+            crate::observability::sanitize_reason(&e.to_string())
+        );
     }
 }
 
@@ -126,10 +132,16 @@ pub fn register_native_host(data_dir: &Path) {
         let chrome_key =
             format!("Software\\Google\\Chrome\\NativeMessagingHosts\\{NATIVE_HOST_NAME}");
         if let Err(e) = set_hkcu_default(&firefox_key, &firefox_path.to_string_lossy()) {
-            log::warn!("[native_host] HKCU firefox key failed (non-fatal): {e}");
+            log::warn!(
+                "[native_host] HKCU firefox key failed (non-fatal): {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
         }
         if let Err(e) = set_hkcu_default(&chrome_key, &chrome_path.to_string_lossy()) {
-            log::warn!("[native_host] HKCU chrome key failed (non-fatal): {e}");
+            log::warn!(
+                "[native_host] HKCU chrome key failed (non-fatal): {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
         }
     }
 

--- a/apps/desktop/src-tauri/src/extension_bridge/status_update.rs
+++ b/apps/desktop/src-tauri/src/extension_bridge/status_update.rs
@@ -161,7 +161,10 @@ pub(super) fn resolve_status_update(
             // Wire-error discipline: never let a raw store error (path/SQL
             // detail) reach `status_result_reply` — log it, reply a fixed
             // sentinel.
-            log::warn!("[extension_bridge] status.update store error: {e}");
+            log::warn!(
+                "[extension_bridge] status.update store error: {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
             AppError::Storage("could not update this application".to_string())
         })?;
     if !transitioned {

--- a/apps/desktop/src-tauri/src/jobs/mod.rs
+++ b/apps/desktop/src-tauri/src/jobs/mod.rs
@@ -211,13 +211,21 @@ impl JobTracker {
 
     /// Register a new job as running.
     pub fn start(&mut self, id: &str, kind: &str) {
+        self.start_with_payload(id, kind, Value::Null);
+    }
+
+    /// [`Self::start`], recording `payload` instead of `Value::Null` — the
+    /// shared body [`Self::start_exclusive_keyed`] uses to stamp the
+    /// distinguishing key (e.g. the model being pulled) onto the record it
+    /// creates, so a later caller can read it back off `job.payload`.
+    fn start_with_payload(&mut self, id: &str, kind: &str, payload: Value) {
         let now = now_ms();
         let record = JobRecord {
             id: id.to_string(),
             kind: kind.to_string(),
             status: JobStatus::Running,
             progress: 0.0,
-            payload: Value::Null,
+            payload,
             result: None,
             error: None,
             retries: 0,
@@ -259,6 +267,49 @@ impl JobTracker {
         }
         self.start(id, kind);
         None
+    }
+
+    /// Like [`Self::start_exclusive`], but the exclusion group is `kind` PLUS
+    /// a caller-supplied `key` (e.g. the model being pulled) rather than
+    /// `kind` alone.
+    ///
+    /// `kind`-only exclusivity is wrong here: a returning caller must join a
+    /// pull of the SAME model already in flight, but a request for a
+    /// DIFFERENT model must not silently adopt that unrelated job — the
+    /// caller would watch (and eventually believe it received) a download it
+    /// never asked for, while its own request never ran at all. Reusing
+    /// `start_exclusive`'s kind-only match here would do exactly that.
+    ///
+    /// Returns `Ok(None)` when this job was started (the key is stamped onto
+    /// its `payload` under `key_field`, readable back via [`Self::get`]);
+    /// `Ok(Some(existing_id))` when a job of `kind` with the SAME key is
+    /// already active (join it, same as `start_exclusive`); `Err(other_key)`
+    /// when a job of `kind` with a DIFFERENT key is active — the caller
+    /// decides how to report that conflict (this tracker has no i18n/error
+    /// layer of its own).
+    pub fn start_exclusive_keyed(
+        &mut self,
+        id: &str,
+        kind: &str,
+        key_field: &str,
+        key: &str,
+    ) -> Result<Option<String>, String> {
+        if let Some(existing) = self.jobs.values().find(|j| {
+            j.kind == kind
+                && matches!(
+                    j.status,
+                    JobStatus::Running | JobStatus::Queued | JobStatus::Streaming
+                )
+        }) {
+            let existing_key = existing.payload.get(key_field).and_then(Value::as_str);
+            return if existing_key == Some(key) {
+                Ok(Some(existing.id.clone()))
+            } else {
+                Err(existing_key.unwrap_or("unknown").to_string())
+            };
+        }
+        self.start_with_payload(id, kind, serde_json::json!({ key_field: key }));
+        Ok(None)
     }
 
     /// Wipe the job-execution log — in-memory records and the `jobs` table.

--- a/apps/desktop/src-tauri/src/jobs/mod.rs
+++ b/apps/desktop/src-tauri/src/jobs/mod.rs
@@ -86,6 +86,24 @@ pub struct JobRecord {
     pub finished_at: Option<u64>,
 }
 
+/// Outcome of [`JobTracker::start_exclusive_keyed`].
+///
+/// A plain three-way result, not `Result<Option<String>, String>`: `Busy`
+/// carries the OTHER job's key (e.g. "llama3" when the caller asked for
+/// "qwen2.5") — that is data the caller routes on, not a diagnostic, so
+/// forcing it through `Err` would just make the call site decode a
+/// convention instead of reading a name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyedExclusiveStart {
+    /// Nothing of `kind` was running; this job started.
+    Started,
+    /// A job of `kind` with the SAME key is already active — join it (its id).
+    Joined(String),
+    /// A job of `kind` with a DIFFERENT key is active — refused. Carries
+    /// that job's key so the caller can say what's already running.
+    Busy(String),
+}
+
 #[derive(Default)]
 pub struct JobTracker {
     jobs: HashMap<String, JobRecord>,
@@ -280,20 +298,17 @@ impl JobTracker {
     /// never asked for, while its own request never ran at all. Reusing
     /// `start_exclusive`'s kind-only match here would do exactly that.
     ///
-    /// Returns `Ok(None)` when this job was started (the key is stamped onto
-    /// its `payload` under `key_field`, readable back via [`Self::get`]);
-    /// `Ok(Some(existing_id))` when a job of `kind` with the SAME key is
-    /// already active (join it, same as `start_exclusive`); `Err(other_key)`
-    /// when a job of `kind` with a DIFFERENT key is active — the caller
-    /// decides how to report that conflict (this tracker has no i18n/error
-    /// layer of its own).
+    /// Three-way outcome, not a `Result` — [`KeyedExclusiveStart::Busy`] is an
+    /// expected routing outcome (which other key is active), not a
+    /// diagnostic, so wrapping it in `Err` would be a stringly-typed
+    /// `Result<_, String>` for something that never fails.
     pub fn start_exclusive_keyed(
         &mut self,
         id: &str,
         kind: &str,
         key_field: &str,
         key: &str,
-    ) -> Result<Option<String>, String> {
+    ) -> KeyedExclusiveStart {
         if let Some(existing) = self.jobs.values().find(|j| {
             j.kind == kind
                 && matches!(
@@ -303,13 +318,13 @@ impl JobTracker {
         }) {
             let existing_key = existing.payload.get(key_field).and_then(Value::as_str);
             return if existing_key == Some(key) {
-                Ok(Some(existing.id.clone()))
+                KeyedExclusiveStart::Joined(existing.id.clone())
             } else {
-                Err(existing_key.unwrap_or("unknown").to_string())
+                KeyedExclusiveStart::Busy(existing_key.unwrap_or("unknown").to_string())
             };
         }
         self.start_with_payload(id, kind, serde_json::json!({ key_field: key }));
-        Ok(None)
+        KeyedExclusiveStart::Started
     }
 
     /// Wipe the job-execution log — in-memory records and the `jobs` table.

--- a/apps/desktop/src-tauri/src/jobs/mod.rs
+++ b/apps/desktop/src-tauri/src/jobs/mod.rs
@@ -18,6 +18,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::db::{now_ms, run_migrations, ts_from_db, ts_to_db, Migration};
+use crate::observability::sanitize_reason;
 
 /// Cancellation tokens for in-flight jobs/runs, keyed by id — the tracker's
 /// sibling: this module records what a job DID, `cancel` records how to STOP it.
@@ -135,12 +136,18 @@ impl JobTracker {
         let mut conn = match crate::db::open(&db_path) {
             Ok(c) => c,
             Err(e) => {
-                log::warn!("[jobs] failed to open jobs.db, running in-memory only: {e}");
+                log::warn!(
+                    "[jobs] failed to open jobs.db, running in-memory only: {}",
+                    e.code()
+                );
                 return Self::default();
             }
         };
         if let Err(e) = run_migrations(&mut conn, Self::MIGRATIONS) {
-            log::warn!("[jobs] migration failed, running in-memory only: {e}");
+            log::warn!(
+                "[jobs] migration failed, running in-memory only: {}",
+                sanitize_reason(&e.to_string())
+            );
             return Self::default();
         }
 

--- a/apps/desktop/src-tauri/src/jobs/test.rs
+++ b/apps/desktop/src-tauri/src/jobs/test.rs
@@ -195,6 +195,57 @@ fn test_start_exclusive_ignores_unrelated_groups() {
     assert_eq!(tracker.get("job-2").unwrap().status, JobStatus::Running);
 }
 
+// ── start_exclusive_keyed: `ai.pull_model` must dedupe per MODEL, not just
+// kind — PR #1036 review finding. `start_exclusive` alone would join a
+// request for "qwen2.5" to an already-running "llama3" pull, handing the
+// caller progress for a model it never asked for while its own request
+// silently never runs.
+// ────────────────────────────────────────────────────────────────────────
+
+/// Same model, second request: still joins the running job and returns its
+/// id — the ORIGINAL `start_exclusive` fix, which must not regress.
+#[test]
+fn test_start_exclusive_keyed_same_key_joins_the_running_job() {
+    let mut tracker = JobTracker::default();
+    let first = tracker.start_exclusive_keyed("job-1", "ai.pull_model", "model", "llama3");
+    assert_eq!(first, Ok(None));
+
+    let second = tracker.start_exclusive_keyed("job-2", "ai.pull_model", "model", "llama3");
+    assert_eq!(second, Ok(Some("job-1".to_string())));
+    // The second call must not have registered "job-2" at all.
+    assert!(tracker.get("job-2").is_none());
+}
+
+/// Different model, second request: refused rather than silently joined to
+/// the wrong job — the defect this test guards against.
+#[test]
+fn test_start_exclusive_keyed_different_key_is_refused_not_joined() {
+    let mut tracker = JobTracker::default();
+    let first = tracker.start_exclusive_keyed("job-1", "ai.pull_model", "model", "llama3");
+    assert_eq!(first, Ok(None));
+
+    let second = tracker.start_exclusive_keyed("job-2", "ai.pull_model", "model", "qwen2.5");
+    assert_eq!(
+        second,
+        Err("llama3".to_string()),
+        "a different model must be refused, never silently joined to job-1"
+    );
+    assert!(
+        tracker.get("job-2").is_none(),
+        "a refused request must not register a job either"
+    );
+}
+
+/// The key survives the round trip: a joined caller (or anything reading the
+/// job list) can read back which model a pull is actually for.
+#[test]
+fn test_start_exclusive_keyed_records_the_key_on_the_payload() {
+    let mut tracker = JobTracker::default();
+    let _ = tracker.start_exclusive_keyed("job-1", "ai.pull_model", "model", "llama3");
+    let job = tracker.get("job-1").unwrap();
+    assert_eq!(job.payload, json!({ "model": "llama3" }));
+}
+
 #[test]
 fn test_interrupted_running_job_marked_failed_on_reload() {
     use tempfile::TempDir;

--- a/apps/desktop/src-tauri/src/jobs/test.rs
+++ b/apps/desktop/src-tauri/src/jobs/test.rs
@@ -208,10 +208,10 @@ fn test_start_exclusive_ignores_unrelated_groups() {
 fn test_start_exclusive_keyed_same_key_joins_the_running_job() {
     let mut tracker = JobTracker::default();
     let first = tracker.start_exclusive_keyed("job-1", "ai.pull_model", "model", "llama3");
-    assert_eq!(first, Ok(None));
+    assert_eq!(first, KeyedExclusiveStart::Started);
 
     let second = tracker.start_exclusive_keyed("job-2", "ai.pull_model", "model", "llama3");
-    assert_eq!(second, Ok(Some("job-1".to_string())));
+    assert_eq!(second, KeyedExclusiveStart::Joined("job-1".to_string()));
     // The second call must not have registered "job-2" at all.
     assert!(tracker.get("job-2").is_none());
 }
@@ -222,12 +222,12 @@ fn test_start_exclusive_keyed_same_key_joins_the_running_job() {
 fn test_start_exclusive_keyed_different_key_is_refused_not_joined() {
     let mut tracker = JobTracker::default();
     let first = tracker.start_exclusive_keyed("job-1", "ai.pull_model", "model", "llama3");
-    assert_eq!(first, Ok(None));
+    assert_eq!(first, KeyedExclusiveStart::Started);
 
     let second = tracker.start_exclusive_keyed("job-2", "ai.pull_model", "model", "qwen2.5");
     assert_eq!(
         second,
-        Err("llama3".to_string()),
+        KeyedExclusiveStart::Busy("llama3".to_string()),
         "a different model must be refused, never silently joined to job-1"
     );
     assert!(

--- a/apps/desktop/src-tauri/src/jobs/test.rs
+++ b/apps/desktop/src-tauri/src/jobs/test.rs
@@ -126,6 +126,75 @@ fn test_persist_reload_migration_roundtrip() {
     assert_eq!(j.retries, 0);
 }
 
+// ── start_exclusive: the "second call while busy" re-entrancy guard shared
+// by the embedding jobs (`ai.reembed`/`ai.indexStale`) and `ai.pull_model`
+// ────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_start_exclusive_first_caller_starts_the_job() {
+    let mut tracker = JobTracker::default();
+    let existing = tracker.start_exclusive("job-1", "ai.pull_model", &["ai.pull_model"]);
+    assert!(existing.is_none());
+    assert_eq!(tracker.get("job-1").unwrap().status, JobStatus::Running);
+}
+
+/// The re-entrancy guard itself: a second call while the first job of an
+/// exclusive kind is still running must NOT start a second job — it must
+/// report the first job's id back instead.
+#[test]
+fn test_start_exclusive_second_caller_joins_the_running_job() {
+    let mut tracker = JobTracker::default();
+    let first = tracker.start_exclusive("job-1", "ai.pull_model", &["ai.pull_model"]);
+    assert!(first.is_none());
+
+    let second = tracker.start_exclusive("job-2", "ai.pull_model", &["ai.pull_model"]);
+    assert_eq!(second, Some("job-1".to_string()));
+    // The second call must not have registered "job-2" at all.
+    assert!(tracker.get("job-2").is_none());
+}
+
+/// Queued/streaming count as "busy" too, not just Running — a job parked
+/// behind the concurrency limiter is still work in flight.
+#[test]
+fn test_start_exclusive_blocks_on_queued_and_streaming() {
+    for status in [JobStatus::Queued, JobStatus::Streaming] {
+        let mut tracker = JobTracker::default();
+        tracker.start("job-1", "ai.pull_model");
+        tracker.jobs.get_mut("job-1").unwrap().status = status.clone();
+        let second = tracker.start_exclusive("job-2", "ai.pull_model", &["ai.pull_model"]);
+        assert_eq!(
+            second,
+            Some("job-1".to_string()),
+            "status {status:?} should block"
+        );
+    }
+}
+
+/// The guard releases once the job reaches a terminal state — it must not
+/// latch permanently after the run that claimed it finishes.
+#[test]
+fn test_start_exclusive_releases_after_completion() {
+    let mut tracker = JobTracker::default();
+    tracker.start_exclusive("job-1", "ai.pull_model", &["ai.pull_model"]);
+    tracker.complete("job-1", json!({ "done": true }));
+
+    let second = tracker.start_exclusive("job-2", "ai.pull_model", &["ai.pull_model"]);
+    assert!(second.is_none(), "a finished job must not block a new run");
+    assert_eq!(tracker.get("job-2").unwrap().status, JobStatus::Running);
+}
+
+/// Two independent exclusive groups don't interfere: a busy job in the
+/// "ai.pull_model" group must not block a start checked against an unrelated
+/// group's kinds (e.g. the embed jobs), and vice versa.
+#[test]
+fn test_start_exclusive_ignores_unrelated_groups() {
+    let mut tracker = JobTracker::default();
+    tracker.start_exclusive("job-1", "ai.pull_model", &["ai.pull_model"]);
+    let second = tracker.start_exclusive("job-2", "ai.reembed", &["ai.reembed", "ai.indexStale"]);
+    assert!(second.is_none());
+    assert_eq!(tracker.get("job-2").unwrap().status, JobStatus::Running);
+}
+
 #[test]
 fn test_interrupted_running_job_marked_failed_on_reload() {
     use tempfile::TempDir;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -89,6 +89,7 @@ use tauri::{AppHandle, Manager};
 use autopilot::AutopilotStore;
 use credentials::CredentialStore;
 use jobs::JobTracker;
+use observability::sanitize_reason;
 use postings::{InteractionStore, PostingsCache};
 use scraping::ScraperEngine;
 use updater::UpdaterState;
@@ -466,7 +467,10 @@ pub fn run() {
     // still boots, and credential operations (AI provider keys, factory reset)
     // surface the error later through `AppError` rather than aborting startup.
     if let Err(e) = credentials::init_keyring() {
-        log::warn!("[startup] OS keyring unavailable (credential features degraded): {e}");
+        log::warn!(
+            "[startup] OS keyring unavailable (credential features degraded): {}",
+            sanitize_reason(&e.to_string())
+        );
     }
 
     let mut builder = tauri::Builder::default();
@@ -610,7 +614,10 @@ pub fn run() {
                 .handle()
                 .plugin(tauri_plugin_global_shortcut::Builder::new().build())
             {
-                log::warn!("[setup] global-shortcut plugin init failed (non-fatal): {e}");
+                log::warn!(
+                    "[setup] global-shortcut plugin init failed (non-fatal): {}",
+                    sanitize_reason(&e.to_string())
+                );
             }
 
             let handle = app.handle();
@@ -701,12 +708,18 @@ pub fn run() {
             );
             match documents::DocumentStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "documents", store),
-                Err(e) => log::warn!("[setup] document store failed to open (non-fatal): {e}"),
+                Err(e) => log::warn!(
+                    "[setup] document store failed to open (non-fatal): {}",
+                    e.code()
+                ),
             }
             match ai_generations::AiGenerationStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "ai_generations", store),
                 Err(e) => {
-                    log::warn!("[setup] ai generations store failed to open (non-fatal): {e}")
+                    log::warn!(
+                        "[setup] ai generations store failed to open (non-fatal): {}",
+                        e.code()
+                    )
                 }
             }
             // Applications: the status-bearing aggregate root (ADR 0001). Opening it
@@ -716,19 +729,28 @@ pub fn run() {
             match applications::ApplicationStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "applications", store),
                 Err(e) => {
-                    log::warn!("[setup] applications store failed to open (non-fatal): {e}")
+                    log::warn!(
+                        "[setup] applications store failed to open (non-fatal): {}",
+                        e.code()
+                    )
                 }
             }
             match job_preferences::JobPreferencesStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "job_preferences", store),
                 Err(e) => {
-                    log::warn!("[setup] job preferences store failed to open (non-fatal): {e}")
+                    log::warn!(
+                        "[setup] job preferences store failed to open (non-fatal): {}",
+                        e.code()
+                    )
                 }
             }
             match contact_profile::ContactProfileStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "contact_profile", store),
                 Err(e) => {
-                    log::warn!("[setup] contact profile store failed to open (non-fatal): {e}")
+                    log::warn!(
+                        "[setup] contact profile store failed to open (non-fatal): {}",
+                        e.code()
+                    )
                 }
             }
             // Backend-owned active AI provider store (task #16): the single source of
@@ -739,13 +761,19 @@ pub fn run() {
                     manage_resettable(app, &mut reset_registry, "ai_provider_config", store)
                 }
                 Err(e) => {
-                    log::warn!("[setup] ai provider config store failed to open (non-fatal): {e}")
+                    log::warn!(
+                        "[setup] ai provider config store failed to open (non-fatal): {}",
+                        e.code()
+                    )
                 }
             }
             match referrals::ReferralStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "referrals", store),
                 Err(e) => {
-                    log::warn!("[setup] referrals store failed to open (non-fatal): {e}")
+                    log::warn!(
+                        "[setup] referrals store failed to open (non-fatal): {}",
+                        e.code()
+                    )
                 }
             }
             manage_resettable(
@@ -771,7 +799,10 @@ pub fn run() {
             // `commands::ai_provider::stream` / `pipeline::Completer::complete`.
             match spend::SpendStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "spend", store),
-                Err(e) => log::warn!("[setup] spend store failed to open (non-fatal): {e}"),
+                Err(e) => log::warn!(
+                    "[setup] spend store failed to open (non-fatal): {}",
+                    e.code()
+                ),
             }
             // Email-confirmation watching (task #23, auto-track Layer C). Holds
             // no secrets (the app password lives in the OS keychain via
@@ -780,7 +811,10 @@ pub fn run() {
             // The poller itself is started separately, below (`email_watch_scheduler::start`).
             match email_watch::EmailWatchStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "email_watch", store),
-                Err(e) => log::warn!("[setup] email watch store failed to open (non-fatal): {e}"),
+                Err(e) => log::warn!(
+                    "[setup] email watch store failed to open (non-fatal): {}",
+                    e.code()
+                ),
             }
             app.manage(Mutex::new(UpdaterState::default()));
             // ONE cancel registry for every job kind (`jobs::cancel`). The
@@ -821,7 +855,10 @@ pub fn run() {
             }
             match pipeline::cache::KvCache::open(&data_dir) {
                 Ok(cache) => manage_resettable(app, &mut reset_registry, "cache", cache),
-                Err(e) => log::warn!("[setup] pipeline cache failed to open (non-fatal): {e}"),
+                Err(e) => log::warn!(
+                    "[setup] pipeline cache failed to open (non-fatal): {}",
+                    e.code()
+                ),
             }
             // Cross-board dedup verdict store (ADR-029): the durable "not a
             // duplicate" pair tombstones. Registered LAST so its label sits at the
@@ -829,7 +866,10 @@ pub fn run() {
             // assertion below pins. Holds only opaque canonical-key pairs.
             match dedup::DedupStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "dedup_tombstones", store),
-                Err(e) => log::warn!("[setup] dedup store failed to open (non-fatal): {e}"),
+                Err(e) => log::warn!(
+                    "[setup] dedup store failed to open (non-fatal): {}",
+                    e.code()
+                ),
             }
             // Passively-harvested ATS company slugs (ADR-030): the slug typeahead +
             // watched-company autopilot targets. Holds only public ATS slugs +
@@ -839,7 +879,10 @@ pub fn run() {
                 Ok(store) => {
                     manage_resettable(app, &mut reset_registry, "discovered_companies", store)
                 }
-                Err(e) => log::warn!("[setup] discovered store failed to open (non-fatal): {e}"),
+                Err(e) => log::warn!(
+                    "[setup] discovered store failed to open (non-fatal): {}",
+                    e.code()
+                ),
             }
             // Pipeline/agent run history + per-stage event trail. Its own DB
             // (`pipeline_runs.db`); retention is newest-3-per-job, pruned on the
@@ -847,7 +890,10 @@ pub fn run() {
             // last, so its label sits at the tail of `MANAGE_RESETTABLE_LABELS`.
             match pipeline::runs::PipelineRunStore::open(&data_dir) {
                 Ok(store) => manage_resettable(app, &mut reset_registry, "pipeline_runs", store),
-                Err(e) => log::warn!("[setup] pipeline run store failed to open (non-fatal): {e}"),
+                Err(e) => log::warn!(
+                    "[setup] pipeline run store failed to open (non-fatal): {}",
+                    e.code()
+                ),
             }
             // Per-board reliability history (Track B1): ONE row per board, folded
             // from every run's `BoardScrapeSummary`, so a chip can tell "found
@@ -919,7 +965,10 @@ pub fn run() {
 
             // Build system tray.
             if let Err(e) = tray::build(handle) {
-                log::warn!("[setup] tray build error (non-fatal): {e}");
+                log::warn!(
+                    "[setup] tray build error (non-fatal): {}",
+                    sanitize_reason(&e.to_string())
+                );
             }
 
             // Schedule background update checks (10 s after launch, then every 4 h).

--- a/apps/desktop/src-tauri/src/notifications/mod.rs
+++ b/apps/desktop/src-tauri/src/notifications/mod.rs
@@ -222,7 +222,10 @@ impl NotificationStore {
         match serde_json::to_string_pretty(&notifications) {
             Ok(json) => {
                 if let Err(e) = std::fs::write(&self.data_file, &json) {
-                    log::warn!("failed to persist notifications to disk: {e}");
+                    log::warn!(
+                        "failed to persist notifications to disk: {}",
+                        crate::observability::sanitize_reason(&e.to_string())
+                    );
                 }
             }
             Err(e) => log::warn!("failed to serialize notifications: {e}"),

--- a/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
+++ b/apps/desktop/src-tauri/src/pipeline/runs/mod.rs
@@ -64,6 +64,7 @@ use serde::{Deserialize, Serialize};
 use crate::data_store::DataStore;
 use crate::db::{run_migrations, ts_from_db, ts_to_db, Migration};
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 /// Byte cap on ONE event's `artifact_json`, MARKER INCLUDED.
 ///
@@ -431,7 +432,10 @@ fn normalize_existing_job_urls(conn: &Connection) {
             "UPDATE pipeline_runs SET job_url = ?1 WHERE id = ?2",
             params![normalized, id],
         ) {
-            log::warn!("[pipeline] could not normalize a legacy run's job_url: {e}");
+            log::warn!(
+                "[pipeline] could not normalize a legacy run's job_url: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
     }
 }
@@ -599,7 +603,10 @@ impl PipelineRunStore {
         let tx = match guard.transaction() {
             Ok(tx) => tx,
             Err(e) => {
-                log::warn!("[pipeline] run-store prune could not open a transaction: {e}");
+                log::warn!(
+                    "[pipeline] run-store prune could not open a transaction: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 span.end(false);
                 return;
             }
@@ -623,7 +630,10 @@ impl PipelineRunStore {
             Ok(runs) => runs,
             Err(e) => {
                 // Return WITHOUT committing: dropping `tx` rolls back.
-                log::warn!("[pipeline] run-store prune failed, leaving history intact: {e}");
+                log::warn!(
+                    "[pipeline] run-store prune failed, leaving history intact: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 span.end(false);
                 return;
             }
@@ -644,7 +654,10 @@ impl PipelineRunStore {
         ) {
             Ok(events) => events,
             Err(e) => {
-                log::warn!("[pipeline] run-store orphan sweep failed, leaving history intact: {e}");
+                log::warn!(
+                    "[pipeline] run-store orphan sweep failed, leaving history intact: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 span.end(false);
                 return;
             }
@@ -652,7 +665,10 @@ impl PipelineRunStore {
         match tx.commit() {
             Ok(()) => span.end_with(&format!("runs={evicted} events={orphans}"), true),
             Err(e) => {
-                log::warn!("[pipeline] run-store prune could not commit: {e}");
+                log::warn!(
+                    "[pipeline] run-store prune could not commit: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 span.end(false);
             }
         }
@@ -674,10 +690,16 @@ impl PipelineRunStore {
     pub fn clear_all(&self) {
         let conn = self.conn.lock();
         if let Err(e) = conn.execute("DELETE FROM pipeline_run_events", []) {
-            log::warn!("[pipeline] factory reset failed to clear pipeline_run_events: {e}");
+            log::warn!(
+                "[pipeline] factory reset failed to clear pipeline_run_events: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
         if let Err(e) = conn.execute("DELETE FROM pipeline_runs", []) {
-            log::warn!("[pipeline] factory reset failed to clear pipeline_runs: {e}");
+            log::warn!(
+                "[pipeline] factory reset failed to clear pipeline_runs: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
     }
 
@@ -736,7 +758,10 @@ impl PipelineRunStore {
         let tx = match guard.transaction() {
             Ok(tx) => tx,
             Err(e) => {
-                log::warn!("[pipeline] could not open a transaction to delete a job's runs: {e}");
+                log::warn!(
+                    "[pipeline] could not open a transaction to delete a job's runs: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 span.end(false);
                 return 0;
             }
@@ -758,7 +783,10 @@ impl PipelineRunStore {
                 ),
                 rusqlite::params_from_iter(chunk.iter()),
             ) {
-                log::warn!("[pipeline] could not delete a job's run events: {e}");
+                log::warn!(
+                    "[pipeline] could not delete a job's run events: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 span.end(false);
                 return 0; // dropping `tx` rolls the whole thing back
             }
@@ -768,7 +796,10 @@ impl PipelineRunStore {
             ) {
                 Ok(rows) => removed += rows,
                 Err(e) => {
-                    log::warn!("[pipeline] could not delete a job's run rows: {e}");
+                    log::warn!(
+                        "[pipeline] could not delete a job's run rows: {}",
+                        sanitize_reason(&e.to_string())
+                    );
                     span.end(false);
                     return 0;
                 }
@@ -780,7 +811,10 @@ impl PipelineRunStore {
                 removed
             }
             Err(e) => {
-                log::warn!("[pipeline] could not commit a job's run deletion: {e}");
+                log::warn!(
+                    "[pipeline] could not commit a job's run deletion: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 span.end(false);
                 0
             }
@@ -803,7 +837,10 @@ impl PipelineRunStore {
         ) {
             Ok(rows) => rows,
             Err(e) => {
-                log::warn!("[pipeline] could not sweep an abandoned run's events: {e}");
+                log::warn!(
+                    "[pipeline] could not sweep an abandoned run's events: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 0
             }
         }
@@ -973,7 +1010,10 @@ fn query_runs(conn: &Connection, sql: &str, args: impl rusqlite::Params) -> Vec<
     }) {
         Ok(rows) => rows,
         Err(e) => {
-            log::warn!("[pipeline] run-store read failed, reporting no runs: {e}");
+            log::warn!(
+                "[pipeline] run-store read failed, reporting no runs: {}",
+                sanitize_reason(&e.to_string())
+            );
             Vec::new()
         }
     }
@@ -986,7 +1026,10 @@ fn query_events(conn: &Connection, sql: &str, args: impl rusqlite::Params) -> Ve
     }) {
         Ok(rows) => rows,
         Err(e) => {
-            log::warn!("[pipeline] run-store event read failed, reporting none: {e}");
+            log::warn!(
+                "[pipeline] run-store event read failed, reporting none: {}",
+                sanitize_reason(&e.to_string())
+            );
             Vec::new()
         }
     }

--- a/apps/desktop/src-tauri/src/platform/accent_watcher.rs
+++ b/apps/desktop/src-tauri/src/platform/accent_watcher.rs
@@ -74,7 +74,10 @@ pub fn start(app: &AppHandle) {
     let settings = match UISettings::new() {
         Ok(s) => s,
         Err(e) => {
-            log::warn!("[accent-watcher] UISettings unavailable; live accent disabled: {e}");
+            log::warn!(
+                "[accent-watcher] UISettings unavailable; live accent disabled: {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
             return;
         }
     };
@@ -99,7 +102,10 @@ pub fn start(app: &AppHandle) {
             });
         }
         Err(e) => {
-            log::warn!("[accent-watcher] ColorValuesChanged subscribe failed: {e}");
+            log::warn!(
+                "[accent-watcher] ColorValuesChanged subscribe failed: {}",
+                crate::observability::sanitize_reason(&e.to_string())
+            );
         }
     }
 }

--- a/apps/desktop/src-tauri/src/postings/mod.rs
+++ b/apps/desktop/src-tauri/src/postings/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::commands::ai_provider::EmbeddingVector;
+use crate::observability::sanitize_reason;
 
 // ── PostingsCache ─────────────────────────────────────────────────────────────
 
@@ -435,18 +436,20 @@ impl InteractionStore {
         let tmp = self.data_file.with_extension("json.tmp");
         if let Err(e) = std::fs::write(&tmp, &json) {
             log::error!(
-                "[postings] failed to write {}: {e} — interaction NOT persisted",
-                file_name_label(&tmp)
+                "[postings] failed to write {}: {} — interaction NOT persisted",
+                file_name_label(&tmp),
+                sanitize_reason(&e.to_string())
             );
             std::fs::remove_file(&tmp).ok();
             return;
         }
         if let Err(e) = std::fs::rename(&tmp, &self.data_file) {
             log::error!(
-                "[postings] failed to move {} onto {}: {e} — interaction NOT persisted \
+                "[postings] failed to move {} onto {}: {} — interaction NOT persisted \
                  (the previous file is intact)",
                 file_name_label(&tmp),
-                file_name_label(&self.data_file)
+                file_name_label(&self.data_file),
+                sanitize_reason(&e.to_string())
             );
             std::fs::remove_file(&tmp).ok();
         }

--- a/apps/desktop/src-tauri/src/reminder_scheduler.rs
+++ b/apps/desktop/src-tauri/src/reminder_scheduler.rs
@@ -26,6 +26,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::applications::{ApplicationStore, FollowUpCandidate};
 use crate::db::now_ms;
+use crate::observability::sanitize_reason;
 
 /// How often the sweep runs. A follow-up reminder is a day-grained thing, so a
 /// coarse tick is plenty and keeps the app idle-cheap.
@@ -143,8 +144,9 @@ fn claim_due(store: &ApplicationStore, now: u64) -> Vec<FollowUpCandidate> {
                 }
                 Err(e) => {
                     log::warn!(
-                        "[reminders] could not mark {} notified (skipping): {e}",
-                        c.id
+                        "[reminders] could not mark {} notified (skipping): {}",
+                        c.id,
+                        sanitize_reason(&e.to_string())
                     );
                     false
                 }
@@ -176,7 +178,10 @@ async fn tick(app: &AppHandle) {
         // sweep is idempotent, so dropping this one and retrying next tick is
         // the whole recovery.
         Err(e) => {
-            log::warn!("[reminders] sweep task failed: {e}");
+            log::warn!(
+                "[reminders] sweep task failed: {}",
+                sanitize_reason(&e.to_string())
+            );
             return;
         }
     };

--- a/apps/desktop/src-tauri/src/scraping/board_health/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/board_health/mod.rs
@@ -64,6 +64,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::db::{now_ms, run_migrations, ts_from_db, ts_to_db, Migration};
 use crate::error::{AppError, AppResult};
+use crate::observability::sanitize_reason;
 
 use super::engine::BoardScrapeSummary;
 
@@ -591,7 +592,10 @@ impl BoardHealthStore {
     pub fn clear_all(&self) {
         let conn = self.conn.lock();
         if let Err(e) = conn.execute("DELETE FROM board_health", []) {
-            log::warn!("[board-health] factory reset failed to clear board_health: {e}");
+            log::warn!(
+                "[board-health] factory reset failed to clear board_health: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
     }
 

--- a/apps/desktop/src-tauri/src/scraping/board_login/import.rs
+++ b/apps/desktop/src-tauri/src/scraping/board_login/import.rs
@@ -40,6 +40,7 @@ use anyhow::Result;
 use serde::Serialize;
 
 use super::{get_config, write_auth_status, write_cookies, StoredCookie};
+use crate::observability::sanitize_reason;
 use crate::platform::{detect_chromium_user_data_roots, ChromiumBrowser};
 
 /// Result of an import attempt for a single board. Serializable so the command
@@ -95,8 +96,9 @@ pub fn import_cookies(app_data_dir: &Path, board_id: &str) -> Result<ImportOutco
                 // Per-browser failures are non-fatal: a locked DB we couldn't
                 // copy, a missing Local State key, etc. Log without values.
                 log::debug!(
-                    "[cookie-import] {} root unreadable for {board_id}: {e}",
-                    browser.label()
+                    "[cookie-import] {} root unreadable for {board_id}: {}",
+                    browser.label(),
+                    sanitize_reason(&e.to_string())
                 );
             }
         }
@@ -171,8 +173,9 @@ fn collect_from_root(browser: ChromiumBrowser, root: &Path, board_id: &str) -> R
                 harvest.cookies.extend(rows.cookies);
             }
             Err(e) => log::debug!(
-                "[cookie-import] {} profile read failed for {board_id}: {e}",
-                browser.label()
+                "[cookie-import] {} profile read failed for {board_id}: {}",
+                browser.label(),
+                sanitize_reason(&e.to_string())
             ),
         }
     }

--- a/apps/desktop/src-tauri/src/scraping/board_login/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/board_login/mod.rs
@@ -23,6 +23,8 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::observability::sanitize_reason;
+
 pub const LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
 pub const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -199,7 +201,10 @@ where
     if connected {
         on_status("Login successful, exporting cookies…");
         if let Err(e) = export_cookies(&page, app_data_dir, board_id).await {
-            log::warn!("[board_login] failed to export cookies for {board_id}: {e}");
+            log::warn!(
+                "[board_login] failed to export cookies for {board_id}: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
     } else {
         on_status("Login cancelled or timed out");

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/adzuna.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/adzuna.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use crate::observability::sanitize_reason;
 use crate::scraping::http::{fetch_json, html_to_markdown, FetchOptions};
 use crate::scraping::types::JobPosting;
 
@@ -261,12 +262,18 @@ impl AdzunaProvider {
         Self {
             app_id: crate::credentials::read_credential(&format!("ai:{ADZUNA_APP_ID}"))
                 .unwrap_or_else(|e| {
-                    log::warn!("[aggregator] {ADZUNA_APP_ID} keyring error: {e}");
+                    log::warn!(
+                        "[aggregator] {ADZUNA_APP_ID} keyring error: {}",
+                        sanitize_reason(&e.to_string())
+                    );
                     None
                 }),
             app_key: crate::credentials::read_credential(&format!("ai:{ADZUNA_APP_KEY}"))
                 .unwrap_or_else(|e| {
-                    log::warn!("[aggregator] {ADZUNA_APP_KEY} keyring error: {e}");
+                    log::warn!(
+                        "[aggregator] {ADZUNA_APP_KEY} keyring error: {}",
+                        sanitize_reason(&e.to_string())
+                    );
                     None
                 }),
             note_sink: None,

--- a/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/aggregator/providers.rs
@@ -12,6 +12,7 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
+use crate::observability::sanitize_reason;
 use crate::scraping::http::{fetch_json, html_to_markdown, FetchOptions};
 use crate::scraping::types::JobPosting;
 
@@ -168,7 +169,10 @@ impl JSearchProvider {
         Self {
             api_key: crate::credentials::read_credential(&format!("ai:{JSEARCH_KEY}"))
                 .unwrap_or_else(|e| {
-                    log::warn!("[aggregator] {JSEARCH_KEY} keyring error: {e}");
+                    log::warn!(
+                        "[aggregator] {JSEARCH_KEY} keyring error: {}",
+                        sanitize_reason(&e.to_string())
+                    );
                     None
                 }),
         }
@@ -427,7 +431,10 @@ impl JoobleProvider {
         Self {
             api_key: crate::credentials::read_credential(&format!("ai:{JOOBLE_KEY}"))
                 .unwrap_or_else(|e| {
-                    log::warn!("[aggregator] {JOOBLE_KEY} keyring error: {e}");
+                    log::warn!(
+                        "[aggregator] {JOOBLE_KEY} keyring error: {}",
+                        sanitize_reason(&e.to_string())
+                    );
                     None
                 }),
         }
@@ -774,7 +781,10 @@ impl ApifyLinkedInProvider {
         use crate::ipc_contracts::provider_slots::APIFY_TOKEN;
         let token = crate::credentials::read_credential(&format!("ai:{APIFY_TOKEN}"))
             .unwrap_or_else(|e| {
-                log::warn!("[aggregator] {APIFY_TOKEN} keyring error: {e}");
+                log::warn!(
+                    "[aggregator] {APIFY_TOKEN} keyring error: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 None
             });
         let settings = read_aggregator_settings();

--- a/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/comeet/mod.rs
@@ -27,6 +27,7 @@ use super::super::types::{
     AuthRequirement, BoardSearchInput, JobPosting, ScrapeContext, Scraper, ScraperMode,
 };
 use super::common::matches_filters;
+use crate::observability::sanitize_reason;
 use async_trait::async_trait;
 use serde::Deserialize;
 
@@ -217,13 +218,19 @@ impl Scraper for ComeetScraper {
 
         let company_uid = crate::credentials::read_credential(&format!("ai:{COMEET_COMPANY_UID}"))
             .unwrap_or_else(|e| {
-                log::warn!("[comeet] {COMEET_COMPANY_UID} keyring error: {e}");
+                log::warn!(
+                    "[comeet] {COMEET_COMPANY_UID} keyring error: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 None
             })
             .filter(|s| !s.trim().is_empty());
         let token = crate::credentials::read_credential(&format!("ai:{COMEET_API_TOKEN}"))
             .unwrap_or_else(|e| {
-                log::warn!("[comeet] {COMEET_API_TOKEN} keyring error: {e}");
+                log::warn!(
+                    "[comeet] {COMEET_API_TOKEN} keyring error: {}",
+                    sanitize_reason(&e.to_string())
+                );
                 None
             })
             .filter(|s| !s.trim().is_empty());

--- a/apps/desktop/src-tauri/src/scraping/boards/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/mod.rs
@@ -154,32 +154,4 @@ mod registry_parity {
             "the two lists must have the same length, not merely overlap"
         );
     }
-
-    /// Every registered board must run in `Http` mode, because a log-leak
-    /// exemption depends on it.
-    ///
-    /// `scripts/check-log-error-leaks.mjs` declares `autopilot_helpers`'
-    /// scrape-failure log safe, and that reasoning runs three hops:
-    /// the error comes from `engine::run_boards`, which reaches every board
-    /// through `scraping::http::fetch_text`/`fetch_json`, whose transport-error
-    /// branch already calls `reqwest::Error::without_url()`. That last hop only
-    /// holds while no board takes the `Browser` arm — and nothing enforced it,
-    /// so the first browser-mode scraper would silently re-open a URL leak that
-    /// a reviewer had already signed off as impossible.
-    ///
-    /// If this fails, the new board is not the bug: re-triage that allowlist
-    /// entry, then decide.
-    #[test]
-    fn every_board_runs_through_the_http_chokepoint() {
-        let browser: Vec<&str> = super::SCRAPERS
-            .iter()
-            .filter(|s| s.mode() != crate::scraping::types::ScraperMode::Http)
-            .map(|s| s.id())
-            .collect();
-        assert!(
-            browser.is_empty(),
-            "these boards no longer run through the HTTP chokepoint, so the \
-             log-leak exemption for autopilot_helpers is no longer sound: {browser:?}"
-        );
-    }
 }

--- a/apps/desktop/src-tauri/src/scraping/boards/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/boards/mod.rs
@@ -154,4 +154,32 @@ mod registry_parity {
             "the two lists must have the same length, not merely overlap"
         );
     }
+
+    /// Every registered board must run in `Http` mode, because a log-leak
+    /// exemption depends on it.
+    ///
+    /// `scripts/check-log-error-leaks.mjs` declares `autopilot_helpers`'
+    /// scrape-failure log safe, and that reasoning runs three hops:
+    /// the error comes from `engine::run_boards`, which reaches every board
+    /// through `scraping::http::fetch_text`/`fetch_json`, whose transport-error
+    /// branch already calls `reqwest::Error::without_url()`. That last hop only
+    /// holds while no board takes the `Browser` arm — and nothing enforced it,
+    /// so the first browser-mode scraper would silently re-open a URL leak that
+    /// a reviewer had already signed off as impossible.
+    ///
+    /// If this fails, the new board is not the bug: re-triage that allowlist
+    /// entry, then decide.
+    #[test]
+    fn every_board_runs_through_the_http_chokepoint() {
+        let browser: Vec<&str> = super::SCRAPERS
+            .iter()
+            .filter(|s| s.mode() != crate::scraping::types::ScraperMode::Http)
+            .map(|s| s.id())
+            .collect();
+        assert!(
+            browser.is_empty(),
+            "these boards no longer run through the HTTP chokepoint, so the \
+             log-leak exemption for autopilot_helpers is no longer sound: {browser:?}"
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/scraping/http/test.rs
+++ b/apps/desktop/src-tauri/src/scraping/http/test.rs
@@ -647,13 +647,20 @@ async fn fetch_text_transport_error_does_not_leak_query_secret() {
         url,
         FetchOptions {
             retries: 0,
+            // Port 9 (discard) is refused instantly on Unix, but Windows lets the
+            // connect attempt sit until its own timeout — which added over a minute
+            // to every `cargo test` run on this platform. The ceiling makes the test
+            // bounded everywhere without weakening it: a refused connection still
+            // fails fast, a hung one fails at 500ms, and BOTH are the transport
+            // errors whose `Display` must not carry the query string.
+            timeout: Some(Duration::from_millis(500)),
             ..Default::default()
         },
         signal,
     )
     .await;
 
-    let err = result.expect_err("connection to a refusing port must fail");
+    let err = result.expect_err("an unreachable port must fail");
     let msg = err.to_string();
     assert!(
         !msg.contains("SECRET"),

--- a/apps/desktop/src-tauri/src/scraping/linkedin/api_client/mod.rs
+++ b/apps/desktop/src-tauri/src/scraping/linkedin/api_client/mod.rs
@@ -1,5 +1,6 @@
 use super::client::LinkedInHttpClient;
 use super::session::LinkedInSessionData;
+use crate::observability::sanitize_reason;
 use crate::scraping::types::JobPosting;
 use anyhow::Result;
 use scraper::Html;
@@ -353,7 +354,8 @@ impl LinkedInJobsApiClient {
                 // A later page failed → keep the pages we already have (and streamed).
                 Err(e) => {
                     log::warn!(
-                        "[linkedin] page {page} failed: {e}; returning {} collected",
+                        "[linkedin] page {page} failed: {}; returning {} collected",
+                        sanitize_reason(&e.to_string()),
                         all_jobs.len()
                     );
                     break;

--- a/apps/desktop/src-tauri/src/spend/mod.rs
+++ b/apps/desktop/src-tauri/src/spend/mod.rs
@@ -48,6 +48,7 @@ use uuid::Uuid;
 use crate::data_store::DataStore;
 use crate::db::{now_ms, run_migrations, ts_from_db, ts_to_db, Migration};
 use crate::error::AppResult;
+use crate::observability::sanitize_reason;
 
 /// One persisted call's real usage + estimated cost (the `DataStore::export`
 /// shape).
@@ -223,7 +224,10 @@ impl SpendStore {
                 rec.run_id,
             ],
         ) {
-            log::warn!("spend: failed to record row: {e}");
+            log::warn!(
+                "spend: failed to record row: {}",
+                sanitize_reason(&e.to_string())
+            );
         }
     }
 

--- a/apps/desktop/src-tauri/src/updater/mod.rs
+++ b/apps/desktop/src-tauri/src/updater/mod.rs
@@ -37,12 +37,27 @@ pub struct UpdaterState {
     pub pending_version: Option<String>,
     /// Raw bytes from the last successful download.
     pub downloaded_bytes: Option<Vec<u8>>,
+    /// Set for the lifetime of one `updater_download` call (cleared by
+    /// [`DownloadGuard`] on every exit path, including a panic). Lets
+    /// `updater_check`/`updater_download` recognize "a transfer is already
+    /// running" without polling the update plugin — the single re-entrancy
+    /// flag both commands share.
+    pub downloading: bool,
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn emit_status(app: &AppHandle, status: Value) {
     emit_event(app, UPDATER_STATUS, status);
+}
+
+/// Whether a download for the pending update has already finished or is
+/// still running — the single predicate both `updater_check` (don't discard
+/// it) and `updater_download` (don't start a second one) key their guard on.
+/// Split out so it is testable against a plain [`UpdaterState`], without a
+/// live `AppHandle` (this crate has no `tauri::test` mock-app harness).
+fn download_in_progress_or_done(state: &UpdaterState) -> bool {
+    state.downloading || state.downloaded_bytes.is_some()
 }
 
 // ── Commands ──────────────────────────────────────────────────────────────────
@@ -52,6 +67,30 @@ fn emit_status(app: &AppHandle, status: Value) {
 /// Stores the Update object for use by updater_download.
 #[tauri::command]
 pub async fn updater_check(app: AppHandle) -> Value {
+    // A finished or in-flight download must never be thrown away by a fresh
+    // check. `check()` below unconditionally replaces `pending_update` and
+    // resets `downloaded_bytes` to `None` on success — correct the FIRST
+    // time, but a returning caller (a remounted route, or a stale "Check now"
+    // button rendered over work that is already running) would otherwise
+    // discard an already-downloaded release — forcing a full re-download —
+    // or swap the `Update` object out from under a transfer still in flight.
+    // Report the state that is already known instead of re-fetching: the
+    // caller wants to re-attach, not restart.
+    {
+        let state = app.state::<Mutex<UpdaterState>>();
+        let guard = state.lock();
+        if let Some(version) = guard.pending_version.clone() {
+            if download_in_progress_or_done(&guard) {
+                return json!({
+                    "available": true,
+                    "version": version,
+                    "downloaded": guard.downloaded_bytes.is_some(),
+                    "downloading": guard.downloading,
+                });
+            }
+        }
+    }
+
     emit_status(&app, json!({ "state": "checking" }));
 
     let updater = match app.updater() {
@@ -101,19 +140,56 @@ pub async fn updater_check(app: AppHandle) -> Value {
     }
 }
 
+/// Clears [`UpdaterState::downloading`] when it drops — on the success
+/// return, the error return, OR a panic unwind mid-transfer — so a download
+/// that dies partway through can never leave the flag stuck `true` and
+/// permanently refuse every future `updater_download` call.
+struct DownloadGuard(AppHandle);
+
+impl Drop for DownloadGuard {
+    fn drop(&mut self) {
+        if let Some(state) = self.0.try_state::<Mutex<UpdaterState>>() {
+            state.lock().downloading = false;
+        }
+    }
+}
+
 /// Download the pending update with progress events.
 /// Uses the Update object stored by updater_check — no re-fetch.
 /// Emits downloading(percent) → downloaded(version) | error.
+///
+/// Not re-entrant: a second call while one is already in flight (or one
+/// already finished) refuses rather than starting a second transfer of the
+/// same release — progress/completion is broadcast on `updater:status` to
+/// every listener regardless of which call started the download, so a
+/// second caller has nothing useful to do but wait.
 #[tauri::command]
 pub async fn updater_download(app: AppHandle) -> Value {
     let (update, version) = {
         let state = app.state::<Mutex<UpdaterState>>();
-        let guard = state.lock();
+        let mut guard = state.lock();
         match (guard.pending_update.clone(), guard.pending_version.clone()) {
-            (Some(u), Some(v)) => (u, v),
+            (Some(u), Some(v)) => {
+                // Checked and claimed under the SAME lock as the reads above,
+                // so two concurrent calls can't both observe "not downloading"
+                // before either sets the flag — the check-then-act race
+                // `job_start_exclusive` closes for jobs; this is the
+                // updater's version of the same fix, over a plain bool
+                // instead of the job tracker.
+                if download_in_progress_or_done(&guard) {
+                    return json!({
+                        "version": v,
+                        "downloaded": guard.downloaded_bytes.is_some(),
+                        "downloading": guard.downloading,
+                    });
+                }
+                guard.downloading = true;
+                (u, v)
+            }
             _ => return json!({ "error": "no pending update — call updater_check first" }),
         }
     };
+    let _guard = DownloadGuard(app.clone());
 
     let app_clone = app.clone();
     let bytes = update

--- a/apps/desktop/src-tauri/src/updater/test.rs
+++ b/apps/desktop/src-tauri/src/updater/test.rs
@@ -114,6 +114,44 @@ fn test_updater_state_bytes_replace() {
     assert_eq!(state.downloaded_bytes, Some(vec![4, 5, 6]));
 }
 
+// ── download_in_progress_or_done: the guard `updater_check` (don't discard)
+// and `updater_download` (don't start a second transfer) both key on ────────
+
+#[test]
+fn test_download_in_progress_or_done_false_when_untouched() {
+    assert!(!download_in_progress_or_done(&UpdaterState::default()));
+}
+
+#[test]
+fn test_download_in_progress_or_done_true_while_downloading() {
+    let state = UpdaterState {
+        downloading: true,
+        ..UpdaterState::default()
+    };
+    assert!(download_in_progress_or_done(&state));
+}
+
+#[test]
+fn test_download_in_progress_or_done_true_once_downloaded() {
+    let state = UpdaterState {
+        downloaded_bytes: Some(vec![1, 2, 3]),
+        ..UpdaterState::default()
+    };
+    assert!(download_in_progress_or_done(&state));
+}
+
+#[test]
+fn test_download_in_progress_or_done_false_after_bytes_taken() {
+    // Mirrors `updater_install`'s `downloaded_bytes.take()` on success — once
+    // consumed, a fresh check/download must be allowed again.
+    let mut state = UpdaterState {
+        downloaded_bytes: Some(vec![1]),
+        ..UpdaterState::default()
+    };
+    state.downloaded_bytes.take();
+    assert!(!download_in_progress_or_done(&state));
+}
+
 // ── Changelog parsing ────────────────────────────────────────────────────────
 
 /// `major.minor.patch` as a tuple for order comparisons in tests only — not a

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.test.ts
@@ -6,9 +6,10 @@
  * real hook to verify that such a resolution routes to the error state — the
  * SAME state the reject path uses — rather than being treated as 'done'.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from '@testing-library/react';
 
+import { useSessionStore } from '@/store/session-store';
 import { renderHookWithClient } from '@/test-support';
 
 // ---------------------------------------------------------------------------
@@ -53,6 +54,13 @@ import { useAutopilotRun } from './useAutopilotRun';
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+// The error banner now lives in the (real, unmocked) session store instead of
+// a local `useState`, so it survives across a test unless reset — mirrors
+// `AutopilotPage.focus.test.tsx`'s own store reset.
+beforeEach(() => {
+  useSessionStore.setState((s) => ({ autopilot: { ...s.autopilot, error: null } }));
+});
 
 describe('useAutopilotRun — handleRun error-payload handling', () => {
   it('routes a resolved { error } payload to the error state, not done', async () => {
@@ -265,5 +273,31 @@ describe('useAutopilotRun — steps for a run this mount did not start', () => {
 
     expect(invalidateAutopilots).toHaveBeenCalledTimes(1);
     expect(result.current.runStates['ap-cancel']).toBe('cancelled');
+  });
+});
+
+/**
+ * The refusal case has no OTHER trace at all: unlike a genuine failure (which
+ * at least leaves `runStatus: 'failed'` on the persisted record), "a run is
+ * already in progress" is never written anywhere backend-side — the banner
+ * IS the only record of it, so it must outlive an unmount on its own.
+ */
+describe('useAutopilotRun — the error banner survives navigation', () => {
+  it('keeps the "already running" refusal visible after this mount is discarded and a fresh one takes its place', async () => {
+    runMutateAsync.mockResolvedValueOnce({ skipped: 'already-running' });
+    const { result, unmount } = renderHookWithClient(() => useAutopilotRun());
+
+    await act(async () => {
+      await result.current.handleRun('ap-nav');
+    });
+    expect(result.current.error).toBe('autopilot.wizard.alreadyRunning');
+
+    // Simulates navigating away from AutopilotPage (this hook — reducers
+    // included — is discarded) and back (a brand-new call, exactly like a
+    // fresh route mount).
+    unmount();
+    const remounted = renderHookWithClient(() => useAutopilotRun());
+
+    expect(remounted.result.current.error).toBe('autopilot.wizard.alreadyRunning');
   });
 });

--- a/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
+++ b/apps/desktop/src/renderer/features/autopilot/hooks/useAutopilotRun.ts
@@ -1,4 +1,4 @@
-import { useCallback, useReducer, useState } from 'react';
+import { useCallback, useReducer } from 'react';
 
 import type { Autopilot, AutopilotStepEvent } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
@@ -14,6 +14,7 @@ import {
   useResumeAutopilot,
   useRunAutopilot,
 } from '@/services';
+import { useSessionStore } from '@/store/session-store';
 
 /**
  * A reducer patch: the fields to merge, or a function of the CURRENT state that
@@ -38,7 +39,18 @@ export function useAutopilotRun() {
       ({ ...prev, ...(typeof patch === 'function' ? patch(prev) : patch) }) as StepLogMap,
     {} as StepLogMap
   );
-  const [error, setError] = useState<string | null>(null);
+  // The Run/Apply banner survives navigation via the session store rather than
+  // a local `useState` — this hook (and its subscription) is re-created from
+  // scratch on every `AutopilotPage` mount, so a local `useState` discarded
+  // the banner on any navigate-away-and-back. See `AutopilotSlice.error`'s
+  // doc comment for why that matters most for the concurrent-run refusal,
+  // which leaves no OTHER trace at all.
+  const error = useSessionStore((s) => s.autopilot.error);
+  const setAutopilot = useSessionStore((s) => s.setAutopilot);
+  const setError = useCallback(
+    (message: string | null) => setAutopilot({ error: message }),
+    [setAutopilot]
+  );
 
   const runAutopilot = useRunAutopilot();
   const pauseAutopilot = usePauseAutopilot();
@@ -74,11 +86,18 @@ export function useAutopilotRun() {
         ],
       }));
       // A run that ENDS is the only moment the persisted record changes, and the
-      // `runAutopilot` mutation's own invalidation only fires for a run this mount
-      // started and stayed mounted for. Refresh here so a run that finished while
-      // the user was on another page — and a scheduled run nobody clicked — lands
-      // its found jobs and its `runStatus` on the card instead of waiting for the
-      // next navigation.
+      // `runAutopilot` mutation's own invalidation only fires for a run this
+      // mount started and stayed mounted for. Refresh here so a SCHEDULED run
+      // nobody clicked — the other case with no mutation watching it — lands
+      // its found jobs and its `runStatus` on the card right away instead of
+      // waiting for something unrelated to refetch.
+      //
+      // Does NOT cover a run that finished while the user was on another
+      // page: `useAutopilotStepEvents` unsubscribes in this hook's own effect
+      // cleanup, so no step event reaches this handler while unmounted,
+      // scheduled run or not. What actually recovers THAT case is
+      // `useAutopilots`'s own staleness-triggered refetch on the next
+      // `AutopilotPage` mount (see its doc comment).
       if (event.step === 'complete' || event.step === 'cancelled') invalidateAutopilots();
     },
     [invalidateAutopilots]

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
@@ -22,6 +22,7 @@ const mutateAsync = vi.fn().mockResolvedValue({ jobId: 'j1' });
 const cancelMutateAsync = vi.fn().mockResolvedValue(undefined);
 /** Job-tracker poll used by the watchdog; defaults to a still-running job. */
 const fetchJobMock = vi.fn().mockResolvedValue({ status: 'running' });
+const invalidatePostingsMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/services', async (importActual) => {
   const actual = await importActual<Record<string, unknown>>();
@@ -31,7 +32,7 @@ vi.mock('@/services', async (importActual) => {
     useCancelJob: () => ({ mutateAsync: cancelMutateAsync }),
     fetchJob: (jobId: string) => fetchJobMock(jobId),
     useScrapeProgress: () => null,
-    useInvalidatePostings: () => vi.fn().mockResolvedValue(undefined),
+    useInvalidatePostings: () => invalidatePostingsMock,
   };
 });
 
@@ -85,6 +86,7 @@ beforeEach(() => {
   mutateAsync.mockClear().mockResolvedValue({ jobId: 'j1' });
   cancelMutateAsync.mockClear().mockResolvedValue(undefined);
   fetchJobMock.mockClear().mockResolvedValue({ status: 'running' });
+  invalidatePostingsMock.mockClear().mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -402,5 +404,88 @@ describe('useScraping — progress survives a route change', () => {
     });
 
     expect(second.result.current.scrapeProgress).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 5 — a scrape that fails while the user is on another route must come
+// back with an explanation (chip strip + note), not silently to an empty
+// strip — and the backend error must be sanitized the same way the live
+// `job.failed` event path already is (path-privacy: AGENTS.md).
+// ---------------------------------------------------------------------------
+
+describe('useScraping — a failed scrape explains itself after a route change', () => {
+  it('restores scrapeSummaries/scrapeFailureNote, sanitized, after failing off-page', async () => {
+    fetchJobMock.mockResolvedValue({ status: 'running' });
+    const form = makeForm();
+
+    const first = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    first.unmount();
+
+    // The job fails only now, while nothing is mounted to hear the event —
+    // and the backend error carries a local path, same as a real filesystem
+    // failure would.
+    fetchJobMock.mockResolvedValue({
+      status: 'failed',
+      error: 'failed to read C:\\Users\\alice\\creds.json',
+    });
+    vi.useFakeTimers();
+    try {
+      const second = renderHookWithClient(() => useScraping(noopNotify, form));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+
+      expect(second.result.current.scraping).toBe(false);
+      const { scrapeSummaries, scrapeFailureNote, scrapeOutcome } = useSessionStore.getState().jobs;
+      // An empty (not stale/undefined) strip — the caller renders it whenever
+      // the array is non-null, so `[]` is what makes the note actually show.
+      expect(scrapeSummaries).toEqual([]);
+      expect(scrapeFailureNote).toContain('failed to read');
+      expect(scrapeFailureNote).toContain('<path-redacted>');
+      expect(scrapeFailureNote).not.toMatch(/alice/i);
+      // The drawer's own outcome note (`ScrapeForm`) must be the SAME sanitized
+      // text, not the raw backend string — reopening "New Scrape" later must
+      // never show the path either.
+      expect(scrapeOutcome?.note).toBe(scrapeFailureNote);
+      expect(scrapeOutcome?.note).not.toMatch(/alice/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 6 — the watchdog's own completion recovery must invalidate the
+// postings cache exactly like the live `job.completed` event handler does, or
+// a 30s `staleTime` leaves the pre-scrape (possibly empty) list on screen.
+// ---------------------------------------------------------------------------
+
+describe('useScraping — completing off-page still refreshes the postings cache', () => {
+  it('invalidates postings after the watchdog recovers a completed scrape', async () => {
+    fetchJobMock.mockResolvedValue({ status: 'running' });
+    const form = makeForm();
+
+    const first = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    first.unmount();
+
+    fetchJobMock.mockResolvedValue({ status: 'completed', result: { boards: [] } });
+    vi.useFakeTimers();
+    try {
+      renderHookWithClient(() => useScraping(noopNotify, form));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+
+      expect(invalidatePostingsMock).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.test.ts
@@ -290,7 +290,10 @@ describe('useScraping — the in-flight job survives a route change', () => {
   });
 
   it('a remount onto a job that already FINISHED settles to a finished state', async () => {
-    fetchJobMock.mockResolvedValue({ status: 'completed', result: { boards: [] } });
+    // Still running while `first` is mounted — the leading watchdog poll (see
+    // the progress-fallback tests below) must not settle it before the page
+    // ever navigates away, or this test would stop exercising the remount path.
+    fetchJobMock.mockResolvedValue({ status: 'running' });
     vi.useFakeTimers();
     try {
       const form = makeForm();
@@ -299,6 +302,9 @@ describe('useScraping — the in-flight job survives a route change', () => {
         await first.result.current.startScrape();
       });
       first.unmount();
+
+      // The job finishes only now, while nothing is mounted to hear the event.
+      fetchJobMock.mockResolvedValue({ status: 'completed', result: { boards: [] } });
 
       // The job.completed EVENT is never delivered — the subscription lives on
       // the unmounted page. Only the watchdog can reconcile this.
@@ -346,5 +352,55 @@ describe('useScraping — per-board diagnostics survive', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect 4 — a remount mid-scrape must not report a false 0% for the rest of
+// the run. `useScrapeProgress` (mocked here to `null`, matching the real hook
+// resetting on every mount) never fires again on the single-board default, so
+// the persisted `JobRecord.progress` the watchdog already polls is the only
+// surviving source of truth.
+// ---------------------------------------------------------------------------
+
+describe('useScraping — progress survives a route change', () => {
+  it('reports the backend-persisted fraction immediately after a remount', async () => {
+    fetchJobMock.mockResolvedValue({ status: 'running', progress: 0.8 });
+    const form = makeForm();
+
+    const first = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    first.unmount();
+
+    const second = renderHookWithClient(() => useScraping(noopNotify, form));
+    // The leading (non-timer) poll must resolve before this assertion — flush
+    // the microtask queue without touching fake timers.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(second.result.current.scrapeProgress).toBe(0.8);
+  });
+
+  it('does not fabricate progress when the backend has none yet', async () => {
+    fetchJobMock.mockResolvedValue({ status: 'running' });
+    const form = makeForm();
+
+    const first = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await first.result.current.startScrape();
+    });
+    first.unmount();
+
+    const second = renderHookWithClient(() => useScraping(noopNotify, form));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(second.result.current.scrapeProgress).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
@@ -40,7 +40,18 @@ export function useScraping(
   const cancelJob = useCancelJob();
   // Live boards-done/total fraction (0..1) for the in-flight scrape; null until
   // the first board completes and after the scrape ends (scrapeJobId → null).
-  const scrapeProgress = useScrapeProgress(scrapeJobId);
+  // On the default single-board config the only event fires as the run ends,
+  // and a remount always resets this to null (see `useScrapeProgress`) — so on
+  // its own this stays null for the whole run after a route change.
+  const liveScrapeProgress = useScrapeProgress(scrapeJobId);
+  // Backend-persisted fallback for the gap above. `job_progress` (Rust) writes
+  // the SAME fraction into `JobRecord.progress` that the `scrape:progress`
+  // event carries (commands/scrape.rs) — not a guess, just a durable copy the
+  // watchdog below already fetches. Reset whenever the tracked job changes.
+  const [backendProgress, setBackendProgress] = useState<number | null>(null);
+  // Prefer the live event (lower latency) once one has arrived this mount;
+  // otherwise fall back to the last polled backend value.
+  const scrapeProgress = liveScrapeProgress ?? backendProgress;
 
   const doScrape = async (amount: number, replace: boolean) => {
     const res = (await scrapeBoards.mutateAsync({
@@ -190,14 +201,20 @@ export function useScraping(
   useEffect(() => {
     if (!scrapeJobId) return;
     let cancelled = false;
+    setBackendProgress(null);
     const check = async () => {
       try {
         const job = (await fetchJob(scrapeJobId)) as {
           status?: string;
+          progress?: number;
           error?: string;
           result?: { boards?: BoardScrapeSummary[] };
         } | null;
         if (cancelled || !job?.status) return;
+        // Seed/refresh the fallback used above regardless of terminal status —
+        // a 'failed'/'cancelled' tick still wants the last-known fraction for
+        // the instant before `finishScrape` clears `scrapeJobId`.
+        if (typeof job.progress === 'number') setBackendProgress(job.progress);
         if (job.status === 'completed') {
           // The tracker keeps the same `{ count, boards }` payload the
           // `job.completed` EVENT carries, so a scrape that finished while the
@@ -212,6 +229,10 @@ export function useScraping(
         // Transient — retry on the next tick.
       }
     };
+    // Leading call: without it the first tick was a full 2.5s after mount, so
+    // a remount mid-scrape showed a false 0% for that whole window even though
+    // the backend fraction was available immediately.
+    void check();
     const id = setInterval(() => void check(), 2500);
     return () => {
       cancelled = true;

--- a/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
+++ b/apps/desktop/src/renderer/features/jobs/hooks/useScraping.ts
@@ -1,10 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { BoardScrapeSummary } from '@ajh/shared';
+import { useTranslation } from '@ajh/translations';
 import type { useNotification } from '@ajh/ui';
 
+import { sanitizeReason } from '@/components/scrape/BoardSummaryChips';
 import type { Posting, ScrapeFormState, ScrapeOutcome } from '@/features/jobs/types';
-import { fetchJob, useCancelJob, useScrapeBoards, useScrapeProgress } from '@/services';
+import {
+  fetchJob,
+  useCancelJob,
+  useInvalidatePostings,
+  useScrapeBoards,
+  useScrapeProgress,
+} from '@/services';
 import { useSessionStore } from '@/store/session-store';
 
 export function useScraping(
@@ -36,8 +44,10 @@ export function useScraping(
   // so it stays local.
   const pendingFinishRef = useRef<Map<string, ScrapeOutcome>>(new Map());
 
+  const { t } = useTranslation();
   const scrapeBoards = useScrapeBoards();
   const cancelJob = useCancelJob();
+  const invalidatePostings = useInvalidatePostings();
   // Live boards-done/total fraction (0..1) for the in-flight scrape; null until
   // the first board completes and after the scrape ends (scrapeJobId → null).
   // On the default single-board config the only event fires as the run ends,
@@ -166,15 +176,25 @@ export function useScraping(
    *
    * `summaries` is written under the SAME identity guard (the watchdog recovery
    * path); the event path leaves it undefined because JobsPage owns the
-   * translated per-board strip.
+   * translated per-board strip. `failureNote` rides alongside it so the
+   * watchdog's own failure recovery (below) can restore an explanation the same
+   * way the event path does — omitted (`undefined`), it defaults to clearing
+   * the note, matching the prior always-null behavior for the success case.
    */
   const finishScrape = useCallback(
-    (jobId: string, outcome: ScrapeOutcome, summaries?: BoardScrapeSummary[]) => {
+    (
+      jobId: string,
+      outcome: ScrapeOutcome,
+      summaries?: BoardScrapeSummary[],
+      failureNote?: string | null
+    ) => {
       if (!jobId || jobId !== useSessionStore.getState().jobs.scrapeJobId) return;
       setJobs({
         scrapeJobId: null,
         scrapeOutcome: outcome,
-        ...(summaries ? { scrapeSummaries: summaries, scrapeFailureNote: null } : {}),
+        ...(summaries
+          ? { scrapeSummaries: summaries, scrapeFailureNote: failureNote ?? null }
+          : {}),
       });
       setScraping(false);
     },
@@ -222,9 +242,25 @@ export function useScraping(
           // per-board diagnostics back instead of an unexplained empty result.
           const boards = job.result?.boards;
           finishScrape(scrapeJobId, { ok: true }, Array.isArray(boards) ? boards : undefined);
-        } else if (job.status === 'failed')
-          finishScrape(scrapeJobId, { ok: false, note: job.error ?? undefined });
-        else if (job.status === 'cancelled') finishScrape(scrapeJobId, { ok: false });
+          // The live `job.completed` handler in JobsPage invalidates the
+          // postings cache unconditionally; this recovery path is the only
+          // other place a scrape settles, so it needs the same call — a 30s
+          // `staleTime` otherwise leaves the pre-scrape (possibly empty) list
+          // on screen after navigating back.
+          void invalidatePostings();
+        } else if (job.status === 'failed') {
+          // Sanitize here — this is the ONLY path that writes a raw backend
+          // error into `scrapeOutcome`/`scrapeFailureNote`; the live event
+          // path (JobsPage) already runs `ev.data` through `sanitizeReason`
+          // before it reaches the store, and a raw Rust error can carry a
+          // filesystem path or hostname (AGENTS.md path-privacy rule).
+          const sanitized = sanitizeReason(job.error ?? t('jobs.scrapeFailed'));
+          // Restore the chip strip's explanation the same way the live path
+          // does (`scrapeSummaries: [], scrapeFailureNote: sanitized`) — a
+          // scrape that fails while the user is elsewhere otherwise comes back
+          // to an empty strip with no note at all.
+          finishScrape(scrapeJobId, { ok: false, note: sanitized }, [], sanitized);
+        } else if (job.status === 'cancelled') finishScrape(scrapeJobId, { ok: false });
       } catch {
         // Transient — retry on the next tick.
       }
@@ -238,7 +274,7 @@ export function useScraping(
       cancelled = true;
       clearInterval(id);
     };
-  }, [scrapeJobId, finishScrape]);
+  }, [scrapeJobId, finishScrape, invalidatePostings, t]);
 
   return {
     noteScrapeFinished,

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
@@ -45,6 +45,9 @@ describe('useModelPull — reattach on mount', () => {
     let handler: ((e: unknown) => void) | null = null;
     const client = createMockClient({
       'jobs.list': vi.fn().mockResolvedValue([makeJob()]),
+      // The post-adoption reconcile read: this job is genuinely still
+      // running, so it must be a no-op (state stays 'pulling' below).
+      'jobs.get': vi.fn().mockResolvedValue(makeJob()),
       'jobs.onEvent': vi.fn((h: (e: unknown) => void) => {
         handler = h;
         return () => {};
@@ -87,5 +90,95 @@ describe('useModelPull — reattach on mount', () => {
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(result.current.pullState).toBe('idle');
+  });
+});
+
+// ── Adoption race: a terminal event that arrives before `pullJobId` commits ──
+//
+// PR #1036 review finding: `useJobEvents` compares an incoming event's jobId
+// against `pullJobId`, which is still `null` for the entire IPC round trip
+// `jobs.list()` takes to resolve. `ai.pull_model` fires its ONE
+// job.completed/job.failed the instant the pull ends, so a terminal event
+// landing in that window is dropped for good — and the registry snapshot the
+// reattach effect then adopts was taken BEFORE that completion, so it still
+// reads 'running'. Without a reconcile read right after adopting, the panel
+// is stuck reporting 'pulling' forever for a job that already finished.
+describe('useModelPull — reconciles a stale adoption', () => {
+  it('settles a job that already completed before the registry read resolved', async () => {
+    const jobId = 'job-race-completed';
+    let resolveList: (jobs: unknown[]) => void = () => {};
+    const listPromise = new Promise<unknown[]>((resolve) => {
+      resolveList = resolve;
+    });
+    let handler: ((e: unknown) => void) | null = null;
+
+    const client = createMockClient({
+      'jobs.list': vi.fn().mockReturnValue(listPromise),
+      'jobs.get': vi.fn().mockResolvedValue(makeJob({ id: jobId, status: 'completed' })),
+      'jobs.onEvent': vi.fn((h: (e: unknown) => void) => {
+        handler = h;
+        return () => {};
+      }),
+    });
+
+    const { result } = renderHook(() => useModelPull({ selectedModel: 'llama3' }), {
+      wrapper: withProviders(client),
+    });
+
+    // Fires the ACTUAL ordering the review flagged: the terminal event
+    // arrives while `jobs.list()` is still in flight, so `pullJobId` is
+    // still null and the live listener's identity check drops it.
+    act(() => handler?.({ type: 'job.completed', jobId, data: { model: 'llama3', done: true } }));
+
+    // The registry read resolves with a snapshot taken BEFORE that
+    // completion — still 'running' — so the reattach effect adopts it. The
+    // fix's reconcile read then settles it in the same flush, before this
+    // test ever observes the intermediate 'pulling' state — asserting the
+    // FINAL settled state plus the `jobs.get` call is what actually pins the
+    // fix (an unfixed hook would stay 'pulling' forever instead).
+    await act(async () => {
+      resolveList([makeJob({ id: jobId })]);
+      await listPromise;
+    });
+
+    // No second job.completed is ever coming for this job — only the
+    // reconcile read (`jobs.get`, right after adoption) can notice it
+    // already finished.
+    await waitFor(() => expect(result.current.pullState).toBe('done'));
+    expect(client.jobs.get).toHaveBeenCalledWith(jobId);
+    expect(notifyApi.success).toHaveBeenCalled();
+  });
+
+  it('settles a job that already failed before the registry read resolved', async () => {
+    const jobId = 'job-race-failed';
+    let resolveList: (jobs: unknown[]) => void = () => {};
+    const listPromise = new Promise<unknown[]>((resolve) => {
+      resolveList = resolve;
+    });
+    let handler: ((e: unknown) => void) | null = null;
+
+    const client = createMockClient({
+      'jobs.list': vi.fn().mockReturnValue(listPromise),
+      'jobs.get': vi.fn().mockResolvedValue(makeJob({ id: jobId, status: 'failed' })),
+      'jobs.onEvent': vi.fn((h: (e: unknown) => void) => {
+        handler = h;
+        return () => {};
+      }),
+    });
+
+    const { result } = renderHook(() => useModelPull({ selectedModel: 'llama3' }), {
+      wrapper: withProviders(client),
+    });
+
+    act(() => handler?.({ type: 'job.failed', jobId, data: 'model not found' }));
+
+    await act(async () => {
+      resolveList([makeJob({ id: jobId })]);
+      await listPromise;
+    });
+
+    await waitFor(() => expect(result.current.pullState).toBe('error'));
+    expect(client.jobs.get).toHaveBeenCalledWith(jobId);
+    expect(notifyApi.error).toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
@@ -143,10 +143,15 @@ describe('useModelPull — reconciles a stale adoption', () => {
 
     // No second job.completed is ever coming for this job — only the
     // reconcile read (`jobs.get`, right after adoption) can notice it
-    // already finished.
+    // already finished. Exact counts (not just "was called"): `jobQueue`'s
+    // cached snapshot never refetches inside this test, so an unfixed hook
+    // (PR #1036 review finding) re-adopts the same stale 'running' entry the
+    // instant `resetTracking` clears `pullJobId`, calling `jobs.get` and the
+    // success toast a SECOND time — these pin that regression shut.
     await waitFor(() => expect(result.current.pullState).toBe('done'));
+    expect(client.jobs.get).toHaveBeenCalledTimes(1);
     expect(client.jobs.get).toHaveBeenCalledWith(jobId);
-    expect(notifyApi.success).toHaveBeenCalled();
+    expect(notifyApi.success).toHaveBeenCalledTimes(1);
   });
 
   it('settles a job that already failed before the registry read resolved', async () => {
@@ -178,7 +183,8 @@ describe('useModelPull — reconciles a stale adoption', () => {
     });
 
     await waitFor(() => expect(result.current.pullState).toBe('error'));
+    expect(client.jobs.get).toHaveBeenCalledTimes(1);
     expect(client.jobs.get).toHaveBeenCalledWith(jobId);
-    expect(notifyApi.error).toHaveBeenCalled();
+    expect(notifyApi.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
@@ -125,6 +125,14 @@ describe('useModelPull — reconciles a stale adoption', () => {
       wrapper: withProviders(client),
     });
 
+    // Prove the listener is actually wired before relying on firing it — a
+    // `handler?.(…)` on a `null` handler is a silent no-op, and both this and
+    // the reconcile assertions below would still pass even if the live
+    // subscription were never registered at all (findings the reconcile read
+    // is supposed to be tested WITH a real event in flight, not without one).
+    await waitFor(() => expect(client.jobs.onEvent).toHaveBeenCalled());
+    expect(handler).not.toBeNull();
+
     // Fires the ACTUAL ordering the review flagged: the terminal event
     // arrives while `jobs.list()` is still in flight, so `pullJobId` is
     // still null and the live listener's identity check drops it.
@@ -174,6 +182,9 @@ describe('useModelPull — reconciles a stale adoption', () => {
     const { result } = renderHook(() => useModelPull({ selectedModel: 'llama3' }), {
       wrapper: withProviders(client),
     });
+
+    await waitFor(() => expect(client.jobs.onEvent).toHaveBeenCalled());
+    expect(handler).not.toBeNull();
 
     act(() => handler?.({ type: 'job.failed', jobId, data: 'model not found' }));
 

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
@@ -25,13 +25,18 @@ vi.mock('@ajh/ui', () => ({ useNotification: () => notifyApi }));
 
 afterEach(() => vi.restoreAllMocks());
 
+// `payload.model` defaults to 'llama3' — every test below renders
+// `useModelPull({ selectedModel: 'llama3' })`, and the reattach effect's
+// adoption predicate now requires `job.payload?.model === selectedModel`
+// (`ai_pull_model` keys its exclusivity on (kind, model) and stamps the
+// model onto the payload from job START, not just on completion).
 function makeJob(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     id: 'job-123',
     kind: 'ai.pull_model',
     status: 'running',
     progress: 0,
-    payload: null,
+    payload: { model: 'llama3' },
     retries: 0,
     maxRetries: 3,
     createdAt: Date.now(),
@@ -90,6 +95,34 @@ describe('useModelPull — reattach on mount', () => {
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(result.current.pullState).toBe('idle');
+  });
+
+  // Rust review follow-up: `ai_pull_model`'s exclusivity moved from keying on
+  // job KIND alone to (kind, model), so a running pull of gpt-oss and one of
+  // llama3 can coexist. Without checking `payload.model` here, this panel
+  // (showing llama3) would adopt the gpt-oss job and render ITS progress
+  // under the llama3 card — refusing the NEW request at the command only
+  // guards a fresh `handlePull`, not this registry scan.
+  it('ignores a running pull of a different model and stays idle', async () => {
+    const client = createMockClient({
+      'jobs.list': vi
+        .fn()
+        .mockResolvedValue([makeJob({ id: 'job-other-model', payload: { model: 'gpt-oss' } })]),
+      'jobs.get': vi.fn(),
+    });
+
+    const { result } = renderHook(() => useModelPull({ selectedModel: 'llama3' }), {
+      wrapper: withProviders(client),
+    });
+
+    await waitFor(() => expect(client.jobs.list).toHaveBeenCalled());
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.pullState).toBe('idle');
+    // Not adopted at all, not adopted-then-reconciled: the reconcile read
+    // (`jobs.get`) must never fire for a job that failed the model check.
+    expect(client.jobs.get).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
@@ -1,0 +1,91 @@
+/**
+ * useModelPull — re-attach-on-mount coverage.
+ *
+ * `pullJobId` used to live ONLY in this hook's own `useState`, so any unmount
+ * of the panel (Cloud/CLI tab switch, Back/Forward through the wizard, or just
+ * navigating away and back) lost it forever: no later `job.stream` /
+ * `job.completed` for the still-running pull could ever match again, and the
+ * panel re-showed the Download button for work that was actually in flight.
+ *
+ * This pins the fix: on mount, the hook reads the backend job registry
+ * (`jobs_list`) for an already-running `ai.pull_model` job and re-attaches to
+ * it, so a LATER event for that same job id is not silently dropped.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { createMockClient, withProviders } from '@/test-support';
+
+import { useModelPull } from './useModelPull';
+
+vi.mock('@ajh/translations', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+const notifyApi = { success: vi.fn(), error: vi.fn() };
+vi.mock('@ajh/ui', () => ({ useNotification: () => notifyApi }));
+
+afterEach(() => vi.restoreAllMocks());
+
+function makeJob(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'job-123',
+    kind: 'ai.pull_model',
+    status: 'running',
+    progress: 0,
+    payload: null,
+    retries: 0,
+    maxRetries: 3,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('useModelPull — reattach on mount', () => {
+  it('adopts an already-running ai.pull_model job from the registry and resumes tracking its events', async () => {
+    let handler: ((e: unknown) => void) | null = null;
+    const client = createMockClient({
+      'jobs.list': vi.fn().mockResolvedValue([makeJob()]),
+      'jobs.onEvent': vi.fn((h: (e: unknown) => void) => {
+        handler = h;
+        return () => {};
+      }),
+    });
+
+    const { result } = renderHook(() => useModelPull({ selectedModel: 'llama3' }), {
+      wrapper: withProviders(client),
+    });
+
+    // The registry query resolves asynchronously; once it does, the hook must
+    // stop reporting idle for a pull that is actually running.
+    await waitFor(() => expect(result.current.pullState).toBe('pulling'));
+
+    // Proves pullJobId itself was recovered (not just the state flag guessed):
+    // only an event carrying the SAME job id moves progress.
+    act(() => handler?.({ type: 'job.stream', jobId: 'job-123', data: { p: 0.42 } }));
+    expect(result.current.pullProgress).toBeCloseTo(42);
+  });
+
+  it('ignores an unrelated or terminal ai.pull_model job and stays idle', async () => {
+    const client = createMockClient({
+      'jobs.list': vi
+        .fn()
+        .mockResolvedValue([
+          makeJob({ status: 'completed' }),
+          makeJob({ id: 'j2', kind: 'ai.embed' }),
+        ]),
+    });
+
+    const { result } = renderHook(() => useModelPull({ selectedModel: 'llama3' }), {
+      wrapper: withProviders(client),
+    });
+
+    await waitFor(() => expect(client.jobs.list).toHaveBeenCalled());
+    // Flush a macrotask so the registry query has fully settled before
+    // asserting the ABSENCE of a state change (a bare microtask can race the
+    // query's own internal promise chain).
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.pullState).toBe('idle');
+  });
+});

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.test.ts
@@ -14,7 +14,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
-import { createMockClient, withProviders } from '@/test-support';
+import { createMockClient, makeQueryClient, withProviders } from '@/test-support';
 
 import { useModelPull } from './useModelPull';
 
@@ -186,5 +186,47 @@ describe('useModelPull — reconciles a stale adoption', () => {
     expect(client.jobs.get).toHaveBeenCalledTimes(1);
     expect(client.jobs.get).toHaveBeenCalledWith(jobId);
     expect(notifyApi.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── mountedRef must survive React.StrictMode's setup→cleanup→setup ──────────
+//
+// PR #1036 review finding (MINOR): the production app renders inside
+// React.StrictMode (main.tsx). StrictMode double-invokes an effect in
+// development — setup, cleanup, setup — while preserving hook state between
+// the two setups. `mountedRef` used to be set `true` only by the initial
+// `useRef(true)` and back to `false` by the cleanup, with nothing restoring
+// it on the SECOND setup — so after StrictMode's dance it is permanently
+// `false`, and the reconcile read's `if (!mountedRef.current …) return;`
+// guard drops every settle for the rest of this hook instance's life.
+describe('useModelPull — survives React.StrictMode remount', () => {
+  it('still settles a job that completed, after StrictMode setup→cleanup→setup', async () => {
+    const jobId = 'job-strictmode';
+    const client = createMockClient({
+      'jobs.list': vi.fn().mockResolvedValue([makeJob({ id: jobId })]),
+      'jobs.get': vi.fn().mockResolvedValue(makeJob({ id: jobId, status: 'completed' })),
+      'jobs.onEvent': vi.fn(() => () => {}),
+    });
+    const queryClient = makeQueryClient();
+
+    // `reactStrictMode: true` is testing-library's OWN option for this —
+    // NOT rendering a `<React.StrictMode>` element through a custom
+    // `wrapper` component, which looks equivalent but is NOT: testing-library
+    // wraps StrictMode around `wrapper` only when told to via this option
+    // (`strictModeIfNeeded` in its source), so a `<StrictMode>` nested a
+    // level deeper inside a hand-rolled wrapper never gets the double
+    // setup→cleanup→setup pass — confirmed empirically (a throwaway probe
+    // effect counted setups=1/cleanups=0 with the manual-wrapper form and
+    // setups=2/cleanups=1 with this option) before trusting this test to
+    // pin the fix. Wrap ONLY this test — adding it to `withProviders`
+    // itself would skew every other suite's call counts.
+    const { result } = renderHook(() => useModelPull({ selectedModel: 'llama3' }), {
+      wrapper: withProviders(client, queryClient),
+      reactStrictMode: true,
+    });
+
+    // An unfixed hook gets stuck on 'pulling' forever here instead — the
+    // reconcile read's own guard silently drops the settle.
+    await waitFor(() => expect(result.current.pullState).toBe('done'));
   });
 });

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   calculateDownloadSpeed,
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from '@ajh/translations';
 import { useNotification } from '@ajh/ui';
 
-import { useJobEvents, usePullModel } from '@/services';
+import { useJobEvents, useJobQueue, usePullModel } from '@/services';
 
 type PullState = 'idle' | 'pulling' | 'done' | 'error';
 
@@ -23,6 +23,7 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
   const { t } = useTranslation();
   const notify = useNotification();
   const pullModel = usePullModel();
+  const jobQueue = useJobQueue();
 
   const [pullState, setPullState] = useState<PullState>('idle');
   const [pullProgress, setPullProgress] = useState(0);
@@ -68,6 +69,26 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
       notify.error({ message: err instanceof Error ? err.message : 'Download failed.' });
     }
   };
+
+  // Re-attach to a pull already running in the backend job registry — `pullJobId`
+  // lives only in this hook's own state, so ANY unmount of this panel (not just
+  // navigating away: switching to the Cloud/CLI tab and back, or Back/Forward
+  // through the wizard) loses it forever and no later job.stream/job.completed
+  // can match again. `ai_pull_model` is exclusive, so at most one can be running
+  // app-wide — reattaching to whichever the registry still reports means this
+  // panel resumes tracking the SAME job instead of quietly going deaf.
+  useEffect(() => {
+    if (pullJobId) return;
+    const active = jobQueue.data?.find(
+      (job) =>
+        job.kind === 'ai.pull_model' &&
+        (job.status === 'running' || job.status === 'streaming' || job.status === 'queued')
+    );
+    if (active) {
+      setPullJobId(active.id);
+      setPullState('pulling');
+    }
+  }, [jobQueue.data, pullJobId]);
 
   useJobEvents((event) => {
     if (event.type === 'job.stream' && event.jobId === pullJobId) {

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
@@ -56,6 +56,10 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
     },
     []
   );
+  // Job ids this hook instance has already settled (via the reconcile read
+  // below or a live terminal event) — see the reattach effect for why this
+  // is needed to stop it re-adopting the same job forever.
+  const settledJobIdsRef = useRef<Set<string>>(new Set());
 
   /** Clear the transient per-download tracking (job id, speed, ETA, byte counters). */
   const resetTracking = useCallback(() => {
@@ -74,13 +78,29 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
     lastTimeUpdateRef.current = 0;
   }, []);
 
-  const finishOk = useCallback(() => {
-    setPullProgress(100);
-    setPullState('done');
-    resetTracking();
-    notify.success({ message: t('onboarding.ai.downloaded', { model: selectedModel }) });
-    onDownloadComplete?.();
-  }, [resetTracking, notify, t, selectedModel, onDownloadComplete]);
+  // Both take the settling job's id so they can record it as settled — see
+  // `settledJobIdsRef` above.
+  const finishOk = useCallback(
+    (jobId: string) => {
+      settledJobIdsRef.current.add(jobId);
+      setPullProgress(100);
+      setPullState('done');
+      resetTracking();
+      notify.success({ message: t('onboarding.ai.downloaded', { model: selectedModel }) });
+      onDownloadComplete?.();
+    },
+    [resetTracking, notify, t, selectedModel, onDownloadComplete]
+  );
+
+  const finishFailed = useCallback(
+    (jobId: string) => {
+      settledJobIdsRef.current.add(jobId);
+      setPullState('error');
+      resetTracking();
+      notify.error({ message: t('onboarding.ai.downloadFailed') });
+    },
+    [resetTracking, notify, t]
+  );
 
   const handlePull = async () => {
     setPullState('pulling');
@@ -107,6 +127,7 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
     const active = jobQueue.data?.find(
       (job) =>
         job.kind === 'ai.pull_model' &&
+        !settledJobIdsRef.current.has(job.id) &&
         (job.status === 'running' || job.status === 'streaming' || job.status === 'queued')
     );
     if (!active) return;
@@ -135,17 +156,15 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
       .then((job) => {
         if (!mountedRef.current || pullJobIdRef.current !== active.id) return;
         if (job?.status === 'completed') {
-          finishOk();
+          finishOk(active.id);
         } else if (job?.status === 'failed') {
-          setPullState('error');
-          resetTracking();
-          notify.error({ message: t('onboarding.ai.downloadFailed') });
+          finishFailed(active.id);
         }
       })
       .catch((err) => {
         console.error('[modelPull] reconcile read failed', { jobId: active.id, err });
       });
-  }, [jobQueue.data, pullJobId, finishOk, resetTracking, notify, t]);
+  }, [jobQueue.data, pullJobId, finishOk, finishFailed]);
 
   useJobEvents((event) => {
     if (event.type === 'job.stream' && event.jobId === pullJobIdRef.current) {
@@ -200,14 +219,12 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
       }
 
       if (data?.status === 'success') {
-        finishOk();
+        finishOk(event.jobId);
       }
     } else if (event.type === 'job.completed' && event.jobId === pullJobIdRef.current) {
-      finishOk();
+      finishOk(event.jobId);
     } else if (event.type === 'job.failed' && event.jobId === pullJobIdRef.current) {
-      setPullState('error');
-      resetTracking();
-      notify.error({ message: t('onboarding.ai.downloadFailed') });
+      finishFailed(event.jobId);
     }
   });
 

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
@@ -130,7 +130,18 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
     if (pullJobId) return;
     const active = jobQueue.data?.find(
       (job) =>
+        // `ai_pull_model` now keys its exclusivity on (kind, model) —
+        // `job_start_exclusive_keyed` — and stamps the model onto the job's
+        // payload from the START, not just on completion, so it round-trips
+        // through both `jobs_list` and `jobs_get`. Checking it here is what
+        // stops this effect adopting a running pull of a DIFFERENT model
+        // than the one this panel shows: refusing a second pull at the
+        // command only guards the NEW request, not this reattach read. The
+        // failed-check case must never reach adoption at all (not adopt then
+        // reconcile away), which is exactly what filtering inside this
+        // `.find()` predicate — before `active` exists — guarantees.
         job.kind === 'ai.pull_model' &&
+        (job.payload as { model?: string } | null | undefined)?.model === selectedModel &&
         !settledJobIdsRef.current.has(job.id) &&
         (job.status === 'running' || job.status === 'streaming' || job.status === 'queued')
     );
@@ -168,7 +179,7 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
       .catch((err) => {
         console.error('[modelPull] reconcile read failed', { jobId: active.id, err });
       });
-  }, [jobQueue.data, pullJobId, finishOk, finishFailed]);
+  }, [jobQueue.data, pullJobId, selectedModel, finishOk, finishFailed]);
 
   useJobEvents((event) => {
     if (event.type === 'job.stream' && event.jobId === pullJobIdRef.current) {

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
@@ -44,18 +44,22 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
   // `useResumePipelineSession`'s `jobIdRef`).
   const pullJobIdRef = useRef(pullJobId);
   pullJobIdRef.current = pullJobId;
-  // True until this hook instance unmounts. Deliberately its OWN effect with
-  // an empty dep array — tying it to the reattach effect below would flip it
-  // false the instant that effect adopts a job (its deps include `pullJobId`,
-  // which the adoption itself changes), cancelling that effect's own
-  // reconcile read before it can resolve.
+  // True while this hook instance is mounted. Deliberately its OWN effect
+  // with an empty dep array — tying it to the reattach effect below would
+  // flip it false the instant that effect adopts a job (its deps include
+  // `pullJobId`, which the adoption itself changes), cancelling that
+  // effect's own reconcile read before it can resolve. Set in the SETUP
+  // half too, not just left `true` from the initial ref value: StrictMode
+  // runs setup → cleanup → setup again while preserving state, so without
+  // this the second setup leaves it `false` from the first cleanup and every
+  // later reconcile read exits early, permanently stuck reporting `pulling`.
   const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    []
-  );
+    };
+  }, []);
   // Job ids this hook instance has already settled (via the reconcile read
   // below or a live terminal event) — see the reattach effect for why this
   // is needed to stop it re-adopting the same job forever.

--- a/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
+++ b/apps/desktop/src/renderer/features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   calculateDownloadSpeed,
@@ -9,7 +9,7 @@ import {
 import { useTranslation } from '@ajh/translations';
 import { useNotification } from '@ajh/ui';
 
-import { useJobEvents, useJobQueue, usePullModel } from '@/services';
+import { fetchJob, useJobEvents, useJobQueue, usePullModel } from '@/services';
 
 type PullState = 'idle' | 'pulling' | 'done' | 'error';
 
@@ -37,8 +37,32 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
   const lastSpeedUpdateRef = useRef(0);
   const lastTimeUpdateRef = useRef(0);
 
+  // The reattach effect's reconcile read below needs the CURRENT `pullJobId`
+  // from inside an async `.then()`, where a closure only has the value from
+  // whichever render scheduled it — a ref synced every render is the
+  // standard way to read "now" from there (same discipline as
+  // `useResumePipelineSession`'s `jobIdRef`).
+  const pullJobIdRef = useRef(pullJobId);
+  pullJobIdRef.current = pullJobId;
+  // True until this hook instance unmounts. Deliberately its OWN effect with
+  // an empty dep array — tying it to the reattach effect below would flip it
+  // false the instant that effect adopts a job (its deps include `pullJobId`,
+  // which the adoption itself changes), cancelling that effect's own
+  // reconcile read before it can resolve.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
   /** Clear the transient per-download tracking (job id, speed, ETA, byte counters). */
-  const resetTracking = () => {
+  const resetTracking = useCallback(() => {
+    // Synchronous, same reasoning as the adopt/handlePull assignments below:
+    // a `setState` call does not update the ref for anything that reads it
+    // before the next render commits.
+    pullJobIdRef.current = null;
     setPullJobId(null);
     setDownloadSpeed('');
     setTimeRemaining('');
@@ -48,21 +72,22 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
     prevTimeRef.current = 0;
     lastSpeedUpdateRef.current = 0;
     lastTimeUpdateRef.current = 0;
-  };
+  }, []);
 
-  const finishOk = () => {
+  const finishOk = useCallback(() => {
     setPullProgress(100);
     setPullState('done');
     resetTracking();
     notify.success({ message: t('onboarding.ai.downloaded', { model: selectedModel }) });
     onDownloadComplete?.();
-  };
+  }, [resetTracking, notify, t, selectedModel, onDownloadComplete]);
 
   const handlePull = async () => {
     setPullState('pulling');
     setPullProgress(0);
     try {
       const result = await pullModel.mutateAsync(selectedModel);
+      pullJobIdRef.current = result.jobId;
       setPullJobId(result.jobId);
     } catch (err) {
       setPullState('error');
@@ -84,14 +109,46 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
         job.kind === 'ai.pull_model' &&
         (job.status === 'running' || job.status === 'streaming' || job.status === 'queued')
     );
-    if (active) {
-      setPullJobId(active.id);
-      setPullState('pulling');
-    }
-  }, [jobQueue.data, pullJobId]);
+    if (!active) return;
+
+    // Synchronous — `pullJobIdRef` must read as "now watching this job"
+    // before the microtask queue below (and `useJobEvents`, if a real event
+    // is already pending) gets a turn. A `setState` call alone does not: it
+    // only updates the ref on the NEXT render commit, and an already-resolved
+    // mock promise (a real IPC response resolves the same way) can unwind
+    // entirely through microtasks without ever yielding the macrotask turn
+    // React's scheduler needs — same discipline as `useResumePipelineSession`.
+    pullJobIdRef.current = active.id;
+    setPullJobId(active.id);
+    setPullState('pulling');
+
+    // The registry snapshot above can already be stale by the time this
+    // commits: `ai.pull_model` fires its ONE job.completed/job.failed the
+    // instant the pull ends, and `useJobEvents` below drops any event whose
+    // jobId doesn't match a `pullJobId` that isn't set yet — `jobQueue.data`
+    // takes a full IPC round trip to resolve, so a terminal event landing in
+    // that gap is gone for good; no second one is coming to correct it.
+    // Re-read this job's OWN current status right after adopting it so the
+    // panel settles regardless of whether that race actually happened,
+    // instead of depending on catching the event at the right moment.
+    void fetchJob(active.id)
+      .then((job) => {
+        if (!mountedRef.current || pullJobIdRef.current !== active.id) return;
+        if (job?.status === 'completed') {
+          finishOk();
+        } else if (job?.status === 'failed') {
+          setPullState('error');
+          resetTracking();
+          notify.error({ message: t('onboarding.ai.downloadFailed') });
+        }
+      })
+      .catch((err) => {
+        console.error('[modelPull] reconcile read failed', { jobId: active.id, err });
+      });
+  }, [jobQueue.data, pullJobId, finishOk, resetTracking, notify, t]);
 
   useJobEvents((event) => {
-    if (event.type === 'job.stream' && event.jobId === pullJobId) {
+    if (event.type === 'job.stream' && event.jobId === pullJobIdRef.current) {
       const data = event.data as {
         status?: string;
         p?: number;
@@ -145,9 +202,9 @@ export function useModelPull({ selectedModel, onDownloadComplete }: Params) {
       if (data?.status === 'success') {
         finishOk();
       }
-    } else if (event.type === 'job.completed' && event.jobId === pullJobId) {
+    } else if (event.type === 'job.completed' && event.jobId === pullJobIdRef.current) {
       finishOk();
-    } else if (event.type === 'job.failed' && event.jobId === pullJobId) {
+    } else if (event.type === 'job.failed' && event.jobId === pullJobIdRef.current) {
       setPullState('error');
       resetTracking();
       notify.error({ message: t('onboarding.ai.downloadFailed') });

--- a/apps/desktop/src/renderer/hooks/use-resume-pipeline-session.test.ts
+++ b/apps/desktop/src/renderer/hooks/use-resume-pipeline-session.test.ts
@@ -69,7 +69,10 @@ function stage(
   return { runId, jobId: JOB_ID, stage: name, phase, index, total: 6, attempt: 1 };
 }
 
-function detail(status: PipelineRunDetail['status']): PipelineRunDetail {
+function detail(
+  status: PipelineRunDetail['status'],
+  stoppedReason?: string | null
+): PipelineRunDetail {
   return {
     runId: RUN_ID,
     jobUrl: 'https://example.test/job',
@@ -77,6 +80,7 @@ function detail(status: PipelineRunDetail['status']): PipelineRunDetail {
     depth: 'quality',
     status,
     startedAt: 1,
+    ...(stoppedReason !== undefined ? { stoppedReason } : {}),
     metrics: {},
     events: [],
     report: null,
@@ -359,6 +363,44 @@ describe('useResumePipelineSession', () => {
     const { result } = renderHook(() => useResumePipelineSession(RUN_ID, JOB_ID));
     await waitFor(() => expect(result.current.state).toBe('done'));
     expect(result.current.runId).toBe(RUN_ID);
+  });
+
+  // ── The failure reason survives a remount the live listener missed ────────
+  //
+  // `job.failed` only ever reaches `setError` while a listener is mounted at
+  // the moment it fires. A fresh mount that reconnects to an already-failed
+  // run never saw that event, so without a fallback `error` stays `null`
+  // forever even though the record says exactly why the run stopped.
+  describe('the failure reason survives a remount that missed job.failed', () => {
+    it('derives the reason from the persisted stoppedReason when no live event ever arrived', async () => {
+      // Simulates a fresh mount reconnecting to a run that already failed
+      // while unmounted — no `bus.job?.(...)` call anywhere in this test.
+      bus.detail = detail('failed', 'run_timeout');
+      const { result } = renderHook(() => useResumePipelineSession(RUN_ID, JOB_ID));
+
+      await waitFor(() => expect(result.current.state).toBe('error'));
+      expect(result.current.error).toBeTruthy();
+      expect(result.current.error).toContain('ran out of time');
+    });
+
+    it('prefers the live job.failed message over the persisted reason when both exist', async () => {
+      const { result, rerender } = renderHook(() => useResumePipelineSession(RUN_ID, JOB_ID));
+      act(() => bus.job?.(jobFailed(JOB_ID, 'the provider refused the request')));
+      await waitFor(() => expect(result.current.state).toBe('error'));
+
+      // The record catches up on a later poll with a DIFFERENT reason — the
+      // live message, which arrived first-hand, must still win.
+      bus.detail = detail('failed', 'timeout');
+      rerender();
+      expect(result.current.error).toBe('the provider refused the request');
+    });
+
+    it('says nothing for a failed run that recorded no reason at all', async () => {
+      bus.detail = detail('failed', null);
+      const { result } = renderHook(() => useResumePipelineSession(RUN_ID, JOB_ID));
+      await waitFor(() => expect(result.current.state).toBe('error'));
+      expect(result.current.error).toBeNull();
+    });
   });
 
   // ── A read that never succeeds must not read as "still working" ───────────

--- a/apps/desktop/src/renderer/hooks/use-resume-pipeline-session.ts
+++ b/apps/desktop/src/renderer/hooks/use-resume-pipeline-session.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { JobEvent, PipelineStageEvent } from '@ajh/shared';
 import type { PipelineRunDetail } from '@ajh/shared/ipc';
@@ -14,6 +14,7 @@ import {
   stageToEvent,
   statusToEvent,
 } from '@/lib/machines/resume-pipeline.machine';
+import { stoppedSuffix } from '@/lib/stopped-reason';
 import { fetchJob, useCancelJob, useJobEvents } from '@/services/use-jobs';
 import {
   usePipelineDraftStream,
@@ -63,7 +64,12 @@ export interface ResumePipelineSession {
   thinking: string;
   /** The run record: the authority on status, report, metrics and document. */
   detail: PipelineRunDetail | null;
-  /** A start failure, or the stopped reason of a run that ended badly. */
+  /**
+   * A start failure, or the stopped reason of a run that ended badly — the
+   * live `job.failed` message when one arrived, otherwise (a remount that
+   * missed it) the persisted record's own reason. See
+   * `persistedFailureReason`'s doc comment for the fallback's limits.
+   */
   error: string | null;
   starting: boolean;
   start: (req: ResumePipelineRunRequest) => Promise<string | null>;
@@ -252,6 +258,28 @@ export function useResumePipelineSession(
     if (next) send(next);
   }, [status, send]);
 
+  /**
+   * The failure reason for a run whose ONLY trace is the record — a remount
+   * after a `job.failed` the live listener above never saw. `error` (the
+   * `useState` above) is empty in exactly that case: it is written only by
+   * `handleJobEvent`/`start`, both of which require a listener mounted at the
+   * moment the event fired, which a fresh mount by definition was not.
+   *
+   * Reuses the SAME wire→label mapping `ResultsPanel`/`PipelineRunsList`
+   * already use for this exact field, rather than inventing a second one —
+   * it will never carry the live path's stage/seconds specificity (the row
+   * persists `stoppedReason`, not the per-call timeout's duration), but it is
+   * a real, localized reason instead of the silence a bare `error` leaves.
+   * `null` on a `failed` run with no recorded reason (a provider error, a
+   * store failure) — there's nothing to say — and on every non-`failed`
+   * status, where `error` is not what renders the outcome.
+   */
+  const persistedFailureReason = useMemo(() => {
+    if (status !== 'failed') return null;
+    const suffix = stoppedSuffix(detail?.stoppedReason);
+    return suffix ? t(`pipeline.stopped.${suffix}`) : null;
+  }, [status, detail?.stoppedReason, t]);
+
   // …and the same discovery is the only thing that can tell the posting's run
   // LIST its run just ended. Nothing was clicked, so none of the three
   // action-driven invalidators fires, and the list has no poll of its own: left
@@ -415,7 +443,9 @@ export function useResumePipelineSession(
     letterDraft,
     thinking,
     detail,
-    error,
+    // The live message wins when one landed; otherwise fall back to what the
+    // record itself says — see `persistedFailureReason`'s doc comment.
+    error: error ?? persistedFailureReason,
     starting: startRun.isPending,
     start,
     cancel,

--- a/apps/desktop/src/renderer/services/use-autopilot/use-autopilot.test.ts
+++ b/apps/desktop/src/renderer/services/use-autopilot/use-autopilot.test.ts
@@ -6,7 +6,7 @@ import { createMockClient, exerciseServiceHooks, renderHookWithClient } from '@/
 
 import { keys } from '../query-client';
 import * as mod from './use-autopilot';
-import { useRemoveAutopilot } from './use-autopilot';
+import { useAutopilots, useRemoveAutopilot } from './use-autopilot';
 
 // gcTime: Infinity so cache seeded without an active observer is not collected.
 const persistentClient = () =>
@@ -20,6 +20,42 @@ const persistentClient = () =>
 describe('use-autopilot services', () => {
   it('renders every exported hook without crashing', async () => {
     await exerciseServiceHooks(mod);
+  });
+});
+
+// ── The fallback's freshness hole ────────────────────────────────────────────
+//
+// `AutopilotPage`'s `runState` fallback reads `ap.runStatus` off THIS query
+// whenever its own run-state machine starts fresh (a remount). Nothing
+// invalidates this query when a run STARTS, so the fallback is only honest if
+// a remount always sees a genuinely fresh answer — which requires this hook's
+// OWN `staleTime`, not the app-wide default, since the app-wide default (30s,
+// see `query-client.ts`) is exactly what let a remount inside that window
+// reuse a pre-run snapshot.
+describe('useAutopilots — staleTime', () => {
+  it('refetches on every mount even under a non-zero inherited staleTime default', async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce([{ _id: 'a', runStatus: 'completed' }])
+      .mockResolvedValueOnce([{ _id: 'a', runStatus: 'inProgress' }]);
+    const client = createMockClient({ 'autopilot.list': list });
+    // Mirrors the app's real default (`query-client.ts`'s `staleTime:
+    // QUERY_TIMES.MEDIUM`, 30s) — the test harness's OWN default QueryClient
+    // (`staleTime: 0`) would mask the bug by construction, since everything
+    // would look fresh-on-mount regardless of what this hook asks for.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
+    });
+
+    const first = renderHookWithClient(() => useAutopilots(), { client, queryClient });
+    await waitFor(() => expect(first.result.current.data?.[0]?.runStatus).toBe('completed'));
+    first.unmount();
+
+    // A second mount immediately after, with the SAME cache — the remount
+    // scenario (navigate away and back), well inside the 30s window.
+    const second = renderHookWithClient(() => useAutopilots(), { client, queryClient });
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(second.result.current.data?.[0]?.runStatus).toBe('inProgress'));
   });
 });
 

--- a/apps/desktop/src/renderer/services/use-autopilot/use-autopilot.ts
+++ b/apps/desktop/src/renderer/services/use-autopilot/use-autopilot.ts
@@ -14,9 +14,25 @@ import { useAppClient } from '@/providers/AppClientProvider';
 import { keys } from '../query-client';
 import { useCheckBrowser } from '../use-system';
 
+/**
+ * `staleTime: 0` is load-bearing, not an oversight — this list's `runStatus`
+ * is the fallback authority `AutopilotPage` reads whenever ITS OWN run-state
+ * machine starts fresh (a remount has no memory of a run this mount didn't
+ * see start). Nothing invalidates this query when a run STARTS, only when one
+ * ENDS (`useRunAutopilot`'s `onSuccess`), so under the inherited 30s default a
+ * remount inside that window reused a snapshot taken before the run began —
+ * rendering an executing run as idle with an enabled Run button, the exact
+ * symptom the fallback exists to prevent. The read is a cheap local IPC call
+ * (no network round trip), so refetching on every mount costs nothing worth
+ * trading for the staleness window.
+ */
 export const useAutopilots = () => {
   const api = useAppClient();
-  return useQuery({ queryKey: keys.autopilot.all, queryFn: () => api.autopilot.list() });
+  return useQuery({
+    queryKey: keys.autopilot.all,
+    queryFn: () => api.autopilot.list(),
+    staleTime: 0,
+  });
 };
 
 /**

--- a/apps/desktop/src/renderer/services/use-updater/use-updater.test.ts
+++ b/apps/desktop/src/renderer/services/use-updater/use-updater.test.ts
@@ -97,4 +97,33 @@ describe('useUpdater', () => {
       total: 10,
     });
   });
+
+  it('a remounted instance sees the in-flight download metrics, not just the status label', () => {
+    // Same shape as the remount test above, but for the progress readout: a
+    // panel that mounts fresh mid-download must see the speed/eta/byte counts
+    // an already-mounted instance (the banner) computed from events the new
+    // instance's own effect never received — not a blank/zero readout until
+    // its next tick.
+    let t = 1000;
+    vi.spyOn(Date, 'now').mockImplementation(() => t);
+    const banner = setup();
+
+    t = 1000;
+    banner.emit({ state: 'downloading', percent: 10, downloaded: 1_000_000, total: 10_000_000 });
+    t = 2000; // 1s later, clears the 500ms throttle
+    banner.emit({ state: 'downloading', percent: 20, downloaded: 3_000_000, total: 10_000_000 });
+
+    expect(banner.hook.result.current.downloadSpeed).toMatch(/\/s$/);
+    expect(banner.hook.result.current.timeRemaining).toBeTruthy();
+
+    const settingsPanel = setup();
+    expect(settingsPanel.hook.result.current.downloadSpeed).toBe(
+      banner.hook.result.current.downloadSpeed
+    );
+    expect(settingsPanel.hook.result.current.timeRemaining).toBe(
+      banner.hook.result.current.timeRemaining
+    );
+    expect(settingsPanel.hook.result.current.downloadedBytes).toBe(3_000_000);
+    expect(settingsPanel.hook.result.current.totalBytes).toBe(10_000_000);
+  });
 });

--- a/apps/desktop/src/renderer/services/use-updater/use-updater.test.ts
+++ b/apps/desktop/src/renderer/services/use-updater/use-updater.test.ts
@@ -3,9 +3,15 @@ import { act, renderHook } from '@testing-library/react';
 
 import { createMockClient, withProviders } from '@/test-support';
 
-import { useUpdater } from './use-updater';
+import { resetUpdaterStatusForTests, useUpdater } from './use-updater';
 
-afterEach(() => vi.restoreAllMocks());
+// `status` is shared MODULE state (see use-updater.ts) so it survives a
+// remount by design — which also means it survives across `it()`s in this
+// file unless reset.
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetUpdaterStatusForTests();
+});
 
 function setup() {
   let handler: ((s: unknown) => void) | null = null;
@@ -66,5 +72,29 @@ describe('useUpdater', () => {
     expect(check).toHaveBeenCalled();
     expect(download).toHaveBeenCalled();
     expect(install).toHaveBeenCalled();
+  });
+
+  it('a remounted instance reads the status an already-mounted instance recorded, not idle', () => {
+    // Simulates the real defect: the settings panel's useUpdater() unmounts on
+    // route navigation and remounts later, while the always-mounted banner's
+    // OWN instance kept receiving `updater:status` the whole time. This pins
+    // that the SECOND (remounted) instance sees the download already in
+    // progress immediately, with no event of its own and no re-fetch.
+    const banner = setup();
+    banner.emit({ state: 'downloading', percent: 42, downloaded: 4, total: 10 });
+    expect(banner.hook.result.current.status).toEqual({
+      state: 'downloading',
+      percent: 42,
+      downloaded: 4,
+      total: 10,
+    });
+
+    const settingsPanel = setup();
+    expect(settingsPanel.hook.result.current.status).toEqual({
+      state: 'downloading',
+      percent: 42,
+      downloaded: 4,
+      total: 10,
+    });
   });
 });

--- a/apps/desktop/src/renderer/services/use-updater/use-updater.ts
+++ b/apps/desktop/src/renderer/services/use-updater/use-updater.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import {
@@ -22,7 +22,14 @@ export type UpdateStatus =
   | { state: 'downloaded'; version: string }
   | { state: 'error'; message: string };
 
-// `status` is shared module state, not local `useState`. There are three
+interface UpdaterSnapshot {
+  status: UpdateStatus;
+  downloadSpeed: string;
+  timeRemaining: string;
+}
+
+// `status` AND the download-progress readout (speed, time remaining) are
+// shared MODULE state, not local `useState`/`useRef`. There are three
 // independent useUpdater() call sites (this settings panel, the always-mounted
 // banner, and the menu), each with its OWN `updater:status` subscription; the
 // banner/menu never unmount, so they never lose it, but the settings panel
@@ -34,92 +41,110 @@ export type UpdateStatus =
 // pushed value to remember, so a plain synchronous external store (every
 // mounted instance reads the SAME value, updated the instant any one of them
 // receives an event) is the whole fix — no extra `check()` call, no re-fetch.
-let sharedUpdateStatus: UpdateStatus = { state: 'idle' };
+//
+// `downloadedBytes`/`totalBytes` don't get a store slot at all: the
+// `downloading` status variant already carries `.downloaded`/`.total`, so
+// every instance derives them straight off the (already-shared) `status`
+// below — one source of truth instead of a second copy that can fall out of
+// sync with it.
+//
+// `downloadSpeed`/`timeRemaining` are rate calculations, so unlike the byte
+// counts they need HISTORY (a previous sample + its timestamp) to compute.
+// That history (`prevBytes`/`prevTime` below) is module-level too, for the
+// same reason `status` is: a settings panel that unmounts mid-download and
+// remounts must not restart its own blank history and sit through one more
+// silent tick before the first speed reading appears. Because the
+// always-mounted banner keeps an `updater.onStatus` listener alive for the
+// whole download, this history is never actually gapped by a remount in
+// practice — a remount only adds a second listener recomputing the same
+// delta from the same shared previous sample, which is idempotent (once the
+// first listener advances `prevBytes` for an event, the rest see
+// `bytes === prevBytes` and skip the calculation). Reset on
+// `downloaded`/`error` keeps a finished download from leaking a stale sample
+// into the next one.
+let sharedSnapshot: UpdaterSnapshot = {
+  status: { state: 'idle' },
+  downloadSpeed: '',
+  timeRemaining: '',
+};
+let prevBytes = 0;
+let prevTime = 0;
+let lastSpeedUpdate = 0;
+let lastTimeUpdate = 0;
+
 const updateStatusListeners = new Set<() => void>();
-function setSharedUpdateStatus(next: UpdateStatus) {
-  sharedUpdateStatus = next;
+function setSharedSnapshot(next: UpdaterSnapshot) {
+  sharedSnapshot = next;
   updateStatusListeners.forEach((listener) => listener());
 }
 function subscribeToUpdateStatus(listener: () => void) {
   updateStatusListeners.add(listener);
   return () => updateStatusListeners.delete(listener);
 }
-function getSharedUpdateStatus() {
-  return sharedUpdateStatus;
+function getSharedSnapshot() {
+  return sharedSnapshot;
+}
+
+function recordStatus(newStatus: UpdateStatus) {
+  let downloadSpeed = sharedSnapshot.downloadSpeed;
+  let timeRemaining = sharedSnapshot.timeRemaining;
+
+  if (newStatus.state === 'downloading') {
+    const now = Date.now();
+    const bytes = newStatus.downloaded ?? 0;
+    const total = newStatus.total ?? 0;
+
+    if (prevTime > 0 && bytes > prevBytes) {
+      const bytesPerSecond = calculateDownloadSpeed(bytes, prevBytes, now, prevTime);
+
+      if (bytesPerSecond > 0) {
+        // Throttle speed updates to every 500ms
+        if (now - lastSpeedUpdate > 500) {
+          downloadSpeed = formatDownloadSpeed(bytesPerSecond);
+          lastSpeedUpdate = now;
+        }
+
+        // Calculate time remaining (throttled to 500ms)
+        if (total > 0 && bytes > 0 && bytes < total && now - lastTimeUpdate > 500) {
+          timeRemaining = formatTimeRemaining(calculateTimeRemaining(total, bytes, bytesPerSecond));
+          lastTimeUpdate = now;
+        }
+      }
+    }
+
+    prevBytes = bytes;
+    prevTime = now;
+  } else if (newStatus.state === 'downloaded' || newStatus.state === 'error') {
+    downloadSpeed = '';
+    timeRemaining = '';
+    prevBytes = 0;
+    prevTime = 0;
+    lastSpeedUpdate = 0;
+    lastTimeUpdate = 0;
+  }
+
+  setSharedSnapshot({ status: newStatus, downloadSpeed, timeRemaining });
 }
 
 /** Test-only: reset the shared status between tests (module state persists across `it()`s). */
 export function resetUpdaterStatusForTests() {
-  sharedUpdateStatus = { state: 'idle' };
+  sharedSnapshot = { status: { state: 'idle' }, downloadSpeed: '', timeRemaining: '' };
+  prevBytes = 0;
+  prevTime = 0;
+  lastSpeedUpdate = 0;
+  lastTimeUpdate = 0;
 }
 
 export function useUpdater() {
   const api = useAppClient();
-  const status = useSyncExternalStore(subscribeToUpdateStatus, getSharedUpdateStatus);
-  const [downloadSpeed, setDownloadSpeed] = useState<string>('');
-  const [downloadedBytes, setDownloadedBytes] = useState<number>(0);
-  const [totalBytes, setTotalBytes] = useState<number>(0);
-  const [timeRemaining, setTimeRemaining] = useState<string>('');
-
-  const prevBytesRef = useRef(0);
-  const prevTimeRef = useRef(0);
-  const lastSpeedUpdateRef = useRef(0);
-  const lastTimeUpdateRef = useRef(0);
+  const { status, downloadSpeed, timeRemaining } = useSyncExternalStore(
+    subscribeToUpdateStatus,
+    getSharedSnapshot
+  );
 
   useEffect(() => {
     const off = api.updater.onStatus((s: unknown) => {
-      const newStatus = s as UpdateStatus;
-      setSharedUpdateStatus(newStatus);
-
-      // Track download metrics
-      if (newStatus.state === 'downloading') {
-        const now = Date.now();
-        const bytes = newStatus.downloaded ?? 0;
-        const total = newStatus.total ?? 0;
-
-        setDownloadedBytes(bytes);
-        setTotalBytes(total);
-
-        // Calculate download speed
-        if (prevTimeRef.current > 0 && bytes > prevBytesRef.current) {
-          const bytesPerSecond = calculateDownloadSpeed(
-            bytes,
-            prevBytesRef.current,
-            now,
-            prevTimeRef.current
-          );
-
-          if (bytesPerSecond > 0) {
-            // Throttle speed updates to every 500ms
-            if (now - lastSpeedUpdateRef.current > 500) {
-              setDownloadSpeed(formatDownloadSpeed(bytesPerSecond));
-              lastSpeedUpdateRef.current = now;
-            }
-
-            // Calculate time remaining (throttled to 500ms)
-            if (total > 0 && bytes > 0 && bytes < total) {
-              if (now - lastTimeUpdateRef.current > 500) {
-                const remainingSeconds = calculateTimeRemaining(total, bytes, bytesPerSecond);
-                setTimeRemaining(formatTimeRemaining(remainingSeconds));
-                lastTimeUpdateRef.current = now;
-              }
-            }
-          }
-        }
-
-        prevBytesRef.current = bytes;
-        prevTimeRef.current = now;
-      } else if (newStatus.state === 'downloaded' || newStatus.state === 'error') {
-        // Reset download state
-        setDownloadSpeed('');
-        setDownloadedBytes(0);
-        setTotalBytes(0);
-        setTimeRemaining('');
-        prevBytesRef.current = 0;
-        prevTimeRef.current = 0;
-        lastSpeedUpdateRef.current = 0;
-        lastTimeUpdateRef.current = 0;
-      }
+      recordStatus(s as UpdateStatus);
     });
     return () => {
       off();
@@ -129,6 +154,9 @@ export function useUpdater() {
   const check = useCallback(() => api.updater.check(), [api]);
   const download = useCallback(() => api.updater.download(), [api]);
   const install = useCallback(() => api.updater.install(), [api]);
+
+  const downloadedBytes = status.state === 'downloading' ? (status.downloaded ?? 0) : 0;
+  const totalBytes = status.state === 'downloading' ? (status.total ?? 0) : 0;
 
   return {
     status,

--- a/apps/desktop/src/renderer/services/use-updater/use-updater.ts
+++ b/apps/desktop/src/renderer/services/use-updater/use-updater.ts
@@ -53,15 +53,24 @@ interface UpdaterSnapshot {
 // That history (`prevBytes`/`prevTime` below) is module-level too, for the
 // same reason `status` is: a settings panel that unmounts mid-download and
 // remounts must not restart its own blank history and sit through one more
-// silent tick before the first speed reading appears. Because the
-// always-mounted banner keeps an `updater.onStatus` listener alive for the
-// whole download, this history is never actually gapped by a remount in
-// practice — a remount only adds a second listener recomputing the same
-// delta from the same shared previous sample, which is idempotent (once the
-// first listener advances `prevBytes` for an event, the rest see
-// `bytes === prevBytes` and skip the calculation). Reset on
-// `downloaded`/`error` keeps a finished download from leaking a stale sample
-// into the next one.
+// silent tick before the first speed reading appears. The banner keeps an
+// `updater.onStatus` listener alive for the whole download, so in practice a
+// remount only adds a second listener recomputing the same delta from the
+// same shared previous sample — idempotent, because once the first listener
+// advances `prevBytes` for an event the rest see `bytes === prevBytes` and
+// skip. Reset on `downloaded`/`error` keeps a finished download from leaking
+// a stale sample into the next one.
+//
+// "The banner never unmounts" is ALMOST true and deliberately not relied on:
+// `__root.tsx` renders it inside `ProtocolVersionGate`, which swaps in an
+// ErrorState *instead of* children on a protocol mismatch, so every listener
+// can in fact go away at once. The consequence is bounded — the next event
+// after the gate reopens computes one speed reading against a stale
+// timestamp, then self-corrects — and it only arises in a state where the app
+// is already showing a fatal error, so guarding it would be code for a
+// cosmetic glitch nobody reaches. Written down because the same
+// "always-mounted" assumption has been asserted twice on this PR and was
+// imprecise both times.
 let sharedSnapshot: UpdaterSnapshot = {
   status: { state: 'idle' },
   downloadSpeed: '',

--- a/apps/desktop/src/renderer/services/use-updater/use-updater.ts
+++ b/apps/desktop/src/renderer/services/use-updater/use-updater.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import {
@@ -22,9 +22,40 @@ export type UpdateStatus =
   | { state: 'downloaded'; version: string }
   | { state: 'error'; message: string };
 
+// `status` is shared module state, not local `useState`. There are three
+// independent useUpdater() call sites (this settings panel, the always-mounted
+// banner, and the menu), each with its OWN `updater:status` subscription; the
+// banner/menu never unmount, so they never lose it, but the settings panel
+// mounts/unmounts with route navigation. There is no backend command to ask
+// "what's the status right now" — only this push event — so a fresh instance
+// previously had no way to learn the truth and rendered a stale 'idle',
+// including a live "Check now" button for an update that was already
+// downloading or done. Not React Query: there is nothing to FETCH, only a
+// pushed value to remember, so a plain synchronous external store (every
+// mounted instance reads the SAME value, updated the instant any one of them
+// receives an event) is the whole fix — no extra `check()` call, no re-fetch.
+let sharedUpdateStatus: UpdateStatus = { state: 'idle' };
+const updateStatusListeners = new Set<() => void>();
+function setSharedUpdateStatus(next: UpdateStatus) {
+  sharedUpdateStatus = next;
+  updateStatusListeners.forEach((listener) => listener());
+}
+function subscribeToUpdateStatus(listener: () => void) {
+  updateStatusListeners.add(listener);
+  return () => updateStatusListeners.delete(listener);
+}
+function getSharedUpdateStatus() {
+  return sharedUpdateStatus;
+}
+
+/** Test-only: reset the shared status between tests (module state persists across `it()`s). */
+export function resetUpdaterStatusForTests() {
+  sharedUpdateStatus = { state: 'idle' };
+}
+
 export function useUpdater() {
   const api = useAppClient();
-  const [status, setStatus] = useState<UpdateStatus>({ state: 'idle' });
+  const status = useSyncExternalStore(subscribeToUpdateStatus, getSharedUpdateStatus);
   const [downloadSpeed, setDownloadSpeed] = useState<string>('');
   const [downloadedBytes, setDownloadedBytes] = useState<number>(0);
   const [totalBytes, setTotalBytes] = useState<number>(0);
@@ -38,7 +69,7 @@ export function useUpdater() {
   useEffect(() => {
     const off = api.updater.onStatus((s: unknown) => {
       const newStatus = s as UpdateStatus;
-      setStatus(newStatus);
+      setSharedUpdateStatus(newStatus);
 
       // Track download metrics
       if (newStatus.state === 'downloading') {

--- a/apps/desktop/src/renderer/store/session-store/session-store.ts
+++ b/apps/desktop/src/renderer/store/session-store/session-store.ts
@@ -174,6 +174,17 @@ interface AutopilotSlice {
   /** The found job's url the user applied from — promoted to `focusedJobUrl`
    *  alongside `lastAppliedId` so Back scrolls to that specific row. */
   lastAppliedJobUrl: string | null;
+  /**
+   * The Run/Apply banner `useAutopilotRun` shows on `AutopilotPage` — a start
+   * failure, "all boards failed", or the backend's "already running" refusal.
+   * Lives here (not a `useState` local to that hook) for the same reason
+   * `JobsSlice.scrapeJobId` does: the hook is re-created from scratch on every
+   * `AutopilotPage` mount, so a local `useState` discarded the banner on any
+   * navigate-away-and-back, including the ONE case with no other trace at
+   * all — the concurrent-run refusal, which (unlike a genuine failure) never
+   * touches the persisted `runStatus` badge either.
+   */
+  error: string | null;
 }
 
 /**
@@ -380,6 +391,7 @@ export const useSessionStore = create<SessionState>((set) => ({
     focusedJobUrl: null,
     lastAppliedId: null,
     lastAppliedJobUrl: null,
+    error: null,
   },
   applicationApply: { ...APPLICATION_APPLY_DEFAULTS },
   applications: { collapsedSections: [], filter: '', stageGroup: null, sort: 'updated' },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "check:event-subscriptions": "node scripts/check-event-subscriptions.mjs",
     "check:toolchain-pin": "node scripts/check-toolchain-pin.mjs",
     "check:adr-citations": "node scripts/check-adr-citations.mjs",
+    "check:log-error-leaks": "node scripts/check-log-error-leaks.mjs",
     "clean": "pnpm -r exec rimraf dist out .turbo node_modules/.cache",
     "clean:turbo": "pnpm -r exec rimraf .turbo node_modules/.cache/turbo",
     "storybook": "pnpm --filter @ajh/ui storybook",

--- a/packages/shared/src/ipc/contracts/updater.ts
+++ b/packages/shared/src/ipc/contracts/updater.ts
@@ -21,9 +21,15 @@ export interface ChangelogResult {
 
 /** Result of {@link UpdaterContract.check}. Mirrors the shell's `updater_check`
  *  JSON: an available update with its version, no update, or an error string.
- *  Detailed progress still arrives via the `updater:status` event stream. */
+ *  `downloaded`/`downloading` are only ever `true` together with `available`
+ *  — the backend refuses to discard a download already finished or in
+ *  flight, and reports that state back instead of re-fetching, so a
+ *  returning caller can re-attach rather than restart. Detailed progress
+ *  still arrives via the `updater:status` event stream. */
 export type UpdateCheckResult =
-  { available: true; version: string } | { available: false } | { error: string };
+  | { available: true; version: string; downloaded?: boolean; downloading?: boolean }
+  | { available: false }
+  | { error: string };
 
 export interface UpdaterContract {
   /** Trigger a check. Resolves with the outcome (also emitted on `onStatus`). */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -16,6 +16,7 @@ export type JobStatus =
 export type JobKind =
   | 'ai.generate'
   | 'ai.embed'
+  | 'ai.pull_model'
   | 'document.import'
   | 'document.ocr'
   | 'document.chunk'

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -180,18 +180,21 @@ const SUBSCRIBERS = {
   },
   'features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts': {
     mount: 'route-scoped',
-    hash: 'a9e9d139751f',
+    hash: '71a03a907c6d',
     note:
       'A multi-GB pull survives any unmount — and the trigger really is ANY unmount, not just ' +
       'skipping the step: switching to the Cloud/CLI tab and back, or Back/Forward through ' +
       'the wizard, both tear this hook down. On mount it now re-reads the job registry and ' +
-      "adopts a still-active `ai.pull_model` job, so progress resumes and the run's " +
-      'completion handling still fires. Clicking Download again cannot start a second ' +
-      'concurrent pull: `ai_pull_model` uses `job_start_exclusive` and hands back the ' +
-      "existing job id to re-attach to. Right after adopting, it also re-reads that job's " +
-      'OWN current status (`jobs_get`) and settles immediately if already `completed`/' +
-      "`failed` — closing the race where the job's ONE terminal event fires in the gap " +
-      'between the registry list resolving and `pullJobId` committing, which would ' +
+      'adopts a still-active `ai.pull_model` job for the SAME model this panel shows, so ' +
+      "progress resumes and the run's completion handling still fires. `ai_pull_model` keys " +
+      'its exclusivity on (kind, model) via `job_start_exclusive_keyed` and stamps the model ' +
+      'onto the payload from job START, so a second click for the SAME model re-attaches ' +
+      'to the existing job id, while a DIFFERENT model pulls independently — this reattach ' +
+      "read filters on `payload.model` too, so it cannot adopt someone else's running pull " +
+      'and show its progress under the wrong card. Right after adopting, it also re-reads ' +
+      "that job's OWN current status (`jobs_get`) and settles immediately if already " +
+      "`completed`/`failed` — closing the race where the job's ONE terminal event fires in " +
+      'the gap between the registry list resolving and `pullJobId` committing, which would ' +
       'otherwise be dropped for good and leave the panel reporting `pulling` forever (PR ' +
       '#1036 review finding). A set of already-settled job ids stops that reconcile read ' +
       "re-adopting the SAME job forever off a jobs-list cache that hasn't refetched yet " +

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -180,7 +180,7 @@ const SUBSCRIBERS = {
   },
   'features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts': {
     mount: 'route-scoped',
-    hash: 'df7f51d3d579',
+    hash: '0d51bf7ef0d3',
     note:
       'A multi-GB pull survives any unmount — and the trigger really is ANY unmount, not just ' +
       'skipping the step: switching to the Cloud/CLI tab and back, or Back/Forward through ' +
@@ -193,14 +193,15 @@ const SUBSCRIBERS = {
       "`failed` — closing the race where the job's ONE terminal event fires in the gap " +
       'between the registry list resolving and `pullJobId` committing, which would ' +
       'otherwise be dropped for good and leave the panel reporting `pulling` forever (PR ' +
-      '#1036 review finding). That commit is synchronous into a ref, not left to the next ' +
-      'render, because a promise that resolves purely through microtasks (a real IPC ' +
-      'response included) can settle before React ever gets a scheduler turn. NOT ' +
-      'recovered, still deliberately: a pull that reaches a terminal state entirely BEFORE ' +
-      'the registry snapshot is taken — finished during the unmount gap, never observed as ' +
-      'still running/queued — is never adopted at all, so its success toast and the ' +
-      'health/models recheck are not retroactively fired; doing that on every later mount ' +
-      'would be worse than missing them once.',
+      '#1036 review finding). A set of already-settled job ids stops that reconcile read ' +
+      "re-adopting the SAME job forever off a jobs-list cache that hasn't refetched yet " +
+      '(review found the settle would otherwise loop, double-firing the toast, at the rate ' +
+      'of one redundant IPC round trip per cycle, until an unrelated job event happened to ' +
+      'invalidate the cache). NOT recovered, still deliberately: a pull that reaches a ' +
+      'terminal state entirely BEFORE the registry snapshot is taken — finished during the ' +
+      'unmount gap, never observed as still running/queued — is never adopted at all, so its ' +
+      'success toast and the health/models recheck are not retroactively fired; doing that ' +
+      'on every later mount would be worse than missing them once.',
   },
   'features/settings/components/ai-settings/EmbeddingsSettings/index.tsx': {
     mount: 'route-scoped',

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -180,7 +180,7 @@ const SUBSCRIBERS = {
   },
   'features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts': {
     mount: 'route-scoped',
-    hash: '0d51bf7ef0d3',
+    hash: 'a9e9d139751f',
     note:
       'A multi-GB pull survives any unmount — and the trigger really is ANY unmount, not just ' +
       'skipping the step: switching to the Cloud/CLI tab and back, or Back/Forward through ' +
@@ -197,8 +197,11 @@ const SUBSCRIBERS = {
       "re-adopting the SAME job forever off a jobs-list cache that hasn't refetched yet " +
       '(review found the settle would otherwise loop, double-firing the toast, at the rate ' +
       'of one redundant IPC round trip per cycle, until an unrelated job event happened to ' +
-      'invalidate the cache). NOT recovered, still deliberately: a pull that reaches a ' +
-      'terminal state entirely BEFORE the registry snapshot is taken — finished during the ' +
+      'invalidate the cache). `mountedRef` is restored on effect SETUP, not just cleared on ' +
+      'cleanup — the production app renders inside StrictMode, whose dev-only extra ' +
+      'setup→cleanup→setup pass otherwise leaves it permanently false and every later ' +
+      'reconcile read silently drops. NOT recovered, still deliberately: a pull that reaches ' +
+      'a terminal state entirely BEFORE the registry snapshot is taken — finished during the ' +
       'unmount gap, never observed as still running/queued — is never adopted at all, so its ' +
       'success toast and the health/models recheck are not retroactively fired; doing that ' +
       'on every later mount would be worse than missing them once.',

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -221,15 +221,20 @@ const SUBSCRIBERS = {
     hash: '896ef1fd88e1',
     note:
       'The THIRD `useUpdater` instance, alongside the always-mounted banner and menu — but ' +
-      'the three no longer disagree. `useUpdater` keeps status in a module-level store all ' +
-      'instances share, so a remounted panel immediately shows a download another instance ' +
-      'already knew about instead of rendering a LIVE "Check now" over work in flight. Two ' +
-      'backend guards close the rest: `updater_check` returns the known state BEFORE emitting ' +
-      '`checking` when a download is running or done (so it neither blanks the banner nor ' +
-      "clears Rust's `downloaded_bytes` and forces a re-download), and `updater_download` is " +
-      'guarded against re-entry by a Drop-based guard that cannot latch. NOTE the fix lives ' +
-      "in `services/use-updater/` and the Rust updater, so this entry's own hash could not " +
-      'have detected it (see the dependency caveat above).',
+      'the three no longer disagree. `useUpdater` keeps status AND the download-progress ' +
+      'readout (speed, time remaining) in one module-level store all instances share — the ' +
+      'byte counts need no store slot of their own, since they are derived straight off the ' +
+      "shared status's `downloaded`/`total` fields — so a remounted panel immediately shows " +
+      'a download another instance already knew about, numbers included, instead of a LIVE ' +
+      '"Check now" over work in flight or a correct label sitting over a blank/zero progress ' +
+      'readout (an earlier pass on this PR shared only `status`, leaving the metrics ' +
+      'per-instance — closed by folding them into the same store). Two backend guards close ' +
+      'the rest: `updater_check` returns the known state BEFORE emitting `checking` when a ' +
+      "download is running or done (so it neither blanks the banner nor clears Rust's " +
+      '`downloaded_bytes` and forces a re-download), and `updater_download` is guarded ' +
+      'against re-entry by a Drop-based guard that cannot latch. NOTE the fix lives in ' +
+      "`services/use-updater/` and the Rust updater, so this entry's own hash could not have " +
+      'detected it (see the dependency caveat above).',
   },
   'features/monitoring/hooks/useActivityFeed.ts': {
     mount: 'route-scoped',

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -586,6 +586,27 @@ export function violations(
     );
   }
 
+  // Vacuity hole (found reviewing #1036): staleNoteEntries only looks at
+  // entries that HAVE a hash, so a route-scoped entry that omits the key
+  // skips the tripwire below forever — silently, since nothing else requires
+  // the key to be present. Checked here, ahead of staleness, so a missing or
+  // malformed hash is reported as its own violation instead of quietly
+  // reading as "nothing to report". `always`-mounted entries stay exempt:
+  // their note is a structural claim about WHERE the file is called from
+  // (true by construction of the call site), not a description of what
+  // navigating away costs, so there is nothing for a content hash to police.
+  const missingHash = Object.entries(inventory)
+    .filter(([, e]) => e.mount === 'route-scoped' && !/^[0-9a-f]{12}$/.test(e.hash ?? ''))
+    .map(([f]) => f);
+  if (missingHash.length > 0) {
+    problems.push(
+      'A route-scoped entry must carry a `hash` (12 hex chars, from hashBytes()) so its ' +
+        'note goes stale when the subscriber file changes — without one the tripwire below ' +
+        'never fires, no matter how far the file drifts:\n' +
+        missingHash.map((f) => `    ${f}`).join('\n')
+    );
+  }
+
   // The tripwire. A note is a claim about the code at a specific point in
   // time; a changed file invalidates that claim until a human re-reads it.
   // This fires on ANY byte change to the subscriber file — including a pure

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -48,6 +48,7 @@
 // which carries no path filter, so it cannot be skipped by a diff that happens to
 // miss the renderer.
 
+import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -98,65 +99,115 @@ const SUBSCRIBERS = {
   },
 
   // ── Debt: backend work whose only listener is route-scoped ────────────────
+  //
+  // `hash` is a tripwire, not part of the invariant above: 12 hex chars of the
+  // subscriber file's own sha256 (see `hashBytes`/`staleNoteEntries`). When the
+  // file's current hash no longer matches, the note was written about a version
+  // of the code that no longer exists — re-read the file, fix the note if it
+  // drifted, and paste in the new hash `staleNoteEntries` prints. This is
+  // deliberately dumb: it fires on a pure rename or comment tweak too, same as
+  // a snapshot test. That is the correct trade — the alternative is a note that
+  // silently outlives the code it describes, which is exactly how 8 of these 9
+  // notes went stale with nobody noticing.
 
   'hooks/use-resume-pipeline-session.ts': {
     mount: 'route-scoped',
+    hash: 'b61aaf6bca1a',
     note:
-      'Mounts THREE subscriptions (job events, pipeline stages, draft stream) from ' +
-      'features/documents/components/TailorFlow/GeneratingPanel.tsx — ' +
-      'route-scoped AND conditionally rendered, so a generation that runs for minutes ' +
-      'drops every stage event emitted while the user is elsewhere. Reconnect covers most ' +
-      'of that: the session store keeps `applicationApply.applyRun`, TailorFlow hands it ' +
-      'back as initialRunId/initialJobId, and the hook re-reads the run record and replays ' +
-      'its persisted stage trail — so a remounted panel shows real progress and can still ' +
-      'cancel. What is NOT recoverable is the streamed draft/letter/thinking text: it is ' +
-      'useState with no durable transcript, so a reconnected run jumps to the finished ' +
-      'document instead of the live stream.',
+      'Mounted in TailorFlow/index.tsx (not GeneratingPanel, which takes only props) via ' +
+      "useTailorPipeline → useResumePipelineSession. Reconnect (the session store's " +
+      'applyRun → run-record re-read + stage-trail replay) restores progress, the step ' +
+      'checklist, and Cancel, so a remounted panel is not blank. NOT recovered: the ' +
+      'streamed draft/letter/thinking text (useState, no transcript — a reconnected run ' +
+      'jumps straight to the finished document), and a run that FAILS before the draft ' +
+      'stage completes returns to a bare "configuring" wizard with no error banner at all — ' +
+      '`error` is written only from the live event, never derived from the run record.',
   },
   'features/jobs/hooks/useScraping.ts': {
     mount: 'route-scoped',
+    hash: '81118657fcb5',
     note:
-      'Scrape progress. Unmounting also discards the in-flight job id, which breaks the ' +
-      '"cancel the previous scrape first" exclusivity contract: the orphan keeps writing ' +
-      'into the postings cache and can no longer be cancelled from the UI, while the ' +
-      'always-mounted status bar still shows it running.',
+      'Unmounting resets the live progress readout: the command-bar label drops back to ' +
+      'plain "Scanning" and the results bar shows a false 0% on remount. On the default ' +
+      'single-board search that reading never self-corrects — `scrape:progress` fires once, ' +
+      'at completion — even though the backend already knows the true fraction (the ' +
+      'watchdog fetches the job record but discards its progress field). NOT lost: the ' +
+      'cancel-across-remount / single-active-scrape exclusivity (the job id lives in the ' +
+      'Zustand store, not this component), and per-board diagnostics + postings, which the ' +
+      'watchdog and cache invalidation still recover.',
   },
   'features/jobs/components/JobsPage/index.tsx': {
     mount: 'route-scoped',
+    hash: 'b2df3b57b2c8',
     note:
-      'A scrape that finishes while the user is elsewhere drops its terminal job event, so ' +
-      'the per-board diagnostics strip ("aggregator: 429 rate limited") is lost for that ' +
-      'run — the one thing that explains an empty result.',
+      'A scrape that COMPLETES while the user is elsewhere recovers its per-board ' +
+      "diagnostics strip on remount (the watchdog re-reads the job record's `result.boards`). " +
+      'What does NOT recover: a scrape that FAILS or is CANCELLED off-page — the watchdog ' +
+      'passes no summaries on those branches and the fields were already cleared when the ' +
+      'scrape started, so the user returns to an empty list with zero explanation, exactly ' +
+      'when one matters most. The completed path also skips the postings-cache invalidation ' +
+      'the live event handler does, so inside the 30s query staleTime a remount can still ' +
+      'show 0 jobs for a scrape that actually found some.',
   },
   'features/autopilot/hooks/useAutopilotRun.ts': {
     mount: 'route-scoped',
+    hash: 'cd56e16f7173',
     note:
-      'The originally-reported bug. Partly mitigated: the card now falls back to the ' +
-      "backend's persisted runStatus and the list is invalidated on a terminal step, so a " +
-      'run survives navigation visibly. The step LOG is still lost.',
+      "The originally-reported bug. Partly mitigated: the card falls back to the backend's " +
+      'persisted `runStatus`, so a run navigated away from usually still reads as running on ' +
+      'return. Still lost: every step-log line (mount-local reducer — only per-board ' +
+      'summaries persist, not the rank/re-rank detail that explains a thin result) and the ' +
+      'inline error / "already running" banner (useState). The terminal-step invalidation ' +
+      'this relies on does NOT help while unmounted — the subscription itself is torn down — ' +
+      'so the actual recovery is the list query going stale on remount; inside its 30s ' +
+      'staleTime (e.g. right after create-then-auto-run) the fallback can read a pre-run ' +
+      'runStatus and show idle for a run that is still going.',
   },
   'features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts': {
     mount: 'route-scoped',
+    hash: '1a35b07347dc',
     note:
-      'A multi-GB Ollama pull loses its progress and its completion event when the ' +
-      'onboarding step is skipped or navigated away from. The pull itself continues.',
+      "Pull tracking (`pullJobId` and all progress/speed state) lives only in this hook's " +
+      'useState, so ANY unmount loses it — not just skipping the step or navigating away, but ' +
+      'switching to the Cloud/CLI tab and back, or Back/Forward through the wizard. On ' +
+      'remount `pullJobId` is null, so no event for the still-running pull can ever match ' +
+      'again: progress, the success toast, AND the `onDownloadComplete` health/models ' +
+      'recheck are all silently lost. The panel then re-shows the Download button, and ' +
+      'clicking it starts a genuine second concurrent pull (`ai_pull_model` uses plain ' +
+      '`job_start`, not the exclusive variant used elsewhere). Nothing else covers for it: ' +
+      'the wizard overlay sits over the always-mounted StatusBar, and the pull has no kind ' +
+      'label there anyway.',
   },
   'features/settings/components/ai-settings/EmbeddingsSettings/index.tsx': {
     mount: 'route-scoped',
+    hash: '0de0f20640fd',
     note:
-      'Re-index completion is handled only by the Settings panel that started it, and the ' +
-      "panel ignores the backend's own `indexing` flag on remount.",
+      'Completion is reported only by the panel that started the run: its `useJobEvents` ' +
+      'handler unsubscribes on unmount, so the complete / partial-failure / failure toast is ' +
+      'lost and never re-raised (no notification-center record either). The button also ' +
+      'reverts to "Re-index now" mid-run because its busy state is local (`reindexJobId` / ' +
+      "`reembed.isPending`), not the backend's `indexing` flag. That flag IS read on remount " +
+      '— it only drives the stale-count copy line, which is hidden whenever `stale === 0`, ' +
+      'and a re-index of already-indexed documents keeps `stale` at 0 for the whole run, so ' +
+      'it never has anywhere to render. No data loss or double-billing: `ai_reembed_all` ' +
+      'hands back the already-running job id.',
   },
   'features/settings/components/update-section/index.tsx': {
     mount: 'route-scoped',
+    hash: '896ef1fd88e1',
     note:
-      'The THIRD independent `useUpdater` instance, each with its own subscription and its ' +
-      'own local status. The other two are always-mounted (the banner and the menu), so the ' +
-      'update itself is never lost — but this copy resets to idle on every route change, so ' +
-      'a download started in Settings shows no progress when the user returns.',
+      "The THIRD independent `useUpdater` instance — its own `useState({ state: 'idle' })` " +
+      'and its own `updater:status` listener, both dropped on unmount, with no backend ' +
+      'status getter to re-sync from. On return mid-download this renders a LIVE "Check now" ' +
+      'button, not a neutral state. Clicking it re-triggers `updater_check`, which emits ' +
+      '`checking` — hiding the always-mounted banner, the one surface still telling the ' +
+      "truth — and clears Rust's `downloaded_bytes`, discarding an already-downloaded update " +
+      'and forcing a re-download, with no guard against a second concurrent one. The update ' +
+      'itself is never lost — only if the user acts on this misleading control.',
   },
   'features/monitoring/hooks/useActivityFeed.ts': {
     mount: 'route-scoped',
+    hash: 'e1923404534f',
     note:
       'ACCEPTED, not debt. A live activity feed is a view of the current moment; there is no ' +
       'per-run state to preserve and nothing is lost by only listening while the monitoring ' +
@@ -164,10 +215,20 @@ const SUBSCRIBERS = {
   },
   'features/dashboard/components/AISystemStatus/index.tsx': {
     mount: 'route-scoped',
+    hash: '55fe0b8309f1',
     note:
-      'ACCEPTED, not debt. useWorkerActivity feeding a live "what is busy right now" readout; ' +
-      'the reading is re-derived from the job registry on mount, so there is no history a ' +
-      'missed event could have cost it.',
+      'Not accepted-by-design: the safety here is real but conditional. StatusBar mounts the ' +
+      'identical `useWorkerActivity` from routes/__root.tsx (inside `ProtocolVersionGate`), ' +
+      'so the shared job-events cache keeps invalidating while this card is unmounted and the ' +
+      'counts read correctly on return — but that is an UNENFORCED cross-file coupling; ' +
+      'nothing checks that StatusBar keeps being rendered everywhere, and this entry is the ' +
+      'only place the dependency is written down. There is also a real gap: React Query ' +
+      "defaults to `networkMode: 'online'` (no override here) and the client sets " +
+      '`refetchOnReconnect: false`, so with `navigator.onLine` false every fetch this card ' +
+      'depends on pauses and nothing re-drives it — the card then shows stale/idle counts for ' +
+      'backend work (embeddings, local-Ollama generation) that keeps running regardless of ' +
+      'network state. Minor: `refreshing`, the spinner flag, is local and drops mid-refresh ' +
+      'on unmount.',
   },
 };
 
@@ -372,12 +433,58 @@ export function discoverSubscribers(hooks, rendererDir = RENDERER) {
 }
 
 /**
+ * First 12 hex chars of a file's sha256 — enough to detect any byte change
+ * without carrying a 64-char digest around in a hand-edited table.
+ */
+export function hashBytes(bytes) {
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 12);
+}
+
+/**
+ * Route-scoped entries whose stored `hash` no longer matches their subscriber
+ * file's CURRENT bytes — i.e. the file changed since the note was last read
+ * against it, so the note may be describing code that no longer exists.
+ *
+ * `readFile(relPath)` is injected (default: read from the real renderer tree)
+ * so this stays a pure function of its inputs: a test can hand it a fixture
+ * reader instead of touching the real tree, and — the one thing a stale-note
+ * guard's own test must never do — this file's own tests do not hash a real
+ * file and then compare that hash to itself.
+ *
+ * Only `route-scoped` entries carry a `hash`. An `always`-mounted entry's note
+ * is a much weaker claim ("this is only ever called from routes/__root.tsx"),
+ * true by construction of where the call sites live rather than a description
+ * of what navigating away costs — and the always-mounted files here
+ * (routes/__root.tsx, StatusBar, …) are touched often for unrelated UI work,
+ * so hashing them would mostly generate noise on the debt list this exists to
+ * keep honest, not on the structural fact those entries actually assert.
+ */
+export function staleNoteEntries(
+  inventory = SUBSCRIBERS,
+  readFile = (rel) => readFileSync(join(RENDERER, rel))
+) {
+  const stale = [];
+  for (const [file, entry] of Object.entries(inventory)) {
+    if (!entry.hash) continue;
+    const currentHash = hashBytes(readFile(file));
+    if (currentHash !== entry.hash) stale.push({ file, note: entry.note, currentHash });
+  }
+  return stale;
+}
+
+/**
  * Every violation, as human-readable lines. Empty means the invariant holds.
  *
  * Returned rather than printed so the check is testable without capturing
  * stdout or trapping `process.exit`.
  */
-export function violations(inventory = SUBSCRIBERS, hooks, subscribers, namespaced = []) {
+export function violations(
+  inventory = SUBSCRIBERS,
+  hooks,
+  subscribers,
+  namespaced = [],
+  staleNotes = []
+) {
   const problems = [];
 
   // Discovery resolves imported BINDINGS, which handles `as` aliases but not a
@@ -462,6 +569,27 @@ export function violations(inventory = SUBSCRIBERS, hooks, subscribers, namespac
     );
   }
 
+  // The tripwire. A note is a claim about the code at a specific point in
+  // time; a changed file invalidates that claim until a human re-reads it.
+  // This fires on ANY byte change to the subscriber file — including a pure
+  // rename, comment, or formatting tweak — by design: the failure mode this
+  // guards is a note that silently outlives the code it describes (8 of the
+  // 9 route-scoped notes here did exactly that), and the fix is always a
+  // one-line hash update, cheap next to the cost of finding out a year late.
+  if (staleNotes.length > 0) {
+    problems.push(
+      'These subscriber files changed since their note was last checked against them — the\n' +
+        '  note may no longer describe the code. Re-read the file, fix the note if it drifted,\n' +
+        '  then paste in the new hash shown below:\n' +
+        staleNotes
+          .map(
+            ({ file, note, currentHash }) =>
+              `    ${file}\n` + `      current note: "${note}"\n` + `      new hash: ${currentHash}`
+          )
+          .join('\n')
+    );
+  }
+
   return problems;
 }
 
@@ -469,7 +597,8 @@ export function violations(inventory = SUBSCRIBERS, hooks, subscribers, namespac
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const hooks = discoverSubscriptionHooks();
   const subscribers = discoverSubscribers(hooks);
-  const problems = violations(SUBSCRIBERS, hooks, subscribers, namespaceImporters());
+  const staleNotes = staleNoteEntries(SUBSCRIBERS);
+  const problems = violations(SUBSCRIBERS, hooks, subscribers, namespaceImporters(), staleNotes);
 
   if (problems.length > 0) {
     for (const p of problems) console.error(`✗ ${p}`);

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -180,7 +180,7 @@ const SUBSCRIBERS = {
   },
   'features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts': {
     mount: 'route-scoped',
-    hash: '66b7dd5ae605',
+    hash: 'df7f51d3d579',
     note:
       'A multi-GB pull survives any unmount — and the trigger really is ANY unmount, not just ' +
       'skipping the step: switching to the Cloud/CLI tab and back, or Back/Forward through ' +
@@ -188,10 +188,19 @@ const SUBSCRIBERS = {
       "adopts a still-active `ai.pull_model` job, so progress resumes and the run's " +
       'completion handling still fires. Clicking Download again cannot start a second ' +
       'concurrent pull: `ai_pull_model` uses `job_start_exclusive` and hands back the ' +
-      'existing job id to re-attach to. NOT recovered, deliberately: a pull that reaches a ' +
-      'terminal state inside the unmount/remount gap — re-firing a success toast and the ' +
-      'health/models recheck for an already-finished job on every later mount would be worse ' +
-      'than missing them once.',
+      "existing job id to re-attach to. Right after adopting, it also re-reads that job's " +
+      'OWN current status (`jobs_get`) and settles immediately if already `completed`/' +
+      "`failed` — closing the race where the job's ONE terminal event fires in the gap " +
+      'between the registry list resolving and `pullJobId` committing, which would ' +
+      'otherwise be dropped for good and leave the panel reporting `pulling` forever (PR ' +
+      '#1036 review finding). That commit is synchronous into a ref, not left to the next ' +
+      'render, because a promise that resolves purely through microtasks (a real IPC ' +
+      'response included) can settle before React ever gets a scheduler turn. NOT ' +
+      'recovered, still deliberately: a pull that reaches a terminal state entirely BEFORE ' +
+      'the registry snapshot is taken — finished during the unmount gap, never observed as ' +
+      'still running/queued — is never adopted at all, so its success toast and the ' +
+      'health/models recheck are not retroactively fired; doing that on every later mount ' +
+      'would be worse than missing them once.',
   },
   'features/settings/components/ai-settings/EmbeddingsSettings/index.tsx': {
     mount: 'route-scoped',

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -109,74 +109,89 @@ const SUBSCRIBERS = {
   // a snapshot test. That is the correct trade — the alternative is a note that
   // silently outlives the code it describes, which is exactly how 8 of these 9
   // notes went stale with nobody noticing.
+  //
+  // KNOWN BLIND SPOT, measured the first time this fired for real: the hash
+  // covers the DECLARED file only, so a note also goes stale when the behaviour
+  // it describes changes in something that file merely CALLS. Both misses came
+  // from one batch — JobsPage's note was fixed inside `useScraping.ts`, and
+  // update-section's inside `services/use-updater/` plus the Rust updater —
+  // and neither declared file was touched, so neither tripped. Hashing the
+  // transitive import graph would fire on nearly every commit and be ignored
+  // within a week, so the trade stands; the entries that were fixed elsewhere
+  // say so in their own note instead. Re-read a note whenever you change what
+  // its file DEPENDS on, not only the file itself.
 
   'hooks/use-resume-pipeline-session.ts': {
     mount: 'route-scoped',
-    hash: 'b61aaf6bca1a',
+    hash: '10ff9d4443cb',
     note:
       'Mounted in TailorFlow/index.tsx (not GeneratingPanel, which takes only props) via ' +
       "useTailorPipeline → useResumePipelineSession. Reconnect (the session store's " +
       'applyRun → run-record re-read + stage-trail replay) restores progress, the step ' +
-      'checklist, and Cancel, so a remounted panel is not blank. NOT recovered: the ' +
-      'streamed draft/letter/thinking text (useState, no transcript — a reconnected run ' +
-      'jumps straight to the finished document), and a run that FAILS before the draft ' +
-      'stage completes returns to a bare "configuring" wizard with no error banner at all — ' +
-      '`error` is written only from the live event, never derived from the run record.',
+      'checklist, and Cancel, so a remounted panel is not blank. A run that FAILS while the ' +
+      "user is elsewhere now shows why: `error` falls back to the run record's " +
+      '`stoppedReason`, so returning no longer lands on a bare "configuring" wizard as if ' +
+      'Generate had never been pressed. NOT recovered: the streamed draft/letter/thinking ' +
+      'text (useState, no transcript — a reconnected run jumps straight to the finished ' +
+      "document), and the live message's exact stage/seconds detail, since the record " +
+      'persists only the wire token.',
   },
   'features/jobs/hooks/useScraping.ts': {
     mount: 'route-scoped',
-    hash: '81118657fcb5',
+    hash: 'b16ef7bcd515',
     note:
-      'Unmounting resets the live progress readout: the command-bar label drops back to ' +
-      'plain "Scanning" and the results bar shows a false 0% on remount. On the default ' +
-      'single-board search that reading never self-corrects — `scrape:progress` fires once, ' +
-      'at completion — even though the backend already knows the true fraction (the ' +
-      'watchdog fetches the job record but discards its progress field). NOT lost: the ' +
-      'cancel-across-remount / single-active-scrape exclusivity (the job id lives in the ' +
-      'Zustand store, not this component), and per-board diagnostics + postings, which the ' +
-      'watchdog and cache invalidation still recover.',
+      'Nothing user-visible is lost on a route change any more. The progress readout used to ' +
+      'show a false 0% for the rest of the run — on the default single-board search ' +
+      '`scrape:progress` fires once, at completion, so it never self-corrected — and now ' +
+      "falls back to the job record's persisted `progress`, which the watchdog was already " +
+      'fetching and discarding. The watchdog also has a leading tick, so recovery is ' +
+      'immediate rather than 2.5s late. A scrape that FAILS off-page now restores a ' +
+      'sanitized reason instead of an unexplained empty list, and the completed path ' +
+      'invalidates the postings cache the way the live event handler does. Still bounded by ' +
+      'the 2.5s poll: between ticks the fraction is as stale as the last poll.',
   },
   'features/jobs/components/JobsPage/index.tsx': {
     mount: 'route-scoped',
     hash: 'b2df3b57b2c8',
     note:
-      'A scrape that COMPLETES while the user is elsewhere recovers its per-board ' +
-      "diagnostics strip on remount (the watchdog re-reads the job record's `result.boards`). " +
-      'What does NOT recover: a scrape that FAILS or is CANCELLED off-page — the watchdog ' +
-      'passes no summaries on those branches and the fields were already cleared when the ' +
-      'scrape started, so the user returns to an empty list with zero explanation, exactly ' +
-      'when one matters most. The completed path also skips the postings-cache invalidation ' +
-      'the live event handler does, so inside the 30s query staleTime a remount can still ' +
-      'show 0 jobs for a scrape that actually found some.',
+      'A scrape that ends off-page — completed OR failed — now comes back explained. The ' +
+      "watchdog re-reads the job record's `result.boards` for the diagnostics strip, writes " +
+      'a sanitized failure note on the failed branch, and invalidates the postings cache so ' +
+      'a remount inside the 30s query staleTime cannot show 0 jobs for a scrape that found ' +
+      'some. Cancelled stays deliberately bare: the user initiated it, so there is nothing ' +
+      'to explain. NOTE this page composes the fix rather than containing it — all of it ' +
+      "lives in `useScraping.ts`, so this entry's own hash could not have detected the " +
+      'change (see the dependency caveat above).',
   },
   'features/autopilot/hooks/useAutopilotRun.ts': {
     mount: 'route-scoped',
-    hash: 'cd56e16f7173',
+    hash: 'bf031614c42a',
     note:
-      "The originally-reported bug. Partly mitigated: the card falls back to the backend's " +
-      'persisted `runStatus`, so a run navigated away from usually still reads as running on ' +
-      'return. Still lost: every step-log line (mount-local reducer — only per-board ' +
-      'summaries persist, not the rank/re-rank detail that explains a thin result) and the ' +
-      'inline error / "already running" banner (useState). The terminal-step invalidation ' +
-      'this relies on does NOT help while unmounted — the subscription itself is torn down — ' +
-      'so the actual recovery is the list query going stale on remount; inside its 30s ' +
-      'staleTime (e.g. right after create-then-auto-run) the fallback can read a pre-run ' +
-      'runStatus and show idle for a run that is still going.',
+      "The originally-reported bug, now closed on both halves. The card reads the backend's " +
+      'persisted `runStatus`, and `useAutopilots` sets `staleTime: 0` so every remount ' +
+      'refetches — previously it inherited the 30s default with nothing invalidating on run ' +
+      'START, so right after create-then-auto-run the card could show idle with an enabled ' +
+      'Run button for a live run. The inline error / "already running" banner now lives in ' +
+      'the session store and survives navigation. Still lost, accepted: every step-log line ' +
+      '(mount-local reducer — only per-board summaries persist, not the rank/re-rank detail ' +
+      'that explains a thin result). The terminal-step invalidation does NOT help while ' +
+      'unmounted — the subscription itself is torn down — so the remount refetch is the ' +
+      'recovery, not that call.',
   },
   'features/onboarding/steps/ollama/ModelSelectionPanel/useModelPull.ts': {
     mount: 'route-scoped',
-    hash: '1a35b07347dc',
+    hash: '66b7dd5ae605',
     note:
-      "Pull tracking (`pullJobId` and all progress/speed state) lives only in this hook's " +
-      'useState, so ANY unmount loses it — not just skipping the step or navigating away, but ' +
-      'switching to the Cloud/CLI tab and back, or Back/Forward through the wizard. On ' +
-      'remount `pullJobId` is null, so no event for the still-running pull can ever match ' +
-      'again: progress, the success toast, AND the `onDownloadComplete` health/models ' +
-      'recheck are all silently lost. The panel then re-shows the Download button, and ' +
-      'clicking it starts a genuine second concurrent pull (`ai_pull_model` uses plain ' +
-      '`job_start`, not the exclusive variant used elsewhere). Nothing else covers for it: ' +
-      'the wizard overlay sits over the always-mounted StatusBar, and the pull has no kind ' +
-      'label there anyway.',
+      'A multi-GB pull survives any unmount — and the trigger really is ANY unmount, not just ' +
+      'skipping the step: switching to the Cloud/CLI tab and back, or Back/Forward through ' +
+      'the wizard, both tear this hook down. On mount it now re-reads the job registry and ' +
+      "adopts a still-active `ai.pull_model` job, so progress resumes and the run's " +
+      'completion handling still fires. Clicking Download again cannot start a second ' +
+      'concurrent pull: `ai_pull_model` uses `job_start_exclusive` and hands back the ' +
+      'existing job id to re-attach to. NOT recovered, deliberately: a pull that reaches a ' +
+      'terminal state inside the unmount/remount gap — re-firing a success toast and the ' +
+      'health/models recheck for an already-finished job on every later mount would be worse ' +
+      'than missing them once.',
   },
   'features/settings/components/ai-settings/EmbeddingsSettings/index.tsx': {
     mount: 'route-scoped',
@@ -196,14 +211,16 @@ const SUBSCRIBERS = {
     mount: 'route-scoped',
     hash: '896ef1fd88e1',
     note:
-      "The THIRD independent `useUpdater` instance — its own `useState({ state: 'idle' })` " +
-      'and its own `updater:status` listener, both dropped on unmount, with no backend ' +
-      'status getter to re-sync from. On return mid-download this renders a LIVE "Check now" ' +
-      'button, not a neutral state. Clicking it re-triggers `updater_check`, which emits ' +
-      '`checking` — hiding the always-mounted banner, the one surface still telling the ' +
-      "truth — and clears Rust's `downloaded_bytes`, discarding an already-downloaded update " +
-      'and forcing a re-download, with no guard against a second concurrent one. The update ' +
-      'itself is never lost — only if the user acts on this misleading control.',
+      'The THIRD `useUpdater` instance, alongside the always-mounted banner and menu — but ' +
+      'the three no longer disagree. `useUpdater` keeps status in a module-level store all ' +
+      'instances share, so a remounted panel immediately shows a download another instance ' +
+      'already knew about instead of rendering a LIVE "Check now" over work in flight. Two ' +
+      'backend guards close the rest: `updater_check` returns the known state BEFORE emitting ' +
+      '`checking` when a download is running or done (so it neither blanks the banner nor ' +
+      "clears Rust's `downloaded_bytes` and forces a re-download), and `updater_download` is " +
+      'guarded against re-entry by a Drop-based guard that cannot latch. NOTE the fix lives ' +
+      "in `services/use-updater/` and the Rust updater, so this entry's own hash could not " +
+      'have detected it (see the dependency caveat above).',
   },
   'features/monitoring/hooks/useActivityFeed.ts': {
     mount: 'route-scoped',

--- a/scripts/check-event-subscriptions.test.mjs
+++ b/scripts/check-event-subscriptions.test.mjs
@@ -383,7 +383,9 @@ describe('violations', () => {
   });
 
   it('rejects a route-scoped entry whose note explains nothing', () => {
-    const lazy = { ...ok, f5: { mount: 'route-scoped', note: 'todo' } };
+    // A valid hash keeps this isolated to the note-length concern — see the
+    // hash-presence block below for the separate missing-hash check.
+    const lazy = { ...ok, f5: { mount: 'route-scoped', hash: hashBytes('x'), note: 'todo' } };
     const problems = violations(lazy, hooks, subs);
 
     expect(problems).toHaveLength(1);
@@ -398,6 +400,45 @@ describe('violations', () => {
     };
 
     expect(violations(typo, hooks, subs)[0]).toContain('f5');
+  });
+
+  // ── The hash-presence hole (found reviewing #1036) ────────────────────────
+  // staleNoteEntries only checks entries that HAVE a hash, so a route-scoped
+  // entry that omits the key never goes stale — permanently, silently. These
+  // prove violations() catches the omission itself, independent of staleness.
+
+  it('rejects a route-scoped entry with no hash — its note could never go stale', () => {
+    const noHash = {
+      ...ok,
+      f5: { mount: 'route-scoped', note: 'a note long enough to pass the length test' },
+    };
+    const problems = violations(noHash, hooks, subs);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('f5');
+    expect(problems[0]).toContain('hash');
+  });
+
+  it('rejects a route-scoped entry whose hash is not a valid 12-hex-char value', () => {
+    const badHash = {
+      ...ok,
+      f5: {
+        mount: 'route-scoped',
+        hash: 'not-a-hash!!',
+        note: 'a note long enough to pass the length test',
+      },
+    };
+    const problems = violations(badHash, hooks, subs);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('f5');
+  });
+
+  it('does not require a hash for an always-mounted entry', () => {
+    // `ok` is every entry at mount: 'always' with no hash at all — this is
+    // the deliberate exemption, proven by staying green rather than by a
+    // special case bolted onto the assertion.
+    expect(violations(ok, hooks, subs)).toEqual([]);
   });
 
   // ── The vacuity guards ────────────────────────────────────────────────────

--- a/scripts/check-event-subscriptions.test.mjs
+++ b/scripts/check-event-subscriptions.test.mjs
@@ -6,9 +6,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   discoverSubscribers,
   discoverSubscriptionHooks,
+  hashBytes,
   importedBindings,
   stripCommentsAndStrings,
   namespaceImporters,
+  staleNoteEntries,
   SUBSCRIBERS,
   violations,
 } from './check-event-subscriptions.mjs';
@@ -300,6 +302,60 @@ describe('namespaceImporters', () => {
   });
 });
 
+describe('hashBytes', () => {
+  it('matches a hand-written expected value, not its own output', () => {
+    // 'hello' is a well-known sha256 test vector
+    // (2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824), typed
+    // in here independently of the implementation — the repo's own lesson from
+    // #998-#1003 is that comparing a hash to itself proves nothing.
+    expect(hashBytes('hello')).toBe('2cf24dba5fb0');
+  });
+
+  it('changes when a single byte changes', () => {
+    expect(hashBytes('hello')).not.toBe(hashBytes('hellp'));
+  });
+});
+
+describe('staleNoteEntries', () => {
+  const inventory = {
+    'features/thing/index.tsx': {
+      mount: 'route-scoped',
+      hash: hashBytes('original content'),
+      note: 'x',
+    },
+    'always/thing.ts': { mount: 'always', note: 'no hash — exempt' },
+  };
+
+  it('reports nothing when the stored hash matches the file', () => {
+    const readFile = () => 'original content';
+    expect(staleNoteEntries(inventory, readFile)).toEqual([]);
+  });
+
+  it('flags an entry whose subscriber file content changed since the hash was recorded', () => {
+    // The mutation this guards against: someone edits the behavior a note
+    // describes without re-reading (or updating) the note.
+    const readFile = (rel) =>
+      rel === 'features/thing/index.tsx' ? 'MUTATED content' : 'original content';
+    const stale = staleNoteEntries(inventory, readFile);
+
+    expect(stale).toHaveLength(1);
+    expect(stale[0].file).toBe('features/thing/index.tsx');
+    expect(stale[0].note).toBe('x');
+    expect(stale[0].currentHash).toBe(hashBytes('MUTATED content'));
+  });
+
+  it('skips entries with no stored hash (the always-mounted exemption)', () => {
+    // The route-scoped entry legitimately drifts here too (readFile always
+    // returns something other than 'original content') — the point is that
+    // the hash-less always-mounted entry is never even checked, let alone
+    // flagged, no matter what its file contains.
+    const readFile = () => 'anything at all, never checked';
+    const stale = staleNoteEntries(inventory, readFile);
+
+    expect(stale.map((s) => s.file)).not.toContain('always/thing.ts');
+  });
+});
+
 describe('violations', () => {
   const hooks = ['a', 'b', 'c', 'd', 'e'];
   const subs = ['f1', 'f2', 'f3', 'f4', 'f5'];
@@ -369,6 +425,22 @@ describe('violations', () => {
     expect(problems).toHaveLength(1);
     expect(problems[0]).toContain('compared against nothing');
   });
+
+  // ── The hash tripwire ─────────────────────────────────────────────────────
+
+  it('passes staleNotes through untouched when empty', () => {
+    expect(violations(ok, hooks, subs, [], [])).toEqual([]);
+  });
+
+  it('fails and prints the note + file when a subscriber file drifted from its hash', () => {
+    const drifted = [{ file: 'f3', note: 'what f3 loses', currentHash: 'deadbeef0000' }];
+    const problems = violations(ok, hooks, subs, [], drifted);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('f3');
+    expect(problems[0]).toContain('what f3 loses');
+    expect(problems[0]).toContain('deadbeef0000');
+  });
 });
 
 describe('against the real renderer', () => {
@@ -390,5 +462,37 @@ describe('against the real renderer', () => {
 
   it('holds the invariant', () => {
     expect(violations(SUBSCRIBERS, hooks, subscribers)).toEqual([]);
+  });
+
+  it('every route-scoped note hash matches its real subscriber file right now', () => {
+    // The end-to-end proof for "with correct hashes, the check passes": this
+    // hashes the ACTUAL files on disk and compares against what is committed
+    // in SUBSCRIBERS, then runs that result through violations() exactly like
+    // the CLI entrypoint does.
+    const staleNotes = staleNoteEntries(SUBSCRIBERS);
+    expect(staleNotes).toEqual([]);
+    expect(violations(SUBSCRIBERS, hooks, subscribers, [], staleNotes)).toEqual([]);
+  });
+
+  it('DETECTS a mutated subscriber file end-to-end, via a temp fixture', () => {
+    // Proves the tripwire fires through the full violations() pipeline, not
+    // just the pure staleNoteEntries() unit above — without touching the real
+    // tree. A subscriber file changes; its note (unedited) is now a claim
+    // about code that no longer exists, and the guard must say so.
+    const inventory = {
+      'features/thing/index.tsx': {
+        mount: 'route-scoped',
+        hash: hashBytes('export function Thing() { return null; }'),
+        note: 'a note describing the ORIGINAL behavior, now stale',
+      },
+    };
+    const mutatedRead = () => 'export function Thing() { return <div>mutated!</div>; }';
+
+    const staleNotes = staleNoteEntries(inventory, mutatedRead);
+    const problems = violations(inventory, hooks, subscribers, [], staleNotes);
+
+    expect(staleNotes).toHaveLength(1);
+    expect(problems.some((p) => p.includes('features/thing/index.tsx'))).toBe(true);
+    expect(problems.some((p) => p.includes('now stale'))).toBe(true);
   });
 });

--- a/scripts/check-log-error-leaks.mjs
+++ b/scripts/check-log-error-leaks.mjs
@@ -66,14 +66,20 @@
 // `{e}`, so `{err}` and a bare positional `e` bypassed it entirely — three
 // live, undeclared sites: `postings/mod.rs:382` and
 // `platform/linux_appimage.rs:170` (`{err}`), and `autopilot_helpers/mod.rs:151`
-// (positional `err`). `findLeaks` was widened to catch all three shapes; all
-// three newly-surfaced sites were traced and declared `safe` — none crosses
-// a path/URL/host/credential (an in-memory serde_json parse, a
-// `Command::exec()` `io::Error` whose Display never embeds the program path,
-// and a board-scrape failure string that bottoms out at the same
-// already-safe chokepoint as the 24 `httpChokepointSafe()` entries above,
-// since every registered scraper is `ScraperMode::Http`). See each entry's
-// own reason for the trace.
+// (positional `err`). `findLeaks` was widened to catch all three shapes.
+// `postings/mod.rs:382` and `platform/linux_appimage.rs:170` were traced and
+// declared `safe` — an in-memory serde_json parse and a `Command::exec()`
+// `io::Error` whose Display never embeds the program path, respectively.
+//
+// `autopilot_helpers/mod.rs:151` was NOT declared safe by tracing: a first
+// pass argued it bottoms out at the fetch_text/fetch_json chokepoint because
+// every registered scraper reports `ScraperMode::Http` — but `ScraperMode` is
+// declared transport, not enforced transport, and `LinkedInScraper` (also
+// `Http`) reaches the network via `LinkedInHttpClient`'s own
+// `reqwest::Client::send()`, bypassing the chokepoint. That three-hop
+// argument was unsound, so the site is sanitized directly with
+// `observability::sanitize_reason` instead and carries no ALLOWLIST entry —
+// see the call site.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -100,17 +106,7 @@ const ALLOWLIST = {
       "serde_json::from_value type-mismatch parsing the app's own Autopilot " +
       'record on the load path — a pure parse failure, never a path/URL.',
   },
-  'autopilot_helpers/mod.rs:151': {
-    status: 'safe',
-    reason:
-      'err is BoardScrapeSummary.error (scraping/engine/mod.rs run_boards), sourced from ' +
-      "scraper.search()'s anyhow::Error or the fixed 'Unknown board: <id>' resolution " +
-      'failure. Every registered scraper (scraping/boards/mod.rs SCRAPERS) reports ' +
-      'ScraperMode::Http — ScraperMode::Browser is unused, #[allow(dead_code)] — so this ' +
-      'bottoms out at the same fetch_text/fetch_json chokepoint the 24 ' +
-      'httpChokepointSafe() entries below already rely on, one hop further up the stack.',
-  },
-  'autopilot_helpers/mod.rs:395': {
+  'autopilot_helpers/mod.rs:399': {
     status: 'safe',
     reason:
       "limits::Limiter::charge_provider_daily's AppError::RateLimited message is a " +

--- a/scripts/check-log-error-leaks.mjs
+++ b/scripts/check-log-error-leaks.mjs
@@ -74,6 +74,16 @@
 // already-safe chokepoint as the 24 `httpChokepointSafe()` entries above,
 // since every registered scraper is `ScraperMode::Http`). See each entry's
 // own reason for the trace.
+//
+// A follow-up review of that same PR found the positional check still only
+// matched a BARE identifier, missing the equivalent one method call away —
+// `log::warn!("...: {}", e.to_string())`. `findPositionalErrorArg` was
+// widened to also flag `<binding>.to_string()`/`.to_owned()`. Measured
+// against every real log call site before widening: zero currently use
+// either shape positionally (every `.to_string()` near a `log::` call is
+// already the sanctioned `sanitize_reason(&e.to_string())` wrapper, which
+// still does not match — see the comment on `positionalErrorRe`), so this
+// arm is a tripwire, not a fix for a live leak.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -332,7 +342,24 @@ function lineOf(text, at) {
  */
 const ERROR_BINDING_NAMES = ['e', 'err', 'error'];
 const capturedErrorRe = new RegExp(`\\{(?:${ERROR_BINDING_NAMES.join('|')})\\}`);
-const positionalErrorRe = new RegExp(`^[&*]*(?:${ERROR_BINDING_NAMES.join('|')})$`);
+/**
+ * A bare error binding (`e`, `&err`, …), or the same binding stringified —
+ * `e.to_string()` / `err.to_owned()` — one method call away from the exact
+ * same leak. A later review (of #1036) found the positional check only
+ * matched the bare identifier, so `log::warn!("...: {}", e.to_string())`
+ * bypassed it entirely — anchored to the WHOLE top-level argument (see
+ * `findPositionalErrorArg`), so a wrapper like
+ * `sanitize_reason(&e.to_string())` — whose argument text is
+ * `sanitize_reason(&e.to_string())`, not `e.to_string()` — still does not
+ * match. Measured against the crate's real log call sites before adding
+ * this: zero currently use `.to_string()`/`.to_owned()` positionally (every
+ * `.to_string()` near a `log::` call is already inside `sanitize_reason`),
+ * so this arm is a tripwire for a shape nobody has hit yet, not a fix for a
+ * live leak.
+ */
+const positionalErrorRe = new RegExp(
+  `^[&*]*(?:${ERROR_BINDING_NAMES.join('|')})(?:\\.(?:to_string|to_owned)\\(\\))?$`
+);
 
 /**
  * From `start` — the index in `text` right after a log macro's leading
@@ -404,11 +431,14 @@ function splitTopLevelArgs(argsText) {
 
 /**
  * The offset (into `argsText`) of the first top-level argument that is a
- * bare error-binding identifier — `e`, `err`, `error`, `&err`, … — with
- * nothing else attached. A method call (`e.code()`, `e.kind()`,
- * `sanitize_reason(&e.to_string())`) never matches: it is not a bare
- * identifier, which is what keeps the sanctioned safe forms out of this
- * check without naming them specially. `null` when no argument qualifies.
+ * bare error-binding identifier (`e`, `err`, `error`, `&err`, …) or that same
+ * binding stringified (`e.to_string()`, `&err.to_owned()`) — the two shapes
+ * that carry the SAME leak. Any other method call (`e.code()`, `e.kind()`,
+ * `sanitize_reason(&e.to_string())`) never matches: each is a distinct
+ * top-level argument in its own right (`sanitize_reason(&e.to_string())`,
+ * not `e.to_string()`), which is what keeps the sanctioned safe forms out of
+ * this check without naming them specially. `null` when no argument
+ * qualifies.
  */
 function findPositionalErrorArg(argsText) {
   for (const { raw, start } of splitTopLevelArgs(argsText)) {

--- a/scripts/check-log-error-leaks.mjs
+++ b/scripts/check-log-error-leaks.mjs
@@ -1,0 +1,370 @@
+// Drift guard: no bare `{e}` interpolation of a caught error inside a
+// `log::{warn,error,info,debug}!` call under apps/desktop/src-tauri/src.
+//
+// ── The defect this exists to stop ──────────────────────────────────────────
+//
+// AGENTS.md's path-privacy rule says an absolute path / username / home dir
+// must never appear anywhere, logs explicitly included. The crate violated it
+// via a recurring shape:
+//
+//   log::warn!("[setup] ... failed: {e}")
+//
+// When `e` is (or wraps) a `rusqlite::Error::InvalidPath`, a filesystem
+// `std::io::Error`, or a `reqwest::Error`, its `Display` can embed the
+// offending absolute path or full request URL — so this writes the user's
+// home directory, or a credential-bearing query string, straight into a log
+// file that support bundles ship verbatim. `apps/desktop/src-tauri/src/
+// applications/mod.rs` (see the comment on `ApplicationStore::open`) is the
+// canonical fix: `.code()` for a fixed, path-free category, or
+// `observability::sanitize_reason(&e.to_string())` when the rest of the
+// message is worth keeping.
+//
+// ── What this checks ─────────────────────────────────────────────────────────
+//
+// Every `log::{warn,error,info,debug}!(...)` call whose leading string
+// literal interpolates a bound error via the literal captured-identifier
+// form `{e}` (Rust 2021 format-string capture — the only shape this
+// codebase's ~250 log call sites ever used for an error binding; a
+// positional `"{}", e` call is not detected — see the note on `findLeaks`).
+//
+// NOT "no site may ever print `{e}`" — an error whose `Display` structurally
+// cannot carry a path/URL/host/credential (a pure JSON/PDF parse failure, a
+// fixed-string domain error) loses real diagnostic value for nothing if it is
+// forced through `.code()`. This enforces that the question was ANSWERED:
+// every surviving `{e}` site is declared in ALLOWLIST with a one-line reason,
+// tagged `safe` (provably cannot leak) or `debt` (a real leak candidate this
+// pass did not fix — see each entry). A newly introduced site fails until
+// someone writes that sentence, mirroring check-event-subscriptions.mjs.
+//
+// Both directions are checked, so the list cannot rot: an undeclared `{e}`
+// site fails, and so does an ALLOWLIST entry that no longer corresponds to a
+// real site (fixed, moved, or deleted) — see `violations()`.
+//
+// `debt` entries are scraping/** sites: `scraping/**` is scraping-applier's
+// domain (AGENTS.md / CLAUDE.md domain routing), out of this pass's
+// primary-path scope. They are pattern-identical to sites fixed elsewhere in
+// this same pass (mostly a `reqwest::Error` embedding the request URL, or a
+// `keyring` error) and are very likely genuine leaks — recorded rather than
+// fixed here so the fix is reviewable by that domain's own author, not so it
+// is forgotten. `pnpm check:log-error-leaks` will keep failing on any NEW
+// site added anywhere in the crate, `scraping/**` included, the whole time
+// this debt sits open.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SRC_REL = 'apps/desktop/src-tauri/src';
+
+/**
+ * Every surviving `{e}` site, keyed `"<path relative to src/>:<line>"` (the
+ * line the literal `{e}` text sits on — for a multi-line format string that
+ * is not necessarily the `log::` call's own line).
+ *
+ * `status: 'safe'` — the error's `Display` structurally cannot carry a
+ *   path/URL/host/credential; `.code()`/`sanitize_reason` would only lose
+ *   diagnostic value. `status: 'debt'` — a likely-real leak, out of this
+ *   pass's scope, tracked for a follow-up fix (see the file header).
+ */
+const ALLOWLIST = {
+  // ── safe: provably cannot carry a path/URL/host/credential ────────────────
+  'autopilot/mod.rs:754': {
+    status: 'safe',
+    reason:
+      "serde_json::from_value type-mismatch parsing the app's own Autopilot " +
+      'record on the load path — a pure parse failure, never a path/URL.',
+  },
+  'autopilot_helpers/mod.rs:395': {
+    status: 'safe',
+    reason:
+      "limits::Limiter::charge_provider_daily's AppError::RateLimited message is a " +
+      'fixed, author-written template naming only the provider id and a static ' +
+      'daily-ceiling number — see limits/mod.rs.',
+  },
+  'documents/mod.rs:1153': {
+    status: 'safe',
+    reason: 'Same charge_provider_daily fixed-template message as autopilot_helpers/mod.rs:395.',
+  },
+  'validate/mod.rs:401': {
+    status: 'safe',
+    reason:
+      'lopdf::Document::load_mem parses IN-MEMORY bytes, not a file path — its errors ' +
+      'are fixed format-parse messages ("trailer not found", …), never a path.',
+  },
+  'profile_import/linkedin.rs:134': {
+    status: 'safe',
+    reason:
+      "net::http::read_text_capped's error path already calls reqwest::Error::" +
+      'without_url() before wrapping in AppError::Network (see accumulate_capped in ' +
+      'net/http.rs) — the URL is stripped upstream of this call site.',
+  },
+  'postings/mod.rs:424': {
+    status: 'safe',
+    reason:
+      "serde_json::to_string_pretty is a SERIALIZE error on the app's own " +
+      'InteractionRecord — a type-system failure, not an echo of file content.',
+  },
+  'notifications/mod.rs:231': {
+    status: 'safe',
+    reason: 'Same serde_json serialize-error shape as postings/mod.rs:424 (AppNotification).',
+  },
+  'commands/autopilot/rerank.rs:270': {
+    status: 'safe',
+    reason: 'Same charge_provider_daily fixed-template message as autopilot_helpers/mod.rs:395.',
+  },
+  'commands/profile_import.rs:20': {
+    status: 'safe',
+    reason:
+      "import_from_url's only branch (linkedin::import) already collapses every " +
+      "failure to a fixed AppError::Network string ('could not reach linkedin' / " +
+      "'could not read the linkedin response') before returning — no URL/host " +
+      'reaches this call site.',
+  },
+  'extension_bridge/register.rs:114': {
+    status: 'safe',
+    reason:
+      'std::env::current_exe() takes no input path to leak — a failure here is a ' +
+      'generic OS resource-resolution error.',
+  },
+  'extension_bridge/native_host.rs:50': {
+    status: 'safe',
+    reason:
+      'tokio::runtime::Builder::build() failure is a generic OS-thread/resource error; ' +
+      'building a runtime touches no filesystem path.',
+  },
+  'extension_bridge/mod.rs:483': {
+    status: 'safe',
+    reason:
+      'TcpListener::accept() failure is a local socket-resource error (e.g. EMFILE); it ' +
+      'carries no peer address or path — the peer is a separate, unread `_peer` binding.',
+  },
+
+  // ── debt: scraping-applier domain, out of this pass's scope ───────────────
+  'scraping/board_health/mod.rs:594': scrapingDebt(),
+  'scraping/board_login/mod.rs:202': scrapingDebt(),
+  'scraping/board_login/import.rs:98': scrapingDebt(),
+  'scraping/board_login/import.rs:174': scrapingDebt(),
+  'scraping/boards/greenhouse/mod.rs:110': scrapingDebt(),
+  'scraping/boards/breezy/mod.rs:100': scrapingDebt(),
+  'scraping/boards/breezy/mod.rs:287': scrapingDebt(),
+  'scraping/boards/ycombinator/mod.rs:109': scrapingDebt(),
+  'scraping/boards/aggregator/adzuna.rs:264': scrapingDebt(),
+  'scraping/boards/aggregator/adzuna.rs:269': scrapingDebt(),
+  'scraping/boards/aggregator/adzuna.rs:422': scrapingDebt(),
+  'scraping/boards/aggregator/adzuna.rs:555': scrapingDebt(),
+  'scraping/engine/mod.rs:1081': scrapingDebt(),
+  'scraping/boards/arbeitnow/mod.rs:81': scrapingDebt(),
+  'scraping/boards/bamboohr/mod.rs:204': scrapingDebt(),
+  'scraping/boards/arbeitsagentur/mod.rs:164': scrapingDebt(),
+  'scraping/boards/aggregator/mod.rs:336': scrapingDebt(),
+  'scraping/boards/aggregator/mod.rs:370': scrapingDebt(),
+  'scraping/boards/aggregator/mod.rs:403': scrapingDebt(),
+  'scraping/boards/aggregator/mod.rs:491': scrapingDebt(),
+  'scraping/boards/aggregator/mod.rs:725': scrapingDebt(),
+  'scraping/boards/aggregator/providers.rs:171': scrapingDebt(),
+  'scraping/boards/aggregator/providers.rs:430': scrapingDebt(),
+  'scraping/boards/aggregator/providers.rs:777': scrapingDebt(),
+  'scraping/boards/ashby/mod.rs:146': scrapingDebt(),
+  'scraping/boards/aggregator/freehire.rs:465': scrapingDebt(),
+  'scraping/boards/comeet/mod.rs:69': scrapingDebt(),
+  'scraping/boards/comeet/mod.rs:220': scrapingDebt(),
+  'scraping/boards/comeet/mod.rs:226': scrapingDebt(),
+  'scraping/boards/workable/mod.rs:116': scrapingDebt(),
+  'scraping/boards/workable/mod.rs:294': scrapingDebt(),
+  'scraping/linkedin/api_client/mod.rs:356': scrapingDebt(),
+  'scraping/boards/lever/mod.rs:143': scrapingDebt(),
+  'scraping/boards/pinpoint/mod.rs:181': scrapingDebt(),
+  'scraping/boards/jobicy/mod.rs:64': scrapingDebt(),
+  'scraping/boards/jobicy/mod.rs:165': scrapingDebt(),
+  'scraping/boards/smartrecruiters/mod.rs:142': scrapingDebt(),
+  'scraping/boards/smartrecruiters/mod.rs:180': scrapingDebt(),
+  'scraping/boards/themuse/mod.rs:193': scrapingDebt(),
+  'scraping/http/mod.rs:332': scrapingDebt(),
+  'scraping/http/mod.rs:442': scrapingDebt(),
+  'scraping/boards/recruitee/mod.rs:117': scrapingDebt(),
+  'scraping/boards/rippling/mod.rs:89': scrapingDebt(),
+  'scraping/boards/rippling/mod.rs:230': scrapingDebt(),
+  'scraping/boards/personio/mod.rs:208': scrapingDebt(),
+};
+
+/** Factory rather than one repeated literal so every `debt` entry stays easy
+ * to scan for its (shared) rationale in one place; still one explicit
+ * ALLOWLIST entry per site, so the undeclared/stale checks below cover each
+ * individually. */
+function scrapingDebt() {
+  return {
+    status: 'debt',
+    reason:
+      "scraping-applier domain (AGENTS.md domain routing) — out of this pass's " +
+      'primary-path scope. Pattern-identical to sites fixed elsewhere in this pass ' +
+      '(a reqwest::Error embedding the request URL, or a keyring error) and very ' +
+      "likely a genuine leak — needs a follow-up fix from that domain's author, not " +
+      'yet applied here.',
+  };
+}
+
+/** Minimum reason length for an entry to count as an explanation, not a stub. */
+const MIN_REASON_CHARS = 20;
+
+/** Recursively list `.rs` files under `dir`. */
+function rustFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...rustFiles(full));
+      continue;
+    }
+    if (name.endsWith('.rs')) out.push(full);
+  }
+  return out;
+}
+
+/** Normalize a relative path to POSIX separators, so keys are stable on Windows. */
+const toPosix = (rel) => rel.split(sep).join('/');
+
+/** 1-based line number of byte offset `at` in `text`. */
+function lineOf(text, at) {
+  let line = 1;
+  for (let i = 0; i < at; i++) {
+    if (text[i] === '\n') line++;
+  }
+  return line;
+}
+
+/**
+ * Every `log::{warn,error,info,debug}!(...)` call site, under `srcDir`, whose
+ * leading string-literal argument contains the literal captured-identifier
+ * `{e}`.
+ *
+ * Detects only the captured-identifier form (`"...{e}..."`), which is the
+ * shape every log call in this codebase used for an error binding at the time
+ * this guard was written. A positional call (`log::warn!("...{}...", e)`)
+ * would dodge detection — not handled, since introducing that shape here
+ * would itself be a conspicuous, reviewable stylistic departure, and this
+ * guard's job is to catch the shape that actually recurred 145 times, not
+ * every theoretical rewrite of it.
+ *
+ * Returns `{ key, file, line }[]`, `key` being `"<path relative to src/>:<line>"`
+ * — the ALLOWLIST's own key shape.
+ */
+export function findLeaks(srcDir = join(REPO_ROOT, SRC_REL)) {
+  const found = [];
+  const callRe = /log::(?:warn|error|info|debug)!\(\s*"((?:[^"\\]|\\[\s\S])*)"/g;
+  for (const file of rustFiles(srcDir)) {
+    const text = readFileSync(file, 'utf8');
+    const rel = toPosix(relative(srcDir, file));
+    callRe.lastIndex = 0;
+    let m;
+    while ((m = callRe.exec(text))) {
+      const braceOffset = m[0].indexOf('{e}');
+      if (braceOffset === -1) continue;
+      const line = lineOf(text, m.index + braceOffset);
+      found.push({ key: `${rel}:${line}`, file: rel, line });
+    }
+  }
+  return found;
+}
+
+/**
+ * Every violation, as human-readable lines. Empty means the invariant holds.
+ *
+ * Returned rather than printed so the check is testable without capturing
+ * stdout or trapping `process.exit`.
+ */
+export function violations(inventory = ALLOWLIST, leaks) {
+  const problems = [];
+
+  const foundKeys = new Set(leaks.map((l) => l.key));
+  const declaredKeys = new Set(Object.keys(inventory));
+
+  const undeclared = leaks.filter((l) => !declaredKeys.has(l.key));
+  if (undeclared.length > 0) {
+    problems.push(
+      'These log call sites interpolate a caught error via bare `{e}`, which can leak ' +
+        'an absolute path (rusqlite::Error::InvalidPath, a filesystem std::io::Error), a ' +
+        'credential-bearing URL (reqwest::Error), or a host:port into the log — and are ' +
+        'not declared in ALLOWLIST:\n' +
+        undeclared.map((l) => `    ${l.key}`).join('\n') +
+        '\n  Fix it (`.code()` for a fixed category, or ' +
+        'observability::sanitize_reason(&e.to_string()) to keep the safe part of the ' +
+        'message — see the comment on applications::ApplicationStore::open), or add an ' +
+        'ALLOWLIST entry in scripts/check-log-error-leaks.mjs stating why this one ' +
+        'cannot leak.'
+    );
+  }
+
+  const stale = [...declaredKeys].filter((k) => !foundKeys.has(k));
+  if (stale.length > 0) {
+    problems.push(
+      'Declared in ALLOWLIST but no `{e}` site found there anymore (fixed, moved, or ' +
+        'deleted) — remove the stale entries so the list stays a true inventory:\n' +
+        stale.map((k) => `    ${k}`).join('\n')
+    );
+  }
+
+  const unexplained = Object.entries(inventory)
+    .filter(([, e]) => !e.reason || e.reason.trim().length < MIN_REASON_CHARS)
+    .map(([k]) => k);
+  if (unexplained.length > 0) {
+    problems.push(
+      'Every ALLOWLIST entry must state why that site cannot leak (or is deliberately ' +
+        'left for a follow-up):\n' +
+        unexplained.map((k) => `    ${k}`).join('\n')
+    );
+  }
+
+  const badStatus = Object.entries(inventory)
+    .filter(([, e]) => e.status !== 'safe' && e.status !== 'debt')
+    .map(([k]) => k);
+  if (badStatus.length > 0) {
+    problems.push(
+      "`status` must be 'safe' or 'debt':\n" + badStatus.map((k) => `    ${k}`).join('\n')
+    );
+  }
+
+  return problems;
+}
+
+/**
+ * Below this many total sites, the scan is treated as broken rather than
+ * "every leak got fixed" — an ABSOLUTE floor, not a comparison against
+ * ALLOWLIST's size (that comparison is exactly what would make a single
+ * legitimately-fixed site indistinguishable from every regex match silently
+ * going to zero; the `stale`-entry check above already covers the former).
+ * The real repo sits at 57 as of this guard's introduction; a Rust log-macro
+ * idiom change or a regex typo dropping this near zero must fail loudly
+ * rather than read as "nothing left to declare".
+ */
+export const MIN_SITES = 40;
+
+// Skipped when imported by the test file.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const leaks = findLeaks();
+
+  if (leaks.length < MIN_SITES) {
+    console.error(
+      `✗ Only ${leaks.length} \`{e}\` site(s) found under ${SRC_REL} — expected at ` +
+        `least ${MIN_SITES}. The log-macro pattern this scans for may have changed; fix ` +
+        'the scan before trusting a green run.'
+    );
+    process.exit(1);
+  }
+
+  const problems = violations(ALLOWLIST, leaks);
+
+  if (problems.length > 0) {
+    for (const p of problems) console.error(`✗ ${p}`);
+    process.exit(1);
+  }
+
+  const safe = Object.values(ALLOWLIST).filter((e) => e.status === 'safe').length;
+  const debt = Object.values(ALLOWLIST).filter((e) => e.status === 'debt').length;
+  console.log(
+    `check:log-error-leaks OK — ${leaks.length} \`{e}\` site(s) found, all declared ` +
+      `(${safe} provably safe, ${debt} tracked as debt).`
+  );
+}
+
+export { ALLOWLIST, SRC_REL };

--- a/scripts/check-log-error-leaks.mjs
+++ b/scripts/check-log-error-leaks.mjs
@@ -1,4 +1,5 @@
-// Drift guard: no bare `{e}` interpolation of a caught error inside a
+// Drift guard: no bare interpolation of a caught error — captured (`{e}`,
+// `{err}`, `{error}`) or positional (`"...{}...", e`) — inside a
 // `log::{warn,error,info,debug}!` call under apps/desktop/src-tauri/src.
 //
 // ── The defect this exists to stop ──────────────────────────────────────────
@@ -21,24 +22,30 @@
 //
 // ── What this checks ─────────────────────────────────────────────────────────
 //
-// Every `log::{warn,error,info,debug}!(...)` call whose leading string
-// literal interpolates a bound error via the literal captured-identifier
-// form `{e}` (Rust 2021 format-string capture — the only shape this
-// codebase's ~250 log call sites ever used for an error binding; a
-// positional `"{}", e` call is not detected — see the note on `findLeaks`).
+// Every `log::{warn,error,info,debug}!(...)` call that interpolates a bound
+// error identifier — captured in the format string (`{e}`, `{err}`,
+// `{error}`, Rust 2021 format-string capture) or passed as a bare positional
+// argument (`"...{}...", e`). Bounded to those three binding names because
+// they are the only ones this codebase's ~264 log call sites ever use for a
+// caught error — see `ERROR_BINDING_NAMES` for the measurement. A caught
+// error re-bound to some OTHER name before logging is still a blind spot; no
+// static scan without real type information can rule that out, and
+// introducing one here would itself be a conspicuous, reviewable departure
+// from every existing call site.
 //
-// NOT "no site may ever print `{e}`" — an error whose `Display` structurally
-// cannot carry a path/URL/host/credential (a pure JSON/PDF parse failure, a
-// fixed-string domain error) loses real diagnostic value for nothing if it is
-// forced through `.code()`. This enforces that the question was ANSWERED:
-// every surviving `{e}` site is declared in ALLOWLIST with a one-line reason,
-// tagged `safe` (provably cannot leak) or `debt` (a real leak candidate this
-// pass did not fix — see each entry). A newly introduced site fails until
-// someone writes that sentence, mirroring check-event-subscriptions.mjs.
+// NOT "no site may ever print an error" — an error whose `Display`
+// structurally cannot carry a path/URL/host/credential (a pure JSON/PDF
+// parse failure, a fixed-string domain error) loses real diagnostic value for
+// nothing if it is forced through `.code()`. This enforces that the question
+// was ANSWERED: every surviving site is declared in ALLOWLIST with a
+// one-line reason, tagged `safe` (provably cannot leak) or `debt` (a real
+// leak candidate this pass did not fix — see each entry). A newly introduced
+// site fails until someone writes that sentence, mirroring
+// check-event-subscriptions.mjs.
 //
-// Both directions are checked, so the list cannot rot: an undeclared `{e}`
-// site fails, and so does an ALLOWLIST entry that no longer corresponds to a
-// real site (fixed, moved, or deleted) — see `violations()`.
+// Both directions are checked, so the list cannot rot: an undeclared site
+// fails, and so does an ALLOWLIST entry that no longer corresponds to a real
+// site (fixed, moved, or deleted) — see `violations()`.
 //
 // `scraping/**` was originally left as 45 `debt` entries (scraping-applier's
 // domain, AGENTS.md / CLAUDE.md domain routing, out of the first pass's
@@ -54,6 +61,19 @@
 // in-memory parse/task failure that never had a path/URL to begin with. Zero
 // `debt` entries remain; the tag stays available (see `status` below) for a
 // future pass that needs to record a real leak it isn't fixing yet.
+//
+// A later review (of #1036) found the detector only matched the literal
+// `{e}`, so `{err}` and a bare positional `e` bypassed it entirely — three
+// live, undeclared sites: `postings/mod.rs:382` and
+// `platform/linux_appimage.rs:170` (`{err}`), and `autopilot_helpers/mod.rs:151`
+// (positional `err`). `findLeaks` was widened to catch all three shapes; all
+// three newly-surfaced sites were traced and declared `safe` — none crosses
+// a path/URL/host/credential (an in-memory serde_json parse, a
+// `Command::exec()` `io::Error` whose Display never embeds the program path,
+// and a board-scrape failure string that bottoms out at the same
+// already-safe chokepoint as the 24 `httpChokepointSafe()` entries above,
+// since every registered scraper is `ScraperMode::Http`). See each entry's
+// own reason for the trace.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -80,6 +100,16 @@ const ALLOWLIST = {
       "serde_json::from_value type-mismatch parsing the app's own Autopilot " +
       'record on the load path — a pure parse failure, never a path/URL.',
   },
+  'autopilot_helpers/mod.rs:151': {
+    status: 'safe',
+    reason:
+      'err is BoardScrapeSummary.error (scraping/engine/mod.rs run_boards), sourced from ' +
+      "scraper.search()'s anyhow::Error or the fixed 'Unknown board: <id>' resolution " +
+      'failure. Every registered scraper (scraping/boards/mod.rs SCRAPERS) reports ' +
+      'ScraperMode::Http — ScraperMode::Browser is unused, #[allow(dead_code)] — so this ' +
+      'bottoms out at the same fetch_text/fetch_json chokepoint the 24 ' +
+      'httpChokepointSafe() entries below already rely on, one hop further up the stack.',
+  },
   'autopilot_helpers/mod.rs:395': {
     status: 'safe',
     reason:
@@ -103,6 +133,13 @@ const ALLOWLIST = {
       "net::http::read_text_capped's error path already calls reqwest::Error::" +
       'without_url() before wrapping in AppError::Network (see accumulate_capped in ' +
       'net/http.rs) — the URL is stripped upstream of this call site.',
+  },
+  'postings/mod.rs:382': {
+    status: 'safe',
+    reason:
+      "err: &serde_json::Error is back_up_corrupt_file's parameter — the from_str parse " +
+      'failure of interactions.json content already read into memory (map_mut). Same ' +
+      'in-memory-parse shape as inMemoryParseSafe() below, never a path/URL/host/credential.',
   },
   'postings/mod.rs:424': {
     status: 'safe',
@@ -143,6 +180,14 @@ const ALLOWLIST = {
     reason:
       'TcpListener::accept() failure is a local socket-resource error (e.g. EMFILE); it ' +
       'carries no peer address or path — the peer is a separate, unread `_peer` binding.',
+  },
+  'platform/linux_appimage.rs:170': {
+    status: 'safe',
+    reason:
+      'err is the std::io::Error Command::exec() returns when execve() fails — its ' +
+      'Display is only the OS errno message (e.g. "No such file or directory (os error ' +
+      '2)"); Rust does not embed the failed program path in that error, so `exe`\'s ' +
+      'absolute path never reaches this log line.',
   },
 
   // ── scraping/**: fetch_text/fetch_json chokepoint already strips the URL ──
@@ -272,20 +317,118 @@ function lineOf(text, at) {
 }
 
 /**
- * Every `log::{warn,error,info,debug}!(...)` call site, under `srcDir`, whose
- * leading string-literal argument contains the literal captured-identifier
- * `{e}`.
+ * The identifiers this codebase's log call sites use for a caught/bound
+ * error when interpolating it directly — captured (`{e}`/`{err}`/`{error}`)
+ * or positional (`"...{}...", e`), the latter optionally `&`/`*`-prefixed.
  *
- * Detects only the captured-identifier form (`"...{e}..."`), which is the
- * shape every log call in this codebase used for an error binding at the time
- * this guard was written. A positional call (`log::warn!("...{}...", e)`)
- * would dodge detection — not handled, since introducing that shape here
- * would itself be a conspicuous, reviewable stylistic departure, and this
- * guard's job is to catch the shape that actually recurred 145 times, not
- * every theoretical rewrite of it.
+ * Bounded to these three rather than "any identifier": a scan of every
+ * `{ident}` capture across all ~264 log call sites in the crate found `e`
+ * (45 sites) and `err` (2 sites) as the only ones naming an error — every
+ * other captured identifier (`host`, `port`, `board_id`, `reason`, `page`, …)
+ * is an ordinary data field. Matching on any identifier would flag every one
+ * of those too, drowning the real leak candidates in noise on normal log
+ * content. `error` is included for the same convention `err` was, even
+ * though nothing currently spells it that way.
+ */
+const ERROR_BINDING_NAMES = ['e', 'err', 'error'];
+const capturedErrorRe = new RegExp(`\\{(?:${ERROR_BINDING_NAMES.join('|')})\\}`);
+const positionalErrorRe = new RegExp(`^[&*]*(?:${ERROR_BINDING_NAMES.join('|')})$`);
+
+/**
+ * From `start` — the index in `text` right after a log macro's leading
+ * format-string literal, still inside the macro call's own opening paren —
+ * returns the raw text of the remaining arguments up to that call's matching
+ * closing paren. Respects nested parens and string/char literals, so a `)`
+ * inside a method call (`e.to_string()`) or a nested string does not end the
+ * scan early. Returns `null` if the source runs out first (malformed or
+ * truncated input — should not happen against real source).
+ */
+function restOfCall(text, start) {
+  let depth = 1; // already inside the macro call's opening '('
+  let i = start;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === '"' || c === "'") {
+      const quote = c;
+      i++;
+      while (i < text.length && text[i] !== quote) {
+        if (text[i] === '\\') i++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    if (c === '(') depth++;
+    else if (c === ')') {
+      depth--;
+      if (depth === 0) return text.slice(start, i);
+    }
+    i++;
+  }
+  return null;
+}
+
+/**
+ * Splits `argsText` on top-level commas — a comma inside a nested call
+ * (`sanitize_reason(&e.to_string())`) or a string does not split — returning
+ * each raw segment together with the offset (into `argsText`) it starts at.
+ */
+function splitTopLevelArgs(argsText) {
+  const args = [];
+  let depth = 0;
+  let start = 0;
+  let i = 0;
+  while (i < argsText.length) {
+    const c = argsText[i];
+    if (c === '"' || c === "'") {
+      const quote = c;
+      i++;
+      while (i < argsText.length && argsText[i] !== quote) {
+        if (argsText[i] === '\\') i++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') depth--;
+    if (c === ',' && depth === 0) {
+      args.push({ raw: argsText.slice(start, i), start });
+      start = i + 1;
+    }
+    i++;
+  }
+  if (start < argsText.length) args.push({ raw: argsText.slice(start), start });
+  return args;
+}
+
+/**
+ * The offset (into `argsText`) of the first top-level argument that is a
+ * bare error-binding identifier — `e`, `err`, `error`, `&err`, … — with
+ * nothing else attached. A method call (`e.code()`, `e.kind()`,
+ * `sanitize_reason(&e.to_string())`) never matches: it is not a bare
+ * identifier, which is what keeps the sanctioned safe forms out of this
+ * check without naming them specially. `null` when no argument qualifies.
+ */
+function findPositionalErrorArg(argsText) {
+  for (const { raw, start } of splitTopLevelArgs(argsText)) {
+    if (!positionalErrorRe.test(raw.trim())) continue;
+    return start + (raw.length - raw.trimStart().length);
+  }
+  return null;
+}
+
+/**
+ * Every `log::{warn,error,info,debug}!(...)` call site, under `srcDir`, that
+ * interpolates a bound error identifier — captured in the format string
+ * (`{e}`, `{err}`, `{error}`) or passed as a bare positional argument
+ * (`"...{}...", e`). See `ERROR_BINDING_NAMES` for why detection is bounded
+ * to those three names rather than every identifier.
  *
  * Returns `{ key, file, line }[]`, `key` being `"<path relative to src/>:<line>"`
- * — the ALLOWLIST's own key shape.
+ * — the ALLOWLIST's own key shape. `line` is the line the identifier itself
+ * sits on (for a multi-line format string, or an argument list wrapped onto
+ * its own line, that is not necessarily the `log::` call's own line).
  */
 export function findLeaks(srcDir = join(REPO_ROOT, SRC_REL)) {
   const found = [];
@@ -296,9 +439,18 @@ export function findLeaks(srcDir = join(REPO_ROOT, SRC_REL)) {
     callRe.lastIndex = 0;
     let m;
     while ((m = callRe.exec(text))) {
-      const braceOffset = m[0].indexOf('{e}');
-      if (braceOffset === -1) continue;
-      const line = lineOf(text, m.index + braceOffset);
+      const captured = capturedErrorRe.exec(m[0]);
+      if (captured) {
+        const line = lineOf(text, m.index + captured.index);
+        found.push({ key: `${rel}:${line}`, file: rel, line });
+        continue;
+      }
+
+      const rest = restOfCall(text, m.index + m[0].length);
+      if (rest === null) continue;
+      const argOffset = findPositionalErrorArg(rest);
+      if (argOffset === null) continue;
+      const line = lineOf(text, m.index + m[0].length + argOffset);
       found.push({ key: `${rel}:${line}`, file: rel, line });
     }
   }
@@ -320,7 +472,8 @@ export function violations(inventory = ALLOWLIST, leaks) {
   const undeclared = leaks.filter((l) => !declaredKeys.has(l.key));
   if (undeclared.length > 0) {
     problems.push(
-      'These log call sites interpolate a caught error via bare `{e}`, which can leak ' +
+      'These log call sites interpolate a caught error, captured or positional, which can ' +
+        'leak ' +
         'an absolute path (rusqlite::Error::InvalidPath, a filesystem std::io::Error), a ' +
         'credential-bearing URL (reqwest::Error), or a host:port into the log — and are ' +
         'not declared in ALLOWLIST:\n' +

--- a/scripts/check-log-error-leaks.mjs
+++ b/scripts/check-log-error-leaks.mjs
@@ -40,15 +40,20 @@
 // site fails, and so does an ALLOWLIST entry that no longer corresponds to a
 // real site (fixed, moved, or deleted) — see `violations()`.
 //
-// `debt` entries are scraping/** sites: `scraping/**` is scraping-applier's
-// domain (AGENTS.md / CLAUDE.md domain routing), out of this pass's
-// primary-path scope. They are pattern-identical to sites fixed elsewhere in
-// this same pass (mostly a `reqwest::Error` embedding the request URL, or a
-// `keyring` error) and are very likely genuine leaks — recorded rather than
-// fixed here so the fix is reviewable by that domain's own author, not so it
-// is forgotten. `pnpm check:log-error-leaks` will keep failing on any NEW
-// site added anywhere in the crate, `scraping/**` included, the whole time
-// this debt sits open.
+// `scraping/**` was originally left as 45 `debt` entries (scraping-applier's
+// domain, AGENTS.md / CLAUDE.md domain routing, out of the first pass's
+// primary-path scope). scraping-applier-author triaged all 45 by tracing each
+// `{e}`'s concrete type: 12 were genuine leaks (a `reqwest::Error` NOT routed
+// through `scraping::http`'s `.without_url()` chokepoint, a keyring error, or
+// a filesystem path op) and are now fixed with
+// `observability::sanitize_reason(&e.to_string())`; the remaining 33 are
+// declared `safe` — either the error crosses `scraping::http::fetch_text`/
+// `fetch_json` (the fleet chokepoint that already strips the request URL
+// before wrapping in `AppError::Network`, so the Adzuna/JSearch/Jooble/Apify
+// API key in the query string never reaches the log), or it is a pure
+// in-memory parse/task failure that never had a path/URL to begin with. Zero
+// `debt` entries remain; the tag stays available (see `status` below) for a
+// future pass that needs to record a real leak it isn't fixing yet.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -140,67 +145,100 @@ const ALLOWLIST = {
       'carries no peer address or path — the peer is a separate, unread `_peer` binding.',
   },
 
-  // ── debt: scraping-applier domain, out of this pass's scope ───────────────
-  'scraping/board_health/mod.rs:594': scrapingDebt(),
-  'scraping/board_login/mod.rs:202': scrapingDebt(),
-  'scraping/board_login/import.rs:98': scrapingDebt(),
-  'scraping/board_login/import.rs:174': scrapingDebt(),
-  'scraping/boards/greenhouse/mod.rs:110': scrapingDebt(),
-  'scraping/boards/breezy/mod.rs:100': scrapingDebt(),
-  'scraping/boards/breezy/mod.rs:287': scrapingDebt(),
-  'scraping/boards/ycombinator/mod.rs:109': scrapingDebt(),
-  'scraping/boards/aggregator/adzuna.rs:264': scrapingDebt(),
-  'scraping/boards/aggregator/adzuna.rs:269': scrapingDebt(),
-  'scraping/boards/aggregator/adzuna.rs:422': scrapingDebt(),
-  'scraping/boards/aggregator/adzuna.rs:555': scrapingDebt(),
-  'scraping/engine/mod.rs:1081': scrapingDebt(),
-  'scraping/boards/arbeitnow/mod.rs:81': scrapingDebt(),
-  'scraping/boards/bamboohr/mod.rs:204': scrapingDebt(),
-  'scraping/boards/arbeitsagentur/mod.rs:164': scrapingDebt(),
-  'scraping/boards/aggregator/mod.rs:336': scrapingDebt(),
-  'scraping/boards/aggregator/mod.rs:370': scrapingDebt(),
-  'scraping/boards/aggregator/mod.rs:403': scrapingDebt(),
-  'scraping/boards/aggregator/mod.rs:491': scrapingDebt(),
-  'scraping/boards/aggregator/mod.rs:725': scrapingDebt(),
-  'scraping/boards/aggregator/providers.rs:171': scrapingDebt(),
-  'scraping/boards/aggregator/providers.rs:430': scrapingDebt(),
-  'scraping/boards/aggregator/providers.rs:777': scrapingDebt(),
-  'scraping/boards/ashby/mod.rs:146': scrapingDebt(),
-  'scraping/boards/aggregator/freehire.rs:465': scrapingDebt(),
-  'scraping/boards/comeet/mod.rs:69': scrapingDebt(),
-  'scraping/boards/comeet/mod.rs:220': scrapingDebt(),
-  'scraping/boards/comeet/mod.rs:226': scrapingDebt(),
-  'scraping/boards/workable/mod.rs:116': scrapingDebt(),
-  'scraping/boards/workable/mod.rs:294': scrapingDebt(),
-  'scraping/linkedin/api_client/mod.rs:356': scrapingDebt(),
-  'scraping/boards/lever/mod.rs:143': scrapingDebt(),
-  'scraping/boards/pinpoint/mod.rs:181': scrapingDebt(),
-  'scraping/boards/jobicy/mod.rs:64': scrapingDebt(),
-  'scraping/boards/jobicy/mod.rs:165': scrapingDebt(),
-  'scraping/boards/smartrecruiters/mod.rs:142': scrapingDebt(),
-  'scraping/boards/smartrecruiters/mod.rs:180': scrapingDebt(),
-  'scraping/boards/themuse/mod.rs:193': scrapingDebt(),
-  'scraping/http/mod.rs:332': scrapingDebt(),
-  'scraping/http/mod.rs:442': scrapingDebt(),
-  'scraping/boards/recruitee/mod.rs:117': scrapingDebt(),
-  'scraping/boards/rippling/mod.rs:89': scrapingDebt(),
-  'scraping/boards/rippling/mod.rs:230': scrapingDebt(),
-  'scraping/boards/personio/mod.rs:208': scrapingDebt(),
+  // ── scraping/**: fetch_text/fetch_json chokepoint already strips the URL ──
+  // Every site below calls (directly, or one anyhow-wrapped hop away via the
+  // Adzuna/JSearch/Jooble/Apify providers) `scraping::http::fetch_text` /
+  // `fetch_json`. Its transport-failure branch calls `reqwest::Error::
+  // without_url()` before wrapping in `AppError::Network` (see `fetch_text`'s
+  // `Err(e) =>` arm in scraping/http/mod.rs), and every other error variant it
+  // can return (`AppError::Provider("HTTP <status>")`,
+  // `AppError::Validation("Response too large")`,
+  // `AppError::Parse(<generic schema-drift string>)`, `AppError::Cancelled`)
+  // is a fixed, path/URL-free message. So the request URL — which for Adzuna/
+  // JSearch/Jooble/Apify carries an API key in the query string — never
+  // reaches these log lines even on failure. Traced individually against the
+  // current source, not pattern-matched.
+  'scraping/boards/greenhouse/mod.rs:110': httpChokepointSafe(),
+  'scraping/boards/breezy/mod.rs:287': httpChokepointSafe(),
+  'scraping/boards/ycombinator/mod.rs:109': httpChokepointSafe(),
+  'scraping/boards/aggregator/adzuna.rs:429': httpChokepointSafe(),
+  'scraping/boards/aggregator/adzuna.rs:562': httpChokepointSafe(),
+  'scraping/boards/arbeitnow/mod.rs:81': httpChokepointSafe(),
+  'scraping/boards/bamboohr/mod.rs:204': httpChokepointSafe(),
+  'scraping/boards/arbeitsagentur/mod.rs:164': httpChokepointSafe(),
+  'scraping/boards/aggregator/mod.rs:336': httpChokepointSafe(),
+  'scraping/boards/aggregator/mod.rs:370': httpChokepointSafe(),
+  'scraping/boards/aggregator/mod.rs:403': httpChokepointSafe(),
+  'scraping/boards/aggregator/mod.rs:491': httpChokepointSafe(),
+  'scraping/boards/aggregator/mod.rs:725': httpChokepointSafe(),
+  'scraping/boards/ashby/mod.rs:146': httpChokepointSafe(),
+  'scraping/boards/aggregator/freehire.rs:465': httpChokepointSafe(),
+  'scraping/boards/workable/mod.rs:294': httpChokepointSafe(),
+  'scraping/boards/lever/mod.rs:143': httpChokepointSafe(),
+  'scraping/boards/pinpoint/mod.rs:181': httpChokepointSafe(),
+  'scraping/boards/smartrecruiters/mod.rs:142': httpChokepointSafe(),
+  'scraping/boards/smartrecruiters/mod.rs:180': httpChokepointSafe(),
+  'scraping/boards/themuse/mod.rs:193': httpChokepointSafe(),
+  'scraping/boards/recruitee/mod.rs:117': httpChokepointSafe(),
+  'scraping/boards/rippling/mod.rs:230': httpChokepointSafe(),
+  'scraping/boards/personio/mod.rs:208': httpChokepointSafe(),
+
+  // ── scraping/**: pure in-memory parse of already-fetched data ─────────────
+  // `serde_json::from_value`/`from_str` on a JSON value/body already read into
+  // memory — Display is a schema-mismatch message ("missing field `x`",
+  // "invalid type: …"), structurally incapable of carrying a path/URL/host/
+  // credential.
+  'scraping/boards/breezy/mod.rs:100': inMemoryParseSafe(),
+  'scraping/boards/jobicy/mod.rs:64': inMemoryParseSafe(),
+  'scraping/boards/jobicy/mod.rs:165': inMemoryParseSafe(),
+  'scraping/boards/comeet/mod.rs:70': inMemoryParseSafe(),
+  'scraping/boards/rippling/mod.rs:89': inMemoryParseSafe(),
+  'scraping/boards/workable/mod.rs:116': inMemoryParseSafe(),
+  'scraping/http/mod.rs:332': inMemoryParseSafe(),
+
+  'scraping/http/mod.rs:442': {
+    status: 'safe',
+    reason:
+      "htmd::convert parses an already-fetched, in-memory HTML string (html_to_markdown's " +
+      'own fallback path) — its Display is a structural markdown-conversion failure, never ' +
+      'a path/URL/host/credential.',
+  },
+  'scraping/engine/mod.rs:1081': {
+    status: 'safe',
+    reason:
+      'tokio::task::JoinError from the record_health spawn_blocking handle (the task ' +
+      'panicked or was cancelled) — its Display names only the task id and panic/cancel ' +
+      'state, never a path/URL/host/credential. Distinct from the sibling arm 3 lines ' +
+      'above, which IS a path-carrying AppError from the store and already uses .code() ' +
+      'for exactly that reason.',
+  },
 };
 
-/** Factory rather than one repeated literal so every `debt` entry stays easy
- * to scan for its (shared) rationale in one place; still one explicit
- * ALLOWLIST entry per site, so the undeclared/stale checks below cover each
- * individually. */
-function scrapingDebt() {
+/** Factory for the fetch_text/fetch_json-chokepoint shape — see the comment
+ * above the first entry that uses it for the full rationale; kept as one
+ * factory so the reasoning is written once and every site stays independently
+ * declared (the undeclared/stale checks below still cover each individually). */
+function httpChokepointSafe() {
   return {
-    status: 'debt',
+    status: 'safe',
     reason:
-      "scraping-applier domain (AGENTS.md domain routing) — out of this pass's " +
-      'primary-path scope. Pattern-identical to sites fixed elsewhere in this pass ' +
-      '(a reqwest::Error embedding the request URL, or a keyring error) and very ' +
-      "likely a genuine leak — needs a follow-up fix from that domain's author, not " +
-      'yet applied here.',
+      'Every error here originates from scraping::http::fetch_text/fetch_json (or, for ' +
+      'the Adzuna/JSearch/Jooble/Apify providers, a thin anyhow wrapper one hop away from ' +
+      "the same call) — the fleet's HTTP chokepoint for named-board scrapers, whose " +
+      'transport-failure branch already calls reqwest::Error::without_url() before ' +
+      'wrapping in AppError::Network, and whose other error variants (HTTP-status, ' +
+      'body-too-large, generic schema-drift, cancelled) are fixed path/URL-free messages.',
+  };
+}
+
+/** Factory for the pure in-memory-parse shape — see the comment above the
+ * first entry that uses it. */
+function inMemoryParseSafe() {
+  return {
+    status: 'safe',
+    reason:
+      'serde_json parsing an already-fetched, in-memory JSON value/body — a pure schema-' +
+      'mismatch failure, never a path, URL, host, or credential.',
   };
 }
 

--- a/scripts/check-log-error-leaks.test.mjs
+++ b/scripts/check-log-error-leaks.test.mjs
@@ -1,0 +1,172 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ALLOWLIST, findLeaks, MIN_SITES, violations } from './check-log-error-leaks.mjs';
+
+// Two kinds of test here, mirroring check-adr-citations.test.mjs.
+//
+// `findLeaks`/`violations` are exercised against a synthetic source tree and
+// synthetic inventories, so a case can state exactly what it is testing
+// without depending on which sites happen to be declared today. Then the
+// last block runs `findLeaks()` against the REAL repo and checks it produces
+// zero `violations()` against the REAL `ALLOWLIST` — a guard whose regex
+// silently stopped matching the actual log-macro idiom is the one failure
+// mode that makes all of the synthetic coverage theatre.
+//
+// `mkdtempSync` under `tmpdir()` rather than a fixed path: parallel test
+// workers must not collide on the same directory.
+
+let dir;
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = undefined;
+});
+
+/** Write `relPath` (e.g. `'foo/bar.rs'`) under a fresh temp src root; returns the root. */
+function writeSrc(files) {
+  dir = mkdtempSync(join(tmpdir(), 'check-log-error-leaks-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe('findLeaks', () => {
+  it('flags a single-line captured `{e}` interpolation', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {e}");\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('finds the site on the LINE the literal `{e}` sits on, not the macro line', () => {
+    // A backslash-continued string literal (the real shape this codebase used
+    // for a long message, e.g. dedup/mod.rs before it was fixed) — `{e}` sits
+    // one line below the `log::warn!(` call itself.
+    const root = writeSrc({
+      'foo.rs': [
+        'log::warn!(',
+        '    "[foo] failed ({e}); degrading — \\',
+        '     more text on a continuation line"',
+        ');',
+        '',
+      ].join('\n'),
+    });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:2', file: 'foo.rs', line: 2 }]);
+  });
+
+  it('does not flag `.code()`', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e.code());\n' });
+    expect(findLeaks(root)).toEqual([]);
+  });
+
+  it('does not flag sanitize_reason(&e.to_string())', () => {
+    const root = writeSrc({
+      'foo.rs': 'log::warn!("[foo] failed: {}", sanitize_reason(&e.to_string()));\n',
+    });
+    expect(findLeaks(root)).toEqual([]);
+  });
+
+  it('does not flag a positional `{}, e` call — a known, documented blind spot', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e);\n' });
+    expect(findLeaks(root)).toEqual([]);
+  });
+
+  it('does not flag `{err}` or any other identifier — only the literal `{e}` capture', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {err}");\n' });
+    expect(findLeaks(root)).toEqual([]);
+  });
+
+  it('catches every log level', () => {
+    const root = writeSrc({
+      'foo.rs': [
+        'log::warn!("a: {e}");',
+        'log::error!("b: {e}");',
+        'log::info!("c: {e}");',
+        'log::debug!("d: {e}");',
+        '',
+      ].join('\n'),
+    });
+    expect(findLeaks(root).map((l) => l.key)).toEqual([
+      'foo.rs:1',
+      'foo.rs:2',
+      'foo.rs:3',
+      'foo.rs:4',
+    ]);
+  });
+
+  it('scans nested directories and produces POSIX-separated keys', () => {
+    const root = writeSrc({ 'a/b/c.rs': 'log::warn!("nested: {e}");\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'a/b/c.rs:1', file: 'a/b/c.rs', line: 1 }]);
+  });
+});
+
+describe('violations', () => {
+  const leak = (key) => {
+    const [file, line] = [key.slice(0, key.lastIndexOf(':')), Number(key.split(':').pop())];
+    return { key, file, line };
+  };
+
+  it('passes when every finding is declared and every entry still has a finding', () => {
+    const inv = { 'foo.rs:1': { status: 'safe', reason: 'a'.repeat(30) } };
+    expect(violations(inv, [leak('foo.rs:1')])).toEqual([]);
+  });
+
+  it('fails on an undeclared finding — the case this guard exists for', () => {
+    const problems = violations({}, [leak('foo.rs:1')]);
+    expect(problems.join('\n')).toContain('foo.rs:1');
+    expect(problems.join('\n')).toContain('not declared in ALLOWLIST');
+  });
+
+  it('fails on a stale entry whose site no longer exists — keeps the list from rotting', () => {
+    const inv = { 'foo.rs:1': { status: 'safe', reason: 'a'.repeat(30) } };
+    const problems = violations(inv, []);
+    expect(problems.join('\n')).toContain('foo.rs:1');
+    expect(problems.join('\n')).toContain('Declared in ALLOWLIST but no `{e}` site found');
+  });
+
+  it('fails on a reason that is too short to be an explanation', () => {
+    const inv = { 'foo.rs:1': { status: 'safe', reason: 'because' } };
+    const problems = violations(inv, [leak('foo.rs:1')]);
+    expect(problems.join('\n')).toContain('must state why');
+  });
+
+  it('fails on an invalid status', () => {
+    const inv = { 'foo.rs:1': { status: 'maybe', reason: 'a'.repeat(30) } };
+    const problems = violations(inv, [leak('foo.rs:1')]);
+    expect(problems.join('\n')).toContain("must be 'safe' or 'debt'");
+  });
+
+  it('a single stale entry among many is reported as stale, not as broken detection', () => {
+    // The exact case an inventory-size-relative vacuity check would get wrong:
+    // 56 real findings for 57 declared entries must read as "one went stale",
+    // not "detection is broken" — this is the normal, common case (one site
+    // got fixed and its entry wasn't removed yet).
+    const inv = Object.fromEntries(
+      Array.from({ length: 57 }, (_, i) => [
+        `foo.rs:${i}`,
+        { status: 'safe', reason: 'x'.repeat(30) },
+      ])
+    );
+    const leaks = Array.from({ length: 56 }, (_, i) => leak(`foo.rs:${i}`));
+    const problems = violations(inv, leaks);
+    expect(problems.join('\n')).toContain('foo.rs:56');
+    expect(problems.join('\n')).not.toContain('detection looks');
+  });
+});
+
+describe('MIN_SITES (the CLI-level absolute floor, not folded into violations())', () => {
+  it('is well below the real repo count, so a real regression is what trips it', () => {
+    expect(findLeaks().length).toBeGreaterThan(MIN_SITES);
+  });
+});
+
+describe('the real ALLOWLIST against the real repo', () => {
+  it('has zero violations — the guard is green against actual source today', () => {
+    const leaks = findLeaks();
+    expect(violations(ALLOWLIST, leaks)).toEqual([]);
+  });
+});

--- a/scripts/check-log-error-leaks.test.mjs
+++ b/scripts/check-log-error-leaks.test.mjs
@@ -63,6 +63,11 @@ describe('findLeaks', () => {
     expect(findLeaks(root)).toEqual([]);
   });
 
+  it('does not flag `.kind()`', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e.kind());\n' });
+    expect(findLeaks(root)).toEqual([]);
+  });
+
   it('does not flag sanitize_reason(&e.to_string())', () => {
     const root = writeSrc({
       'foo.rs': 'log::warn!("[foo] failed: {}", sanitize_reason(&e.to_string()));\n',
@@ -70,13 +75,41 @@ describe('findLeaks', () => {
     expect(findLeaks(root)).toEqual([]);
   });
 
-  it('does not flag a positional `{}, e` call — a known, documented blind spot', () => {
+  it('flags a positional bare `e` argument — the vacuity hole review found live', () => {
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e);\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('flags a positional bare `err` argument, `&`-prefixed', () => {
+    // The exact shape live at autopilot_helpers/mod.rs:151 before this fix.
+    const root = writeSrc({
+      'foo.rs': "log::warn!(\"[foo] board '{}' failed (error='{}')\", board, &err);\n",
+    });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('does not flag a positional argument named something other than e/err/error', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] status: {}", status);\n' });
     expect(findLeaks(root)).toEqual([]);
   });
 
-  it('does not flag `{err}` or any other identifier — only the literal `{e}` capture', () => {
+  it('flags `{err}` — a captured identifier this scanner used to miss entirely', () => {
+    // Live (before this fix) at postings/mod.rs:382 and
+    // platform/linux_appimage.rs:170.
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {err}");\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('flags `{error}` too, for the same reason as `{err}`', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {error}");\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('does not flag a captured identifier that is not an error-binding name', () => {
+    // Bounded matching, not "any identifier" — see ERROR_BINDING_NAMES. `host`
+    // and `port` are real, frequent captures in this crate's log calls, and
+    // neither is an error.
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] connecting to {host}:{port}");\n' });
     expect(findLeaks(root)).toEqual([]);
   });
 

--- a/scripts/check-log-error-leaks.test.mjs
+++ b/scripts/check-log-error-leaks.test.mjs
@@ -75,6 +75,40 @@ describe('findLeaks', () => {
     expect(findLeaks(root)).toEqual([]);
   });
 
+  it('flags a positional `e.to_string()` — the method-call gap a review found', () => {
+    // The finding: the bare-identifier check missed `e.to_string()`, one
+    // method call away from the exact same leak as a bare `e`.
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e.to_string());\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('flags a positional `err.to_owned()`, `&`-prefixed, same shape as `.to_string()`', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", &err.to_owned());\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('flags `error.to_string()` too, for the same reason as `e`/`err`', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", error.to_string());\n' });
+    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+  });
+
+  it('still does not flag sanitize_reason(&e.to_string()) once .to_string() is matched', () => {
+    // The false-positive risk this widening introduces: sanitize_reason's own
+    // wrapper CONTAINS the literal text `.to_string()` inside it. Excluded by
+    // the wrapping call (sanitize_reason(...) is not itself a bare
+    // `e.to_string()` argument), never by pattern-matching the inner text —
+    // see findPositionalErrorArg's doc comment.
+    const root = writeSrc({
+      'foo.rs': 'log::warn!("[foo] failed: {}", sanitize_reason(&e.to_string()));\n',
+    });
+    expect(findLeaks(root)).toEqual([]);
+  });
+
+  it('does not flag `.to_string()` on a non-error-binding identifier', () => {
+    const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] value: {}", status.to_string());\n' });
+    expect(findLeaks(root)).toEqual([]);
+  });
+
   it('flags a positional bare `e` argument — the vacuity hole review found live', () => {
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e);\n' });
     expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);


### PR DESCRIPTION
## What this is

An audit of the nine route-scoped entries in `check-event-subscriptions.mjs` found **eight of the nine notes were wrong**. Fixing them turned up six real defects behind them, so this PR carries both: the corrections, the fixes, and two guards so neither class rots again.

## The notes were wrong, and nothing could tell us

Three notes described a loss that had already been fixed, four understated it, one named a cause the code does not have. Only the activity-feed note was accurate.

They rot because nothing coupled them to the code: #1019 fixed the jobs scrape and never touched the note beside it, and #1025 later edited that very file without noticing the note next to it was by then obsolete. The guard enforced that a note **exists**, never that it is **true**.

Each route-scoped entry now carries a content hash of the file it describes, and the check fails when the file drifts, printing the note so re-reading costs seconds. It fired on this PR's own merge for four files — that is the mechanism working.

**Known blind spot, recorded in the file:** the hash covers the declared file only, so a note also goes stale when behaviour changes in something that file merely *calls*. Both misses came from this batch — `JobsPage`'s defect was fixed inside `useScraping.ts`, `update-section`'s inside the updater service — and neither declared file was touched. Hashing the import graph would fire on nearly every commit and be ignored within a week, so those two entries say in their own text that they were fixed elsewhere.

## The six defects

**You get invited to start expensive work that is already running.** Returning to Settings mid-update rendered a live "Check now"; clicking it cleared `downloaded_bytes`, discarding a finished download and forcing a full re-fetch, with no re-entry guard. Returning to onboarding mid-pull re-showed Download; clicking it started a *second* multi-GB pull, because `ai_pull_model` used `job_start` rather than the `job_start_exclusive` that already existed.

**The failure reason never arrived.** A résumé run that failed while you were on another tab left no error at all — you came back to the plain wizard as if you had never pressed Generate, because `error` was only ever written by the live listener. Autopilot had the same shape, plus a `staleTime` hole that showed an idle card with an enabled Run button for a live run.

**Jobs lied about progress.** The default board set is one board, so `scrape:progress` fires once, at the end — after a remount the bar asserted a false 0% for the rest of the run, while the tracker already held the true fraction and the watchdog fetched it and threw it away. A scrape that *failed* off-page came back with no explanation at all.

## Path leaks in logs

145 `log::…("{e}")` sites audited against rule 1 of `AGENTS.md`. **100 fixed**, the rest traced and declared safe with a reason. Not a blanket replacement — 33 of the scraping sites turned out genuinely safe because `scraping::http::fetch_text` already calls `.without_url()`, and replacing them would have discarded useful diagnostics to fix nothing.

The one worth naming: `linkedin/api_client/mod.rs` bypasses that chokepoint with a raw `client.get(url).send()`, so a transport failure logged the full guest-search URL **including the user's free-text keywords and location**.

`scripts/check-log-error-leaks.mjs` now fails in both directions — an undeclared leak, and a declared entry that no longer matches.

## Verification

- `cargo test --all-features --locked` — 4,349 passed
- `pnpm test` — 7,102 passed · `pnpm typecheck` · `pnpm lint:strict --max-warnings 0` — clean
- both new guards plus `check:agent-system` green

Every fix was mutation-checked by execution, not by reasoning: the guard removed, the test watched go red, the guard restored.

Two things I checked rather than assumed. Two Rust tests failed once under full parallelism and passed on a clean re-run; neither file is in this diff, so they are pre-existing flakes, confirmed by re-running rather than by asserting it. And a new leak test dialled the discard port, which Windows leaves hanging until its own timeout — over a minute on every run, now bounded to 0.52s.

## Note for review

`extension_bridge/mod.rs` crossed the R8 LOC cap once its fixes landed, so its token/opt-in persistence split into `persist.rs`, following that file's own existing `autotrack.rs` precedent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI model downloads and software updates now resume reliably after navigation or remounting.
  - Scraping progress, completion status, and failure details are restored more consistently.
  - Autopilot and résumé pipeline errors persist across page changes.
  - Updater status remains synchronized across multiple views.
  - Extension pairing tokens are stored with stronger file protection.

- **Bug Fixes**
  - Prevented duplicate AI and update downloads.
  - Improved refresh behavior for autopilot data and completed scraping jobs.
  - Sensitive details are now redacted from diagnostic logs.

- **Chores**
  - Added automated checks to prevent unsafe error details from entering logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->