### PR TITLE
fix: stop a false language critical and read today as a date column

### DIFF
--- a/apps/desktop/src-tauri/src/documents/evidence/entry.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/entry.rs
@@ -511,33 +511,70 @@ const MONTH_TOKENS: &[&str] = &[
     "dezember",
 ];
 
-/// "Today"-family present-tense markers recognised **only** by [`is_date_only`]
-/// — deliberately never added to [`PRESENT_MARKERS`], which [`is_open_ended`]
-/// and `validate::content::factual::unsupported_date_issues` both also consult.
+/// "Today"/"currently"-family present-tense markers recognised **only** by
+/// [`is_date_only`] — deliberately never added to [`PRESENT_MARKERS`], which
+/// [`is_open_ended`] and `validate::content::factual::unsupported_date_issues`
+/// both also consult, and never merged with either by stem/prefix matching.
 ///
-/// Measured, not just cautious: those two consumers match a SINGLE WORD
-/// anywhere in arbitrary text via [`contains_word`]/`contains_phrase` — no
-/// year, no separator, no other date structure required, because
-/// `is_open_ended`'s first branch returns as soon as the word is found.
-/// "today" is ordinary English vocabulary ("the system still runs today",
-/// "shipped the migration today"); putting it in [`PRESENT_MARKERS`] would
-/// turn any such bullet into a date context, and in
-/// `unsupported_date_issues` specifically, a false `factual.unsupported_date`
-/// Critical the moment that bullet also names a year the source résumé
-/// doesn't. (Confirmed the same failure mode is already live for `actual`,
-/// which is in [`PRESENT_MARKERS`] for Spanish `actual` — `is_open_ended`
-/// returns true for "Reduced actual costs by 20% in 2023" on the word alone.)
-///
+/// **Why a separate list at all — measured, not just cautious.** Those two
+/// consumers match a SINGLE WORD anywhere in arbitrary text via
+/// [`contains_word`]/`contains_phrase` — no year, no separator, no other date
+/// structure required, because `is_open_ended`'s first branch returns as soon
+/// as the word is found. Every spelling here is ordinary prose in its
+/// language, not just "today": "currently" ("we are currently migrating"),
+/// "derzeit", "actuellement", "presente" (also an ordinary Spanish/Portuguese/
+/// Italian adjective — "el problema presente"). Putting any of them in
+/// [`PRESENT_MARKERS`] would turn a matching bullet into a date context and,
+/// in `unsupported_date_issues` specifically, risk a false
+/// `factual.unsupported_date` Critical the moment that bullet also names a
+/// year the source résumé doesn't. (Confirmed the same failure mode is
+/// already live for `actual`, which IS in [`PRESENT_MARKERS`] for Spanish
+/// `actual` — `is_open_ended` returns true for "Reduced actual costs by 20%
+/// in 2023" on the word alone; see the handoff for the measurement.)
 /// [`is_date_only`] cannot make that mistake: it already requires EVERY token
 /// on the line to be a digit, a month or a marker, so a prose sentence
 /// carrying any other word is rejected before this list is ever consulted —
 /// exact-token equality against a whole date column is structurally safe in a
 /// way word-bounded matching against free text is not.
 ///
-/// `aujourd'hui` is split by [`word_tokens`] into `aujourd` and `hui` — the
-/// apostrophe is not alphanumeric — so both halves are listed; `is_date_only`
-/// requires every token to resolve, not the phrase as a whole.
-const DATE_ONLY_MARKERS: &[&str] = &["today", "aujourd", "hui", "oggi", "actualidad"];
+/// **Why literal spellings, never a shared stem.** `actual`/`actuel`/
+/// `actualidad`/`atualmente`/`attualmente` all share a Latin root and a
+/// prefix rule would collapse them into one entry, but this const is already
+/// read by a whole-line gate today and nothing stops a future caller reading
+/// it against free text the way [`PRESENT_MARKERS`] is — the exact hazard the
+/// paragraph above documents. A literal list stays safe under a change of
+/// consumer; a prefix rule would not, so every spelling is listed in full
+/// even where it costs a near-duplicate entry.
+///
+/// **`aujourd'hui`** is split by [`word_tokens`] into `aujourd` and `hui` —
+/// the apostrophe is not alphanumeric — so both halves are listed;
+/// `is_date_only` requires every token to resolve, not the phrase as a whole.
+///
+/// **`nu`** (Dutch/Swedish "now") is deliberately left OUT, not an oversight.
+/// Every other entry here is 4+ letters; `nu` is two, which collides with
+/// initials, unit abbreviations and stray two-letter tokens far more readily
+/// than the rest of this list — and unlike those, a false hit doesn't need a
+/// second unrelated word nearby, just one line where every OTHER token also
+/// happens to be date-shaped. The Dutch/Swedish market share this pipeline
+/// serves does not justify that exposure; `heden` (Dutch "today", already in
+/// [`PRESENT_MARKERS`]) covers the same case at four letters with none of the
+/// risk.
+const DATE_ONLY_MARKERS: &[&str] = &[
+    "today",
+    "aujourd",
+    "hui",
+    "oggi",
+    "actualidad",
+    "presente",
+    "currently",
+    "hoje",
+    "atualmente",
+    "hoy",
+    "actuellement",
+    "attualmente",
+    "derzeit",
+    "vandaag",
+];
 
 /// True when `s` is a date COLUMN and nothing else: every word in it is a
 /// number, a month, a present-tense marker or a [`DATE_ONLY_MARKERS`] entry,

--- a/apps/desktop/src-tauri/src/documents/evidence/entry.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/entry.rs
@@ -511,10 +511,39 @@ const MONTH_TOKENS: &[&str] = &[
     "dezember",
 ];
 
+/// "Today"-family present-tense markers recognised **only** by [`is_date_only`]
+/// — deliberately never added to [`PRESENT_MARKERS`], which [`is_open_ended`]
+/// and `validate::content::factual::unsupported_date_issues` both also consult.
+///
+/// Measured, not just cautious: those two consumers match a SINGLE WORD
+/// anywhere in arbitrary text via [`contains_word`]/`contains_phrase` — no
+/// year, no separator, no other date structure required, because
+/// `is_open_ended`'s first branch returns as soon as the word is found.
+/// "today" is ordinary English vocabulary ("the system still runs today",
+/// "shipped the migration today"); putting it in [`PRESENT_MARKERS`] would
+/// turn any such bullet into a date context, and in
+/// `unsupported_date_issues` specifically, a false `factual.unsupported_date`
+/// Critical the moment that bullet also names a year the source résumé
+/// doesn't. (Confirmed the same failure mode is already live for `actual`,
+/// which is in [`PRESENT_MARKERS`] for Spanish `actual` — `is_open_ended`
+/// returns true for "Reduced actual costs by 20% in 2023" on the word alone.)
+///
+/// [`is_date_only`] cannot make that mistake: it already requires EVERY token
+/// on the line to be a digit, a month or a marker, so a prose sentence
+/// carrying any other word is rejected before this list is ever consulted —
+/// exact-token equality against a whole date column is structurally safe in a
+/// way word-bounded matching against free text is not.
+///
+/// `aujourd'hui` is split by [`word_tokens`] into `aujourd` and `hui` — the
+/// apostrophe is not alphanumeric — so both halves are listed; `is_date_only`
+/// requires every token to resolve, not the phrase as a whole.
+const DATE_ONLY_MARKERS: &[&str] = &["today", "aujourd", "hui", "oggi", "actualidad"];
+
 /// True when `s` is a date COLUMN and nothing else: every word in it is a
-/// number, a month or a present-tense marker, **and** it carries more date
-/// structure than a lone year — a span separator (`2018 – 2021`), an open end
-/// (`2021 – Present`, `2021 –`) or a month (`Jan 2022`).
+/// number, a month, a present-tense marker or a [`DATE_ONLY_MARKERS`] entry,
+/// **and** it carries more date structure than a lone year — a span separator
+/// (`2018 – 2021`), an open end (`2021 – Present`, `2021 – Today`) or a month
+/// (`Jan 2022`).
 ///
 /// Both halves are load-bearing, and [`looks_like_date_span`] alone is neither.
 /// It is satisfied by any text carrying a year, so the word test was doing all
@@ -534,6 +563,7 @@ pub(super) fn is_date_only(s: &str) -> bool {
         t.chars().all(|c| c.is_ascii_digit())
             || MONTH_TOKENS.contains(&t.as_str())
             || PRESENT_MARKERS.contains(&t.as_str())
+            || DATE_ONLY_MARKERS.contains(&t.as_str())
     });
     if !date_words || !looks_like_date_span(s) {
         return false;
@@ -541,6 +571,9 @@ pub(super) fn is_date_only(s: &str) -> bool {
     !date_spans(s).is_empty()
         || is_open_ended(s)
         || tokens.iter().any(|t| MONTH_TOKENS.contains(&t.as_str()))
+        || tokens
+            .iter()
+            .any(|t| DATE_ONLY_MARKERS.contains(&t.as_str()))
 }
 
 /// True when one pipe/middot SEGMENT is the entry's date column: it carries a

--- a/apps/desktop/src-tauri/src/documents/evidence/entry.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/entry.rs
@@ -559,12 +559,37 @@ const MONTH_TOKENS: &[&str] = &[
 /// serves does not justify that exposure; `heden` (Dutch "today", already in
 /// [`PRESENT_MARKERS`]) covers the same case at four letters with none of the
 /// risk.
-const DATE_ONLY_MARKERS: &[&str] = &[
+///
+/// **Known boundary, not an oversight: single tokens only.** A multi-word
+/// present-tense column — Spanish `en la actualidad`, French `en cours` /
+/// `à ce jour`, Italian `ad oggi` / `in corso`, Portuguese `até hoje`,
+/// Spanish `o presente`, Dutch `tot heden`, German `bis heute` (the last
+/// already failing today, since `heute` is a [`PRESENT_MARKERS`] single
+/// token) — is not recognised, because [`is_date_only`]'s `date_words` gate
+/// asks whether EVERY token resolves on its own; a phrase needs the SEPARATOR
+/// between its words to also be accounted for, which is a different
+/// mechanism (multi-token phrase matching) and a wider change than this list.
+///
+/// **A second safety property, beyond "prose fails the token gate."** No
+/// entry here is ever added to [`PRESENT_MARKERS`], so [`is_open_ended`]
+/// never fires on any of these words — which means even a line built
+/// ENTIRELY from digits/months/[`DATE_ONLY_MARKERS`] tokens still can't pass
+/// [`is_date_only`] unless it also carries a real year or a genuine
+/// [`PRESENT_MARKERS`] open-ended marker: [`looks_like_date_span`] gates on
+/// exactly those two things and never consults this list.
+/// `"Today Today"`, `"Hoy Hoy"`, `"Today 5"` and `"Currently 100"` all fail
+/// [`is_date_only`] for this reason, not because any token is unrecognised —
+/// every token in each of them resolves fine, but none of the four ever
+/// reaches a year or a [`PRESENT_MARKERS`] marker. The disjointness this
+/// relies on — no spelling lives in both lists — is asserted in the test
+/// suite, not just documented here.
+pub(super) const DATE_ONLY_MARKERS: &[&str] = &[
     "today",
     "aujourd",
     "hui",
     "oggi",
     "actualidad",
+    "actualmente",
     "presente",
     "currently",
     "hoje",

--- a/apps/desktop/src-tauri/src/documents/evidence/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/mod.rs
@@ -545,6 +545,20 @@ pub fn classify_section(heading: &str) -> SectionKind {
 /// gap list with "unsere", "hinter" and "bereits" instead of skills. Entries are
 /// the *unstemmed, normalized* forms (what [`display_forms`] yields), because
 /// the split happens on stems when the languages align.
+///
+/// **Not the same primitive as `validate::content::language`'s
+/// `FUNCTION_WORDS_DE`/`function_words_for`, despite the identical name and
+/// overlapping content — do not "unify" them.** That module asks a language-
+/// IDENTITY question (does this text carry positive evidence of being
+/// written in a specific OTHER language, so a confident-but-wrong `whatlang`
+/// read is not this crate's only witness) and answers it for seven curated
+/// languages; this one asks a SKILL-CLAIM question (which tokens on a skills
+/// line are filler rather than a claimed skill) and, as the doc above
+/// explains, is deliberately curated for German only. A word missing here is
+/// safe (a display-only gap list stays merely noisy); a word wrongly
+/// PRESENT there is not (it manufactures a language accusation) — the two
+/// lists answer to different correctness bars for that reason, and merging
+/// them would let a change tuned for one silently regress the other.
 const FUNCTION_WORDS_DE: &[&str] = &[
     // Determiners, pronouns and prepositions that survive the ≥4-char filter.
     "aber",
@@ -667,6 +681,12 @@ pub(crate) fn function_words(lang: &str) -> &'static [&'static str] {
 /// removed must go quiet here rather than report a number it cannot stand
 /// behind. Adding a language to [`function_words`] is what re-enables it —
 /// deliberately one edit, in one place.
+///
+/// `false` for `"es"` here does NOT mean this crate has no Spanish function
+/// words anywhere — `validate::content::language::function_words_for("es")`
+/// returns 61 of them, curated for a DIFFERENT question (see
+/// [`FUNCTION_WORDS_DE`]'s doc for why the two are deliberately separate
+/// primitives, not the same list read from two places).
 pub(crate) fn has_curated_function_words(lang: &str) -> bool {
     matches!(lang, "en" | "de")
 }

--- a/apps/desktop/src-tauri/src/documents/evidence/test.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/test.rs
@@ -884,6 +884,57 @@ Acme Payments, Berlin, 2018 - 2021
     assert_eq!(acme.bullets.len(), 2, "got {:?}", acme.bullets);
 }
 
+/// Same shape as [`an_unparsed_entry_line_opens_its_own_role_instead_of_joining_the_last`],
+/// with the date column spelled `2020 - Today` instead of `2018 - 2021` —
+/// the user-visible consequence of the `is_date_only` gap: before the fix,
+/// `Today` was not recognised as a present-tense marker, so `is_date_only`
+/// rejected the column, `trailing_date_column` returned `None`, and this
+/// arm fell through to `attach_to_role`, which appended Acme's header line
+/// AND both of its bullets onto Globex's role.
+#[test]
+fn an_english_today_date_column_opens_its_own_role() {
+    let resume = "\
+Jane Doe
+jane@example.com
+
+EXPERIENCE
+
+Senior Engineer | Globex Logistics | 2015 - 2018
+- Built the billing API in Python and PostgreSQL
+
+Acme Payments, Berlin, 2020 - Today
+- Shipped Docker containers onto a Kubernetes cluster
+- Cut checkout latency with a Redis cache in front of the ledger service
+";
+    let set = extract_evidence(resume, "Docker Kubernetes Redis Python backend engineer");
+    assert_eq!(set.roles.len(), 2, "two employers; got {:?}", set.roles);
+
+    let globex = &set.roles[0];
+    assert_eq!(globex.company, "Globex Logistics");
+    assert_eq!(
+        globex.bullets.len(),
+        1,
+        "Globex's role must not absorb Acme's header line or its work; got {:?}",
+        globex.bullets
+    );
+    assert!(
+        !globex
+            .bullets
+            .iter()
+            .any(|b| b.text.contains("Docker") || b.text.contains("Acme")),
+        "Acme's work must not be credited to Globex; got {:?}",
+        globex.bullets
+    );
+
+    let acme = &set.roles[1];
+    assert_eq!(
+        acme.company, "Acme Payments",
+        "the employer is salvaged from the unparsed line, never guessed"
+    );
+    assert_eq!(acme.dates, "2020 - Today");
+    assert_eq!(acme.bullets.len(), 2, "got {:?}", acme.bullets);
+}
+
 /// The other half of the same rule: a line that is NOT entry-shaped must keep
 /// continuing the entry above it. "2021 to Present" on its own line is the
 /// second half of the round-4 fixture's header, not a new employer.
@@ -1003,6 +1054,41 @@ fn a_date_column_needs_more_than_a_year_in_it() {
     }
     for prose in ["2022", "delivered in 2019", "40 warehouse sites", ""] {
         assert!(!is_date_only(prose), "{prose:?} is not a date column");
+    }
+}
+
+/// The "today"-family spellings added to [`DATE_ONLY_MARKERS`] — English
+/// `Today`, Spanish `Actualidad`, French `Aujourd'hui`, Italian `Oggi` — both
+/// directions: the date column each spelling appears in IS recognised, and an
+/// ordinary sentence carrying the same word (with other, non-date words
+/// around it) is NOT. [`is_date_only`] requires EVERY token on the line to be
+/// a digit, a month or a marker, so a multi-word sentence can never qualify no
+/// matter what the marker list holds — that structural gate, not curation, is
+/// what keeps the prose cases safe.
+///
+/// Mutation check (reported verbatim in the handoff): with `DATE_ONLY_MARKERS`
+/// emptied, every `column` case here goes red; every `prose` case stays green
+/// regardless, because the gate does that work.
+#[test]
+fn today_family_markers_open_a_date_column_but_never_leak_into_prose() {
+    for column in [
+        "2020 - Today",
+        "2015 - Actualidad",
+        "2019 - Aujourd'hui",
+        "2021 - Oggi",
+    ] {
+        assert!(is_date_only(column), "{column:?} is a date column");
+    }
+    for prose in [
+        "Shipped the migration today",
+        "En la actualidad trabajo en remoto",
+        "Nous avons livré le projet aujourd'hui",
+        "Il progetto oggi è completo",
+    ] {
+        assert!(
+            !is_date_only(prose),
+            "{prose:?} is ordinary prose, not a date column"
+        );
     }
 }
 

--- a/apps/desktop/src-tauri/src/documents/evidence/test.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/test.rs
@@ -1057,27 +1057,33 @@ fn a_date_column_needs_more_than_a_year_in_it() {
     }
 }
 
-/// The "today"/"currently"-family spellings in [`DATE_ONLY_MARKERS`] — English
-/// `Today`/`Currently`, Spanish `Actualidad`/`Hoy`, Portuguese `Hoje`/
-/// `Atualmente`, French `Aujourd'hui`/`Actuellement`, Italian `Oggi`, and the
-/// `Present`-adjacent `Presente`/`Attualmente`/`Derzeit`/`Vandaag` — both
-/// directions: the date column each spelling appears in IS recognised, and an
-/// ordinary sentence carrying the same word (with other, non-date words
-/// around it) is NOT. [`is_date_only`] requires EVERY token on the line to be
-/// a digit, a month or a marker, so a multi-word sentence can never qualify no
-/// matter what the marker list holds — that structural gate, not curation, is
-/// what keeps the prose cases safe.
+/// Every "today"/"currently"-family spelling in [`DATE_ONLY_MARKERS`] — English
+/// `Today`/`Currently`, Spanish `Actualidad`/`Actualmente`/`Hoy`, Portuguese
+/// `Hoje`/`Atualmente`, French `Aujourd'hui`/`Actuellement`, Italian `Oggi`,
+/// and the `Present`-adjacent `Presente`/`Attualmente`/`Derzeit`/`Vandaag` —
+/// opens the date column it appears in.
 ///
-/// Mutation check (reported verbatim in the handoff): with `DATE_ONLY_MARKERS`
-/// emptied, every `column` case here goes red; every `prose` case stays green
-/// regardless, because the gate does that work, not the list — which is the
-/// point of pairing every marker with a prose sentence that survives its
-/// removal unchanged.
+/// Collects every failure instead of asserting inside the loop: a bare
+/// `assert!` per iteration reports only the FIRST broken spelling and hides
+/// every other one behind it, so a future regression that drops or typos a
+/// second marker would read identically to "everything fine" for this test.
+/// This one call names every spelling that stopped working.
+///
+/// This test is deliberately NOT paired with a prose loop the way an earlier
+/// version was — every one of those "prose" rows only passed because
+/// `word_tokens` splits the sentence into words the `date_words.all()` gate
+/// (a digit, a month or a marker) already rejects before any marker is even
+/// consulted, so the row proved the tokenizer works on ordinary sentences,
+/// not that [`DATE_ONLY_MARKERS`] is safe. [`a_date_column_needs_more_than_a_year_in_it`]
+/// already covers that mechanism; duplicating it here under a name that
+/// implies it guards this list would be misleading about what failed if it
+/// ever went red.
 #[test]
-fn today_family_markers_open_a_date_column_but_never_leak_into_prose() {
-    for column in [
+fn date_only_markers_open_every_added_spelling() {
+    let columns = [
         "2020 - Today",
         "2015 - Actualidad",
+        "2020 - Actualmente",
         "2019 - Aujourd'hui",
         "2021 - Oggi",
         "2020 - Presente",
@@ -1089,29 +1095,36 @@ fn today_family_markers_open_a_date_column_but_never_leak_into_prose() {
         "2020 - Attualmente",
         "2020 - Derzeit",
         "2020 - Vandaag",
-    ] {
-        assert!(is_date_only(column), "{column:?} is a date column");
-    }
-    for prose in [
-        "Shipped the migration today",
-        "En la actualidad trabajo en remoto",
-        "Nous avons livré le projet aujourd'hui",
-        "Il progetto oggi è completo",
-        "El equipo estuvo presente en la reunión",
-        "We are currently migrating the platform",
-        "Terminamos o projeto hoje mesmo",
-        "Atualmente trabalhamos em home office",
-        "Entregamos el proyecto hoy mismo",
-        "Nous travaillons actuellement à distance",
-        "Il team lavora attualmente da remoto",
-        "Das Team arbeitet derzeit remote",
-        "Het team werkt vandaag vanuit huis",
-    ] {
-        assert!(
-            !is_date_only(prose),
-            "{prose:?} is ordinary prose, not a date column"
-        );
-    }
+    ];
+    let not_recognised: Vec<&str> = columns
+        .into_iter()
+        .filter(|column| !is_date_only(column))
+        .collect();
+    assert!(
+        not_recognised.is_empty(),
+        "not read as date columns: {not_recognised:?}"
+    );
+}
+
+/// The safety argument for [`DATE_ONLY_MARKERS`] depends entirely on it never
+/// sharing a spelling with [`PRESENT_MARKERS`] — [`is_open_ended`] and
+/// `validate::content::factual::unsupported_date_issues` both match
+/// [`PRESENT_MARKERS`] against arbitrary free text, so a spelling living in
+/// both lists would turn ordinary prose carrying that word into a false date
+/// context. That invariant lived only in the const's doc comment; this makes
+/// keeping it cost one assertion instead of a careful re-read before the next
+/// spelling is added.
+#[test]
+fn date_only_markers_never_overlap_present_markers() {
+    let overlap: Vec<&str> = DATE_ONLY_MARKERS
+        .iter()
+        .filter(|m| PRESENT_MARKERS.contains(m))
+        .copied()
+        .collect();
+    assert!(
+        overlap.is_empty(),
+        "spellings in both lists — is_open_ended would fire on them as bare prose: {overlap:?}"
+    );
 }
 
 /// R7-F1(b) — the salvage contradicted its own contract. A label with no comma

--- a/apps/desktop/src-tauri/src/documents/evidence/test.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/test.rs
@@ -1057,8 +1057,10 @@ fn a_date_column_needs_more_than_a_year_in_it() {
     }
 }
 
-/// The "today"-family spellings added to [`DATE_ONLY_MARKERS`] — English
-/// `Today`, Spanish `Actualidad`, French `Aujourd'hui`, Italian `Oggi` — both
+/// The "today"/"currently"-family spellings in [`DATE_ONLY_MARKERS`] — English
+/// `Today`/`Currently`, Spanish `Actualidad`/`Hoy`, Portuguese `Hoje`/
+/// `Atualmente`, French `Aujourd'hui`/`Actuellement`, Italian `Oggi`, and the
+/// `Present`-adjacent `Presente`/`Attualmente`/`Derzeit`/`Vandaag` — both
 /// directions: the date column each spelling appears in IS recognised, and an
 /// ordinary sentence carrying the same word (with other, non-date words
 /// around it) is NOT. [`is_date_only`] requires EVERY token on the line to be
@@ -1068,7 +1070,9 @@ fn a_date_column_needs_more_than_a_year_in_it() {
 ///
 /// Mutation check (reported verbatim in the handoff): with `DATE_ONLY_MARKERS`
 /// emptied, every `column` case here goes red; every `prose` case stays green
-/// regardless, because the gate does that work.
+/// regardless, because the gate does that work, not the list — which is the
+/// point of pairing every marker with a prose sentence that survives its
+/// removal unchanged.
 #[test]
 fn today_family_markers_open_a_date_column_but_never_leak_into_prose() {
     for column in [
@@ -1076,6 +1080,15 @@ fn today_family_markers_open_a_date_column_but_never_leak_into_prose() {
         "2015 - Actualidad",
         "2019 - Aujourd'hui",
         "2021 - Oggi",
+        "2020 - Presente",
+        "2020 - Currently",
+        "2020 - Hoje",
+        "2020 - Atualmente",
+        "2020 - Hoy",
+        "2020 - Actuellement",
+        "2020 - Attualmente",
+        "2020 - Derzeit",
+        "2020 - Vandaag",
     ] {
         assert!(is_date_only(column), "{column:?} is a date column");
     }
@@ -1084,6 +1097,15 @@ fn today_family_markers_open_a_date_column_but_never_leak_into_prose() {
         "En la actualidad trabajo en remoto",
         "Nous avons livré le projet aujourd'hui",
         "Il progetto oggi è completo",
+        "El equipo estuvo presente en la reunión",
+        "We are currently migrating the platform",
+        "Terminamos o projeto hoje mesmo",
+        "Atualmente trabalhamos em home office",
+        "Entregamos el proyecto hoy mismo",
+        "Nous travaillons actuellement à distance",
+        "Il team lavora attualmente da remoto",
+        "Das Team arbeitet derzeit remote",
+        "Het team werkt vandaag vanuit huis",
     ] {
         assert!(
             !is_date_only(prose),

--- a/apps/desktop/src-tauri/src/validate/content/language.rs
+++ b/apps/desktop/src-tauri/src/validate/content/language.rs
@@ -258,6 +258,7 @@ const MIN_DISTINCTIVE_TOKEN_CHARS: usize = 2;
 /// | quiet | same list + ci/cd, .io, vi, HA, or per (the short-token leaks) | 0 |
 /// | quiet | German institution name, terse "Degree, Institution, Dates" | 1 |
 /// | quiet | German institution name, EDUCATION section (2 entries) | 3 |
+/// | quiet | genuinely German résumé, terse participle/connector-sparse register, whole document (not an English document naming an institution) | 3 |
 /// | quiet | German institution names, CERTIFICATIONS (3 entries) | 4 |
 /// | fire | short genuine Spanish paragraph (2 sentences) | 6 |
 /// | fire | Italian VOLUNTEER section (PR #1003's own fixture) | 6 |
@@ -276,6 +277,33 @@ const MIN_DISTINCTIVE_TOKEN_CHARS: usize = 2;
 /// corpus with a full unit of margin on both sides, matching (independently,
 /// not by construction) the separation an earlier review measured on a
 /// different fixture set.
+///
+/// **The quiet class is not one thing, and reading it as only "an English
+/// document naming a foreign institution" understates what the floor
+/// accepts.** Every OTHER row above IS that shape — a document that SHOULD
+/// stay quiet, correctly does. The new row is not: a genuinely GERMAN
+/// résumé, written in the terse participle/connector-sparse register real
+/// German CVs favor ("Zahlungsplattform aufgebaut", not "Ich habe die
+/// Zahlungsplattform aufgebaut" — the article and the finite-verb clause
+/// both dropped), lands in the SAME 0-4 band for the same underlying reason
+/// the correctly-quiet rows do: too few of `text`'s words are the
+/// closed-class connectors this design counts, at all. A pure evidence
+/// COUNT cannot tell "an English document that happens to name a German
+/// institution" apart from "a genuinely German document that happens to
+/// write in a connector-light register" — both present as a small number of
+/// hits. Confirmed, not just argued: 3, the measured evidence for this
+/// connector-sparse German row, is the EXACT value the EDUCATION-section row
+/// above it already relies on staying quiet for — a floor low enough to
+/// catch one reopens the other. This is a THIRD accepted miss (after the
+/// uncurated `tr`/`vi` miss — [`LATIN_SCRIPT_LANGUAGES`]'s doc — and the
+/// close-relative-target Romance-language miss —
+/// `test::a_short_paragraph_against_a_close_relative_target_is_an_accepted_miss`),
+/// pinned in `test::a_terse_participle_register_german_resume_is_an_accepted_miss`.
+/// It is a DESIGN limit, not a calibration error: recovering it needs a
+/// signal this module does not have (participle/compound morphology, or a
+/// second corroborating witness), not a threshold change, and is
+/// deliberately left to a future change rather than folded into whichever
+/// fix happens to be touching this file.
 ///
 /// **Residual risk, measured across all four Latin languages this crate
 /// curates rather than on one, and accepted rather than hidden.** An

--- a/apps/desktop/src-tauri/src/validate/content/language.rs
+++ b/apps/desktop/src-tauri/src/validate/content/language.rs
@@ -277,18 +277,44 @@ const MIN_DISTINCTIVE_TOKEN_CHARS: usize = 2;
 /// not by construction) the separation an earlier review measured on a
 /// different fixture set.
 ///
-/// **Residual risk, measured and accepted rather than hidden:** an
-/// adversarially INSTITUTION-DENSE English CERTIFICATIONS section — five
-/// DIFFERENT German institutions in one list, a shape rarer than the
-/// 3-institution case above — reaches evidence 8, ABOVE both the floor and
-/// the thinnest genuine positive (6). A pure count cannot separate "an
-/// unusually credentialed English document" from "a short genuine foreign
-/// paragraph" in every case, because evidence scales with how much text
-/// there is, not with whether that text is target-language prose or
-/// accumulated foreign proper nouns. Raising the floor to close this would
-/// silence the genuinely thin true positives it sits right next to (6);
-/// this module already treats a false negative as the worse failure three
-/// times over, so the floor stays at 5 and this gap is accepted rather than
+/// **Residual risk, measured across all four Latin languages this crate
+/// curates rather than on one, and accepted rather than hidden.** An
+/// EDUCATION section (a real `SectionKey`, so a false positive here is a
+/// Critical, not a Warning) listing nothing but the candidate's own foreign
+/// institution names, in an otherwise-English document, accumulates
+/// evidence purely from proper-noun connectors ("de", "en", "des", "und",
+/// "van"…). How fast is NOT the same number for every language — an earlier
+/// draft of this doc swept German only and called it the worst case; a
+/// fresh sweep of French, Italian, Dutch and German (same shape, real
+/// institution names, stacked one per line) shows German is in fact the
+/// BEST case:
+///
+/// | language | institutions stacked to cross (or not) | chars | evidence |
+/// |---|---|---|---|
+/// | French | 2 (INRIA, CNAM — their own official names) | 144 | 6 — fires |
+/// | Italian | 5 (Milano, Torino, Pisa, Bologna, Politecnico di Milano) | 187 | 5 — fires, exactly on the floor |
+/// | Dutch | 6 (Delft, UvA, Groningen, Tilburg, VU, Utrecht) | 237 | 4 — quiet |
+/// | German | 6 (LMU, TUM, HTW Berlin, HWR Berlin, FU Berlin, Saarland) | 278 | 3 — quiet |
+///
+/// French is the genuinely thin case: just TWO real institution names, at
+/// 144 characters (barely above [`MIN_CHARS_FOR_LANGUAGE_CHECK`]'s 120),
+/// TIES the thinnest genuine positive in the table above (6) — not "close
+/// to it", the same number. Italian needs five institutions to cross the
+/// floor at all, and lands exactly ON it (5), one unit BELOW that same
+/// genuine-positive value. Dutch and German, stacked to the same
+/// six-institution shape, do not cross the floor even once — their real
+/// institution names simply do not carry as many curated function words per
+/// name as French's or Italian's do. A pure count cannot separate "an
+/// unusually credentialed English document, listing its author's French or
+/// Italian alma maters" from "a short genuine French or Italian paragraph"
+/// for these two languages specifically, because evidence scales with how
+/// much foreign proper-noun text there is, not with whether that text is
+/// target-language prose. Raising the floor to close the French case would
+/// silence Italian's own thinnest genuine positive, which sits at the same
+/// value (5) — one language's residual risk is the next language's real
+/// bug; this module already treats a false negative as the worse failure
+/// three times over, so the floor stays at 5 and this gap — real for French
+/// and Italian, absent for Dutch and German — is accepted rather than
 /// closed by a shape rule that would just be the next one this crate
 /// discovers is wrong for some language.
 const MIN_DISTINCTIVE_HITS: usize = 5;

--- a/apps/desktop/src-tauri/src/validate/content/language.rs
+++ b/apps/desktop/src-tauri/src/validate/content/language.rs
@@ -11,6 +11,24 @@
 //! detectors disagree, the guard goes quiet. Consistent with this module's
 //! posture everywhere else (a check that cannot be made reliably goes quiet
 //! rather than guesses), but it is a real limit, not a future bug report.
+//!
+//! ## Mitigated limit: whatlang's confidence is a MARGIN, not a probability
+//!
+//! `is_language_mismatch` used to trust a confident [`detected_language`]
+//! read of the GENERATED text on its own. That read can be confidently
+//! WRONG: `whatlang`'s n-gram model needs closed-class function words (the
+//! articles, prepositions, pronouns, copulas any real sentence is full of) to
+//! tell languages apart, and an ordinary noun-phrase-heavy block — a skills
+//! line, a terse CV — starves it of them. Measured: a truthful ENGLISH
+//! noun-phrase block reads as French at `confidence() == 1.0`,
+//! `is_reliable() == true`. `is_language_mismatch` now also requires
+//! [`distinctive_language_evidence`] — real, collision-pruned function-word
+//! evidence of some OTHER curated language — before a confident Latin-script
+//! read becomes an accusation. See that function's doc for why it is a
+//! POSITIVE check, never an absence test, and why it is scoped to Latin
+//! scripts only.
+
+use std::collections::HashMap;
 
 use super::{
     issue, significant_chars, Analysis, ContentIssue, Section, SectionKind, Severity,
@@ -23,18 +41,228 @@ use crate::documents::keywords::detected_language;
 /// check goes quiet instead.
 pub(super) const MIN_CHARS_FOR_LANGUAGE_CHECK: usize = 120;
 
+/// Function words distinctive to ONE Latin-script curated language — the
+/// discriminator [`is_language_mismatch`] needs on top of whatlang's raw
+/// guess.
+///
+/// `whatlang`'s `confidence()` is a top-1-vs-top-2 MARGIN over n-gram
+/// statistics, not a correctness probability. A block of ordinary noun
+/// phrases ("Administration / Supervision / Coordination / Optimisation /
+/// Certification…") starves the n-gram model of the function words it needs
+/// to read a language from at all, and it lands on some OTHER language with
+/// MAXIMUM margin — `is_reliable() == true` and all (measured: a terse
+/// English noun-phrase block reads as confident French). No signal derived
+/// from how the OUTPUT relates to the SOURCE can rule this out — a genuine
+/// translation and a false misread of a truthful document read identically on
+/// that axis, because the two differ only in what the TARGET actually is. The
+/// fix has to be a better language-identity read for exactly the register
+/// whatlang is weak on: real prose is dense with closed-class function words
+/// (articles, prepositions, pronouns, copulas); a noun-phrase list is not.
+///
+/// **Deliberately SEPARATE from `documents::evidence::function_words` /
+/// `has_curated_function_words`.** That pair feeds the ATS keyword-density
+/// and skill-not-demonstrated checks, where the failure mode is a MISSING
+/// filler word (an unremoved German "Kenntnisse" reads as a fake keyword) —
+/// so every curated language there needs an exhaustive list, and an
+/// under-curated one is unsafe. Here the failure mode runs the OTHER way: an
+/// under-curated list just produces LESS evidence and this check goes quiet
+/// (safe); an OVER-eager one — a word claimed distinctive when another
+/// language uses it too — manufactures a false accusation (unsafe). So the
+/// bar here is "correct after pruning collisions", not "exhaustive", and the
+/// two lists must never be conflated or reused for each other's purpose —
+/// reusing this list for the ATS checks would under-cover them (they need
+/// every filler, not just the collision-pruned remainder), and reusing theirs
+/// here would double-count words this module never authored against a
+/// pruning invariant.
+///
+/// Collisions are real and common across these seven languages: "de" is a
+/// Dutch article and a French/Spanish/Portuguese preposition; "a"/"in" are
+/// English and Italian/Spanish; "la" is French, Spanish and Italian. Rather
+/// than hand-picking around each one, every list below is written honestly
+/// (the words a fluent speaker would actually list), and
+/// [`distinctive_pool`] pools all seven and drops anything that lands in more
+/// than one — so a genuine collision safely removes itself from evidence
+/// instead of being guessed at.
+const FUNCTION_WORDS_EN: &[&str] = &[
+    "the", "a", "an", "and", "or", "but", "if", "so", "as", "of", "in", "on", "at", "to", "by",
+    "for", "with", "from", "into", "onto", "about", "over", "under", "between", "through",
+    "during", "before", "after", "this", "that", "these", "those", "it", "he", "she", "him", "her",
+    "his", "they", "them", "their", "we", "us", "our", "you", "your", "i", "my", "is", "are",
+    "was", "were", "be", "been", "being", "have", "has", "had", "do", "does", "did", "will",
+    "would", "can", "could", "should", "must", "not", "no",
+];
+const FUNCTION_WORDS_DE: &[&str] = &[
+    "der", "die", "das", "den", "dem", "des", "ein", "eine", "einen", "einem", "einer", "eines",
+    "im", "am", "beim", "vom", "zum", "zur", "und", "oder", "aber", "doch", "denn", "weil", "dass",
+    "wenn", "als", "wie", "ob", "in", "an", "auf", "aus", "bei", "mit", "nach", "seit", "von",
+    "zu", "für", "durch", "gegen", "ohne", "um", "über", "unter", "zwischen", "hinter", "ich",
+    "du", "er", "sie", "es", "wir", "ihr", "mich", "dich", "sich", "uns", "euch", "mein", "dein",
+    "sein", "ihre", "unser", "euer", "ist", "sind", "war", "waren", "bin", "bist", "seid", "habe",
+    "hast", "hat", "haben", "hatte", "wird", "werden", "kann", "muss", "soll",
+];
+const FUNCTION_WORDS_FR: &[&str] = &[
+    "le", "la", "les", "un", "une", "des", "du", "au", "aux", "et", "ou", "mais", "donc", "car",
+    "ni", "que", "si", "quand", "de", "à", "en", "dans", "sur", "sous", "avec", "sans", "pour",
+    "par", "chez", "vers", "entre", "depuis", "pendant", "je", "tu", "il", "elle", "nous", "vous",
+    "ils", "elles", "me", "te", "se", "lui", "leur", "mon", "ton", "son", "notre", "votre", "est",
+    "sont", "était", "étaient", "suis", "es", "sommes", "êtes", "être", "été", "avoir", "ai", "as",
+    "avons", "avez", "ont", "avait",
+];
+const FUNCTION_WORDS_ES: &[&str] = &[
+    "el", "la", "los", "las", "un", "una", "unos", "unas", "y", "o", "pero", "porque", "que", "si",
+    "aunque", "ni", "de", "en", "a", "con", "por", "para", "sin", "sobre", "entre", "hasta",
+    "desde", "hacia", "yo", "tú", "él", "ella", "nosotros", "vosotros", "ellos", "ellas", "me",
+    "te", "se", "nos", "mi", "tu", "su", "nuestro", "vuestro", "es", "son", "era", "eran", "soy",
+    "eres", "somos", "estar", "está", "están", "ser", "fue", "fueron", "tiene", "tienen", "hay",
+];
+const FUNCTION_WORDS_IT: &[&str] = &[
+    "il", "lo", "la", "i", "gli", "le", "un", "uno", "una", "e", "o", "ma", "però", "che", "se",
+    "perché", "né", "di", "a", "da", "in", "con", "su", "per", "tra", "fra", "senza", "dentro",
+    "sotto", "sopra", "nei", "nella", "dello", "della", "io", "tu", "lui", "lei", "noi", "voi",
+    "loro", "mi", "ti", "si", "ci", "vi", "mio", "tuo", "suo", "nostro", "vostro", "è", "sono",
+    "era", "erano", "sei", "siamo", "siete", "essere", "stato", "avere", "ha", "hanno", "ho",
+    "hai",
+];
+const FUNCTION_WORDS_NL: &[&str] = &[
+    "de", "het", "een", "en", "of", "maar", "want", "dus", "omdat", "als", "dat", "terwijl", "in",
+    "op", "aan", "bij", "met", "naar", "van", "voor", "door", "over", "onder", "tussen", "zonder",
+    "na", "ik", "jij", "je", "hij", "zij", "wij", "jullie", "ze", "mij", "jou", "hem", "haar",
+    "ons", "mijn", "jouw", "zijn", "hun", "is", "zijn", "was", "waren", "ben", "bent", "heb",
+    "hebt", "heeft", "hebben", "had", "hadden", "wordt", "worden", "kan", "moet",
+];
+const FUNCTION_WORDS_PT: &[&str] = &[
+    "o", "a", "os", "as", "um", "uma", "uns", "umas", "e", "ou", "mas", "porque", "que", "se",
+    "embora", "nem", "de", "em", "a", "com", "por", "para", "sem", "sobre", "entre", "até",
+    "desde", "eu", "tu", "ele", "ela", "nós", "vós", "eles", "elas", "me", "te", "se", "nos",
+    "meu", "teu", "seu", "nosso", "vosso", "é", "são", "era", "eram", "sou", "és", "somos",
+    "estar", "está", "estão", "ser", "foi", "foram", "tem", "têm", "há",
+];
+
+/// The seven languages [`is_language_mismatch`]'s corroboration check
+/// curates — English plus the SAME six Snowball languages
+/// `documents::keywords::make_stemmer` stems for, not the full nineteen
+/// [`crate::documents::keywords::locale_tag_of`] recognises. This is the
+/// whole Latin-script ambiguity zone the module doc above describes; every
+/// other curated language reads a distinct SCRIPT, which whatlang already
+/// gets right at near-1.0 confidence regardless of function-word density
+/// (see [`is_latin_curated`]).
+const CURATED_FUNCTION_WORDS: &[(&str, &[&str])] = &[
+    ("en", FUNCTION_WORDS_EN),
+    ("de", FUNCTION_WORDS_DE),
+    ("fr", FUNCTION_WORDS_FR),
+    ("es", FUNCTION_WORDS_ES),
+    ("it", FUNCTION_WORDS_IT),
+    ("nl", FUNCTION_WORDS_NL),
+    ("pt", FUNCTION_WORDS_PT),
+];
+
+/// Below this many hits, a match is noise rather than evidence — a single
+/// surviving token could be an incidental loanword or a name. Two rather than
+/// one, and no higher: the tightest genuine case measured (see
+/// `every_curated_language_is_silent_for_itself_and_fires_for_every_other`'s
+/// Spanish fixture — after pruning, only "tiene" survives, three times over)
+/// clears two with a full unit of margin; three would leave that fixture
+/// exactly on the boundary.
+const MIN_DISTINCTIVE_HITS: usize = 2;
+
+/// Every token that appears in exactly one of [`CURATED_FUNCTION_WORDS`]'s
+/// seven lists, mapped to that one language — collisions (appearing in two or
+/// more) are dropped entirely rather than guessed at. Rebuilt on every call:
+/// ~300 short strings, and this runs at most a handful of times per
+/// `validate()` call (once for the document, once per prose section), not
+/// worth caching.
+fn distinctive_pool() -> HashMap<&'static str, &'static str> {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for (_, words) in CURATED_FUNCTION_WORDS {
+        for w in *words {
+            *seen.entry(w).or_default() += 1;
+        }
+    }
+    let mut pool = HashMap::new();
+    for (lang, words) in CURATED_FUNCTION_WORDS {
+        for w in *words {
+            if seen[w] == 1 {
+                pool.insert(*w, *lang);
+            }
+        }
+    }
+    pool
+}
+
+/// Whether `lang` is one of the seven languages whose confident-but-wrong
+/// reads need [`distinctive_language_evidence`]'s corroboration before they
+/// count as a mismatch — see [`CURATED_FUNCTION_WORDS`]'s doc. A non-Latin
+/// SCRIPT never needs it: `whatlang` reads script alone at near-1.0
+/// confidence regardless of function-word density (see
+/// `documents::keywords::test`'s twelve-language non-Latin sweep), so
+/// requiring evidence there would only make a genuine mismatch — a résumé
+/// section that drifted to Arabic, say — go quiet for no reason.
+fn is_latin_curated(lang: &str) -> bool {
+    CURATED_FUNCTION_WORDS.iter().any(|(l, _)| *l == lang)
+}
+
+/// Whether `text` carries [`MIN_DISTINCTIVE_HITS`] or more occurrences of
+/// function words distinctive to some ONE curated language other than
+/// `target` — POSITIVE evidence that the text really is written in a
+/// different language.
+///
+/// Never the other direction — this does not ask whether `target`'s own
+/// words are ABSENT. That would reopen the exact false Critical this exists
+/// to close by a different route: a terse but genuine target-language
+/// document (few function words, by construction) would fail an absence
+/// test the same way it confuses whatlang. Positive evidence only degrades
+/// safely: an under-curated or genuinely short text just produces less of
+/// it, and the guard stays quiet rather than guessing.
+///
+/// Answers only "is SOME other language evidenced", not "which one whatlang
+/// guessed" — `is_language_mismatch` does not require this to name the same
+/// language `detected_language` did; either language is real, unwanted
+/// evidence.
+fn distinctive_language_evidence(text: &str, target: &str) -> Option<&'static str> {
+    let pool = distinctive_pool();
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for word in text.split(|c: char| !c.is_alphabetic()) {
+        if word.is_empty() {
+            continue;
+        }
+        let lower = word.to_lowercase();
+        if let Some(&lang) = pool.get(lower.as_str()) {
+            if lang != target {
+                *counts.entry(lang).or_default() += 1;
+            }
+        }
+    }
+    counts
+        .into_iter()
+        .find(|(_, n)| *n >= MIN_DISTINCTIVE_HITS)
+        .map(|(lang, _)| lang)
+}
+
 /// Whether `text` is confidently written in something other than `lang`.
 ///
-/// Two independent reasons to go quiet, both already the module's stated
+/// Three independent reasons to go quiet, all already the module's stated
 /// posture: too SHORT to read a language from at all
-/// ([`MIN_CHARS_FOR_LANGUAGE_CHECK`]), or [`detected_language`] itself is not
-/// confident (below `documents::keywords::MIN_DETECTION_CONFIDENCE`) or
-/// reads a language this crate does not curate. Either way, `None` never
-/// counts as a mismatch — an unreliable read cannot manufacture an
+/// ([`MIN_CHARS_FOR_LANGUAGE_CHECK`]); [`detected_language`] itself is not
+/// confident (below `documents::keywords::MIN_DETECTION_CONFIDENCE`) or reads
+/// a language this crate does not curate; or — new — `whatlang` confidently
+/// names one of the seven Latin-script languages ([`is_latin_curated`])
+/// without [`distinctive_language_evidence`] backing it up. That third gate
+/// is what closes the confident-but-wrong noun-phrase misread the module doc
+/// above measures: a whatlang guess in the Latin ambiguity zone is corroborated
+/// by actual function-word evidence before it becomes an accusation, exactly
+/// the way `target_is_corroborated` already corroborates the TARGET side.
+/// Every other reason to go quiet is unchanged. `None`/`false` never counts as
+/// a mismatch — an unreliable or uncorroborated read cannot manufacture an
 /// accusation, it can only fail to make one.
 pub(super) fn is_language_mismatch(text: &str, lang: &str) -> bool {
-    significant_chars(text) >= MIN_CHARS_FOR_LANGUAGE_CHECK
-        && matches!(detected_language(text), Some(found) if found != lang)
+    if significant_chars(text) < MIN_CHARS_FOR_LANGUAGE_CHECK {
+        return false;
+    }
+    let Some(found) = detected_language(text) else {
+        return false;
+    };
+    found != lang
+        && (!is_latin_curated(found) || distinctive_language_evidence(text, lang).is_some())
 }
 
 /// Whether an independent witness — the job ad, or the candidate's own source
@@ -258,7 +486,14 @@ fn section_language_issues(ctx: &Analysis) -> Vec<ContentIssue> {
             if !looks_like_prose(&body) {
                 return None;
             }
-            if !matches!(detected_language(&body), Some(found) if found != ctx.lang) {
+            // Routed through the SAME `is_language_mismatch` the document pass
+            // uses (rather than a second, duplicated `detected_language`
+            // comparison) so the distinctive-function-word corroboration
+            // above applies here too — a section-scoped noun-phrase block
+            // (a terse "Certifications" heading `classify_section` files as
+            // `Other`, say) is exactly as vulnerable to whatlang's
+            // confident-but-wrong misread as the whole document is.
+            if !is_language_mismatch(&body, &ctx.lang) {
                 return None;
             }
             let mut found = issue(

--- a/apps/desktop/src-tauri/src/validate/content/language.rs
+++ b/apps/desktop/src-tauri/src/validate/content/language.rs
@@ -23,16 +23,26 @@
 //! noun-phrase block reads as French at `confidence() == 1.0`,
 //! `is_reliable() == true`. `is_language_mismatch` now also requires
 //! [`distinctive_evidence_confirms`] — real, PAIRWISE function-word evidence
-//! that the whatlang-named language is better supported in the text than the
-//! target itself is — before a confident Latin-script read becomes an
-//! accusation. See that function's doc for why the check is comparative
-//! (found vs. target in the SAME text) rather than a single global pool: a
-//! global pool was measured to leave Spanish/Portuguese too thin to evidence
-//! themselves (a true-positive regression), and neither a pairwise-only nor a
-//! higher-threshold-only fix survives a genuinely English document that
-//! merely NAMES a German institution or French award. See
-//! [`pairwise_evidence_count`] and [`distinctive_evidence_confirms`] for the
-//! measurements behind both halves.
+//! that the whatlang-named language is present in the text at all — before a
+//! confident Latin-script read becomes an accusation. See
+//! [`pairwise_evidence_count`] for why the check is pairwise (found vs.
+//! target only, not a single global pool pruned across all seven languages at
+//! once): a global pool was measured to leave Spanish/Portuguese too thin to
+//! evidence themselves — a true-positive regression, not a hypothetical one.
+//!
+//! Two OTHER suppressors were tried on top of the pairwise floor — a curated
+//! denylist for short tokens that double as English abbreviations
+//! (`ci`/`vi`/`io`/`ha`…), and a comparative margin requiring `found`'s
+//! evidence to EXCEED `target`'s own — and both were REMOVED after
+//! measurement found no realistic document that needed either: every
+//! behavioural test through `validate_content` passed with each one disabled,
+//! only its own manufactured unit test failed, and the denylist's one
+//! measured trigger (French idiom words stuffed together with no connecting
+//! English grammar) was adversarial, not a shape this validator's real input
+//! — generated or user-uploaded résumé/letter prose — ever produces. Removed
+//! rather than kept on the strength of the argument for them, per this
+//! module's own history: the original global pool was equally defensible on
+//! paper and silently killed the Spanish Critical anyway.
 
 use std::collections::HashSet;
 
@@ -157,39 +167,33 @@ pub(super) fn function_words_for(lang: &str) -> &'static [&'static str] {
 /// Below this many characters, a token is dropped outright — a bare
 /// single-letter survivor ("a", "i", "e", "o", "y" — real one-letter words in
 /// several of these languages) is too little to ever be evidence on its own
-/// and is noise in every language at once. Deliberately NOT the boundary that
-/// excludes `ci`/`vi`/`io`/`ha`/`da`/`ti` — see [`AMBIGUOUS_SHORT_TOKENS`] for
-/// why those are a CURATED denylist, not a length rule: a blanket floor of 3
-/// was tried first and measured to ALSO exclude Italian's own core vocabulary
-/// (`il`, `la`, `di`, all 2 characters), which is exactly how short a real
-/// Romance-language sentence's articles and prepositions are — a genuinely
-/// Italian AWARDS section (`a_drifted_awards_section_warns_rather_than_blocks`)
-/// dropped from 3+ distinctive hits to 1 under that rule and stopped firing.
+/// and is noise in every language at once. Deliberately not higher: a blanket
+/// floor of 3 was tried and measured to ALSO exclude Italian's own core
+/// vocabulary (`il`, `la`, `di`, all 2 characters), which is exactly how short
+/// a real Romance-language sentence's articles and prepositions are — a
+/// genuinely Italian AWARDS section
+/// (`a_drifted_awards_section_warns_rather_than_blocks`) dropped from 3+
+/// distinctive hits to 1 under that rule and stopped firing.
+///
+/// **A curated denylist for the residual short-token ambiguity
+/// (`ci`/`vi`/`io`/`ha`/`da`/`ti`/… — genuine short function words in one
+/// curated language that are ALSO common English abbreviations, editor names
+/// or TLD fragments: `ci/cd`, the `vi` editor, `.io`, an "HA cluster") was
+/// tried on top of this floor and REMOVED after measurement.** The
+/// found-SPECIFIC pairwise match already closes every one of those cases on
+/// its own — none of `ci`/`vi`/`io`/`ha`/`da`/`ti` is a word in French, and
+/// whatlang's guess on the tool-list fixture those tokens were measured
+/// against never changed to Italian — so the denylist's only demonstrated
+/// trigger was an adversarial string of disconnected French idioms
+/// ("au naturel au revoir au contraire …", no connecting English grammar at
+/// all) that does not resemble anything this validator's real input
+/// (generated or user-uploaded résumé/letter prose) produces; the same
+/// phrases used as genuine English loanwords in an ordinary sentence never
+/// reached the vulnerable state. Kept out rather than kept anyway: it would
+/// have permanently denied `el`/`zu`/`na`/`et`/`di`/`ci` — high-frequency
+/// function words of Spanish, German, Dutch, French and Italian — sitting one
+/// hit from the margin the Spanish/Portuguese fix above needed.
 const MIN_DISTINCTIVE_TOKEN_CHARS: usize = 2;
-
-/// Tokens excluded from evidence in EVERY language, by name rather than by
-/// length: each one is a genuine short function word in ONE curated language
-/// (`ha`/`di`/`ci`/`io`/`vi`/`da`/`ti` → Italian; `os`/`em` → Portuguese;
-/// `am`/`im`/`zu` → German; `el` → Spanish; `na` → Dutch; `ai`/`et`/`au` →
-/// French) that is ALSO a common English abbreviation, initial, editor name
-/// or URL/TLD fragment — `ci/cd`, the `vi` editor, `.io` domains, an "HA
-/// cluster", the letters "AM"/"IM". Matching free text (unlike a whole-line
-/// structural gate — `documents::evidence::entry`'s `DATE_ONLY_MARKERS`
-/// excludes Dutch `nu` for the identical reason) has no other way to exclude
-/// them, so they are named individually rather than caught by a length rule
-/// that would also catch every OTHER 2-character word in these languages —
-/// most of which (`il`, `la`, `de`, `un`, `le`) carry no comparable collision
-/// risk and are exactly the evidence [`MIN_DISTINCTIVE_TOKEN_CHARS`]'s doc
-/// explains a blanket floor cannot afford to lose. "per" (a genuine
-/// 3-character English preposition ALSO used by Italian) is the one
-/// short-token false positive measured with a length other than 2 — it is
-/// closed instead by curating "per" into [`FUNCTION_WORDS_EN`], so it
-/// collides out at the ordinary pairwise step rather than needing a name
-/// here.
-const AMBIGUOUS_SHORT_TOKENS: &[&str] = &[
-    "ha", "di", "ci", "io", "vi", "da", "ti", "os", "em", "am", "im", "zu", "el", "na", "ai", "et",
-    "au",
-];
 
 /// Below this many pairwise hits, a match is noise rather than evidence — a
 /// single surviving token could be an incidental collision or a name.
@@ -253,9 +257,7 @@ pub(super) fn pairwise_evidence_count(text: &str, lang: &str, other: &str) -> us
         .filter(|(_, w)| w.chars().count() >= MIN_DISTINCTIVE_TOKEN_CHARS)
         .filter(|(_, w)| {
             let lower = w.to_lowercase();
-            lang_words.contains(lower.as_str())
-                && !other_words.contains(lower.as_str())
-                && !AMBIGUOUS_SHORT_TOKENS.contains(&lower.as_str())
+            lang_words.contains(lower.as_str()) && !other_words.contains(lower.as_str())
         })
         .filter(|(i, _)| {
             let prev_titlecase = *i > 0 && is_title_case(tokens[i - 1]);
@@ -275,55 +277,33 @@ pub(super) fn needs_distinctive_evidence(lang: &str) -> bool {
 
 /// Whether `found` — the language `detected_language(text)` actually named —
 /// is corroborated well enough by `text` itself to accuse it of NOT being
-/// `target`.
+/// `target`: [`pairwise_evidence_count`] for `found` against `target` must
+/// clear [`MIN_DISTINCTIVE_HITS`]. Positive evidence only: this never asks
+/// whether `target`'s own words are ABSENT, which would reopen the original
+/// false Critical (a sparse-function-word document genuinely written in
+/// `target`) by a different route.
 ///
-/// Two bars, both required:
-///
-/// 1. **Absolute floor** — [`pairwise_evidence_count`] for `found` against
-///    `target` must clear [`MIN_DISTINCTIVE_HITS`]. Positive evidence only:
-///    this never asks whether `target`'s own words are ABSENT, which would
-///    reopen the original false Critical (a sparse-function-word document
-///    genuinely written in `target`) by a different route.
-/// 2. **Comparative margin** — `found`'s evidence must exceed `target`'s OWN
-///    pairwise evidence in the SAME text, not just clear the floor in
-///    isolation. Mechanically verified directly
-///    (`distinctive_evidence_confirms_requires_a_real_margin_not_a_tie` in the
-///    test module: a real 2-vs-2 tie does not confirm, a 3-vs-2 margin does).
-///    The reasoning it exists for: a single, bigger absolute floor cannot
-///    separate "an otherwise-English document that happens to name a foreign
-///    institution" (a few incidental hits) from "genuinely sparse
-///    Spanish/Portuguese text" (see [`pairwise_evidence_count`]'s doc) —
-///    raising the floor to survive the first deepens the second. A
-///    comparison against `target`'s OWN evidence in the SAME text separates
-///    them instead: in the proper-noun case `target`'s evidence is abundant;
-///    in the genuine-foreign-language case it is near zero, so even thin
-///    `found` evidence clears it. **Measured limit, reported rather than
-///    concealed:** the title-case-sandwich exclusion in
-///    [`pairwise_evidence_count`] independently silences every REALISTIC
-///    proper-noun fixture this module's test suite constructs (a terse
-///    "Degree, Institution, Dates" line, or a longer multi-sentence label), so
-///    this bar currently has no end-to-end regression that isolates it from
-///    that exclusion — a deliberately German-/French-institution-dense search
-///    for one either stayed confidently English overall (never reaching this
-///    branch) or produced enough real foreign-language evidence to be a
-///    defensible true positive, not a tie. Kept as a principled second layer
-///    (a bare floor is measurably weaker in the abstract) with direct,
-///    mechanical coverage rather than removed for lack of a natural trigger.
+/// **A second bar — requiring `found`'s evidence to EXCEED `target`'s own
+/// pairwise evidence in the same text, not just clear the floor — was tried
+/// and REMOVED after measurement.** It was built to separate "an otherwise-
+/// English document that merely names a foreign institution" from "genuinely
+/// sparse Spanish/Portuguese text", but that separation turned out to already
+/// be the title-case-sandwich exclusion's job (see
+/// [`pairwise_evidence_count`]'s doc): disabling the comparative bar alone
+/// left every `validate::content` behavioural test green, and left only its
+/// own manufactured unit test red. Removed rather than kept on the strength
+/// of the argument for it — the argument was real, the measurement said it
+/// carried no load.
 ///
 /// A non-Latin-script `found` (gated by [`needs_distinctive_evidence`]) skips
-/// both bars — whatlang's script read is already reliable there regardless of
-/// function-word density, and requiring evidence this crate has no
-/// vocabulary for would only turn a genuine mismatch quiet.
+/// this floor entirely — whatlang's script read is already reliable there
+/// regardless of function-word density, and requiring evidence this crate has
+/// no vocabulary for would only turn a genuine mismatch quiet.
 pub(super) fn distinctive_evidence_confirms(text: &str, found: &str, target: &str) -> bool {
     if !needs_distinctive_evidence(found) {
         return true;
     }
-    let found_evidence = pairwise_evidence_count(text, found, target);
-    if found_evidence < MIN_DISTINCTIVE_HITS {
-        return false;
-    }
-    let target_evidence = pairwise_evidence_count(text, target, found);
-    found_evidence > target_evidence
+    pairwise_evidence_count(text, found, target) >= MIN_DISTINCTIVE_HITS
 }
 
 /// Whether `text` is confidently written in something other than `lang`.
@@ -337,9 +317,9 @@ pub(super) fn distinctive_evidence_confirms(text: &str, found: &str, target: &st
 /// [`distinctive_evidence_confirms`] backing it up. That third gate is what
 /// closes the confident-but-wrong noun-phrase misread the module doc above
 /// measures: a whatlang guess in the Latin ambiguity zone is corroborated by
-/// actual, comparative function-word evidence before it becomes an
-/// accusation, exactly the way `target_is_corroborated` already corroborates
-/// the TARGET side. Every other reason to go quiet is unchanged. `None`/
+/// actual function-word evidence before it becomes an accusation, exactly the
+/// way `target_is_corroborated` already corroborates the TARGET side. Every
+/// other reason to go quiet is unchanged. `None`/
 /// `false` never counts as a mismatch — an unreliable or uncorroborated read
 /// cannot manufacture an accusation, it can only fail to make one.
 pub(super) fn is_language_mismatch(text: &str, lang: &str) -> bool {

--- a/apps/desktop/src-tauri/src/validate/content/language.rs
+++ b/apps/desktop/src-tauri/src/validate/content/language.rs
@@ -103,10 +103,10 @@ const FUNCTION_WORDS_NL: &[&str] = &[
 ];
 const FUNCTION_WORDS_PT: &[&str] = &[
     "o", "a", "os", "as", "um", "uma", "uns", "umas", "e", "ou", "mas", "porque", "que", "se",
-    "embora", "nem", "de", "em", "a", "com", "por", "para", "sem", "sobre", "entre", "até",
-    "desde", "eu", "tu", "ele", "ela", "nós", "vós", "eles", "elas", "me", "te", "se", "nos",
-    "meu", "teu", "seu", "nosso", "vosso", "é", "são", "era", "eram", "sou", "és", "somos",
-    "estar", "está", "estão", "ser", "foi", "foram", "tem", "têm", "há",
+    "embora", "nem", "de", "em", "com", "por", "para", "sem", "sobre", "entre", "até", "desde",
+    "eu", "tu", "ele", "ela", "nós", "vós", "eles", "elas", "me", "te", "nos", "meu", "teu", "seu",
+    "nosso", "vosso", "é", "são", "era", "eram", "sou", "és", "somos", "estar", "está", "estão",
+    "ser", "foi", "foram", "tem", "têm", "há",
 ];
 
 /// The seven languages [`function_words_for`] curates a real vocabulary for —

--- a/apps/desktop/src-tauri/src/validate/content/language.rs
+++ b/apps/desktop/src-tauri/src/validate/content/language.rs
@@ -43,6 +43,17 @@
 //! rather than kept on the strength of the argument for them, per this
 //! module's own history: the original global pool was equally defensible on
 //! paper and silently killed the Spanish Critical anyway.
+//!
+//! A THIRD suppressor — a title-case-sandwich exclusion in
+//! [`pairwise_evidence_count`], dropping a hit whose immediate neighbours
+//! were both capitalised — was tried, shipped, and then REMOVED after a
+//! pre-PR gate found it deleted German's evidence wholesale: standard German
+//! CV register is nominal ("Aufbau und Betrieb der Zahlungsplattform"), and
+//! German capitalises every noun, so in that register every connector sits
+//! between two capitalised nouns whether or not it is inside a proper noun.
+//! [`MIN_DISTINCTIVE_HITS`] is what replaced it — a threshold, not a shape
+//! rule, chosen from a corpus swept fresh for this removal; see its own doc
+//! for the full table and the residual risk it accepts instead of hiding.
 
 use std::collections::HashSet;
 
@@ -64,6 +75,20 @@ pub(super) const MIN_CHARS_FOR_LANGUAGE_CHECK: usize = 120;
 /// [`pairwise_evidence_count`]'s doc for why a single global pool — pruning a
 /// word the moment it appears in ANY two of the seven lists — was measured to
 /// leave Spanish and Portuguese too thin to evidence themselves at all).
+///
+/// **Not the same primitive as `documents::evidence`'s `FUNCTION_WORDS_DE` /
+/// `has_curated_function_words`, despite the identical const name (for
+/// German) and overlapping content — do not "unify" them.** That module asks
+/// a SKILL-CLAIM question (which tokens on a skills line are filler, not a
+/// claimed skill) and is deliberately curated for German only, since an
+/// under-curated list there is safe (a noisier display-only gap list) but an
+/// over-eager one is not. This module asks a language-IDENTITY question
+/// (does `text` carry positive evidence of some OTHER specific curated
+/// language) across all seven languages `documents::keywords::make_stemmer`
+/// stems for — a missing word here only makes the guard quieter, never
+/// louder, so exhaustiveness matters less than not accusing wrongly. Same
+/// shape of list, different correctness bar; merging them would let a change
+/// tuned for one silently regress the other.
 const FUNCTION_WORDS_EN: &[&str] = &[
     "the", "a", "an", "and", "or", "but", "if", "so", "as", "of", "in", "on", "at", "to", "by",
     "for", "with", "from", "into", "onto", "about", "over", "under", "between", "through",
@@ -156,6 +181,13 @@ const LATIN_SCRIPT_LANGUAGES: &[&str] = &["en", "de", "fr", "es", "it", "pt", "n
 /// not written one (every language outside [`CURATED_FUNCTION_WORDS`],
 /// including the two extra Latin-script tags [`LATIN_SCRIPT_LANGUAGES`]
 /// tracks for the corroboration GATE but not for evidence).
+///
+/// A DIFFERENT question from `documents::evidence::has_curated_function_words` —
+/// that one answers `false` for `"es"`/`"fr"`/`"it"`/`"nl"`/`"pt"` (no skill-
+/// filler list written for them) while this function returns 61/68/65/58/58
+/// real words for the same five tags; see [`FUNCTION_WORDS_EN`]'s doc for why
+/// the two primitives are deliberately separate rather than one the other
+/// could read from.
 pub(super) fn function_words_for(lang: &str) -> &'static [&'static str] {
     CURATED_FUNCTION_WORDS
         .iter()
@@ -197,7 +229,69 @@ const MIN_DISTINCTIVE_TOKEN_CHARS: usize = 2;
 
 /// Below this many pairwise hits, a match is noise rather than evidence — a
 /// single surviving token could be an incidental collision or a name.
-const MIN_DISTINCTIVE_HITS: usize = 2;
+///
+/// **This is the ONLY discriminator left; a shape-based heuristic (a
+/// title-case-sandwich exclusion) was tried here and REMOVED after it
+/// deleted German's evidence wholesale.** Standard German CV register is
+/// nominal ("Aufbau und Betrieb der Zahlungsplattform", not "Ich habe die
+/// Zahlungsplattform aufgebaut und betrieben"): German capitalises every
+/// noun, so in this register EVERY connector sits between two capitalised
+/// nouns by construction, not because it is inside a proper noun — the
+/// exclusion could not tell those apart and fired on nothing for a whole
+/// nominal-register German résumé. This module's own history is now three
+/// suppressors in a row, each a shape assumption that held for some
+/// languages and broke for one it had not been checked against (a globally
+/// pruned pool assumed collisions "remove themselves" — wrong for Spanish; a
+/// short-token denylist assumed length implies ambiguity — unfalsifiable; a
+/// title-case exclusion assumed a function word between capitals is inside a
+/// proper noun — wrong for German). A threshold makes no shape assumption,
+/// only a quantity one, so it is what remains.
+///
+/// **5, chosen from a corpus swept fresh for this change (not carried over
+/// from an earlier round's number), reported in full because the failure
+/// mode this crate has now hit three times is calibrating a threshold
+/// against the fixture that tests it:**
+///
+/// | class | fixture | evidence |
+/// |---|---|---|
+/// | quiet | English noun-phrase tool list (the original bug) | 0 |
+/// | quiet | same list + ci/cd, .io, vi, HA, or per (the short-token leaks) | 0 |
+/// | quiet | German institution name, terse "Degree, Institution, Dates" | 1 |
+/// | quiet | German institution name, EDUCATION section (2 entries) | 3 |
+/// | quiet | German institution names, CERTIFICATIONS (3 entries) | 4 |
+/// | fire | short genuine Spanish paragraph (2 sentences) | 6 |
+/// | fire | Italian VOLUNTEER section (PR #1003's own fixture) | 6 |
+/// | fire | Italian AWARDS section (PR #1003's own fixture) | 8 |
+/// | fire | short genuine nominal-register German bullet (1 line) | 9 |
+/// | fire | Portuguese EXPERIENCE, prose or bullets+date-column | 14 |
+/// | fire | French, Title-Case rendered | 15 |
+/// | fire | Spanish EXPERIENCE, prose or bullets+date-column | 16–18 |
+/// | fire | Dutch, Title-Case rendered | 16 |
+/// | fire | genuine third-language Italian output | 17 |
+/// | fire | Italian EXPERIENCE section (drifted-section fixture) | 19 |
+/// | fire | nominal-register German, whole résumé or one section | 20–24 |
+/// | fire | German verb-register résumé (the original reported bug) | 24 |
+///
+/// Quiet tops out at 4, fire starts at 6 — a floor of 5 separates this
+/// corpus with a full unit of margin on both sides, matching (independently,
+/// not by construction) the separation an earlier review measured on a
+/// different fixture set.
+///
+/// **Residual risk, measured and accepted rather than hidden:** an
+/// adversarially INSTITUTION-DENSE English CERTIFICATIONS section — five
+/// DIFFERENT German institutions in one list, a shape rarer than the
+/// 3-institution case above — reaches evidence 8, ABOVE both the floor and
+/// the thinnest genuine positive (6). A pure count cannot separate "an
+/// unusually credentialed English document" from "a short genuine foreign
+/// paragraph" in every case, because evidence scales with how much text
+/// there is, not with whether that text is target-language prose or
+/// accumulated foreign proper nouns. Raising the floor to close this would
+/// silence the genuinely thin true positives it sits right next to (6);
+/// this module already treats a false negative as the worse failure three
+/// times over, so the floor stays at 5 and this gap is accepted rather than
+/// closed by a shape rule that would just be the next one this crate
+/// discovers is wrong for some language.
+const MIN_DISTINCTIVE_HITS: usize = 5;
 
 /// How many times `text` uses a function word that belongs to `lang`'s
 /// curated vocabulary but NOT to `other`'s — PAIRWISE against the specific
@@ -221,48 +315,31 @@ const MIN_DISTINCTIVE_HITS: usize = 2;
 /// curated language `other` has never heard of is not ambiguous for this
 /// specific comparison and stays.
 ///
-/// **A hit sandwiched between two Title-Case neighbours is excluded** — a
-/// connector word ("der", "und", "für") glued between two capitalised words
-/// is almost always sitting INSIDE a proper noun (an institution's own
-/// official compound name — "Fachhochschule für Technik und Wirtschaft
-/// Berlin" genuinely contains "für" and "und"), not free-standing prose
-/// usage. Measured: an otherwise-English EDUCATION entry that spells out
-/// such a name — the realistic shape, matching this crate's own fixture
-/// convention of a terse "Degree, Institution, Dates" line — cleared the
-/// evidence floor without this exclusion; genuinely wrong-language PROSE
-/// (the Spanish/Portuguese regression fixtures, the existing wrong-language
-/// résumé fixtures) is unaffected, because a real sentence surrounds its
-/// function words with ordinary lowercase words, not two proper-noun
-/// neighbours in a row. Costs the SAME direction every other guard in this
-/// module costs: a genuinely wrong-language document whose every function
-/// word happens to fall between two capitalised neighbours would lose that
-/// evidence too — accepted, because the alternative (counting it) is the
-/// false accusation this whole mechanism exists to prevent, and a document
-/// that short and that proper-noun-dense was already a poor candidate for a
-/// confident read (see [`MIN_CHARS_FOR_LANGUAGE_CHECK`]).
+/// **A title-case-sandwich exclusion (dropping a hit whose immediate
+/// neighbours were BOTH capitalised, on the theory that it sits inside a
+/// proper noun) was tried here and REMOVED — it was a false generalisation
+/// from Latin languages to German.** Standard German CV register is nominal
+/// ("Aufbau und Betrieb der Zahlungsplattform", "Leitung der Migration der
+/// Dienste"): German capitalises every noun, so in this register EVERY
+/// connector sits between two capitalised nouns by construction, not
+/// because it is part of a proper noun. The exclusion deleted German's
+/// evidence wholesale — measured: a whole nominal-register German résumé
+/// against an English target dropped to 1 pairwise hit and stopped firing,
+/// with no second line of defence, because both the document and section
+/// passes route through this same function. See [`MIN_DISTINCTIVE_HITS`]'s
+/// doc for the threshold-only replacement and the corpus it was chosen
+/// from.
 pub(super) fn pairwise_evidence_count(text: &str, lang: &str, other: &str) -> usize {
     let lang_words: HashSet<&str> = function_words_for(lang).iter().copied().collect();
     if lang_words.is_empty() {
         return 0;
     }
     let other_words: HashSet<&str> = function_words_for(other).iter().copied().collect();
-    let tokens: Vec<&str> = text
-        .split(|c: char| !c.is_alphabetic())
-        .filter(|w| !w.is_empty())
-        .collect();
-    let is_title_case = |w: &str| w.chars().next().is_some_and(char::is_uppercase);
-    tokens
-        .iter()
-        .enumerate()
-        .filter(|(_, w)| w.chars().count() >= MIN_DISTINCTIVE_TOKEN_CHARS)
-        .filter(|(_, w)| {
+    text.split(|c: char| !c.is_alphabetic())
+        .filter(|w| w.chars().count() >= MIN_DISTINCTIVE_TOKEN_CHARS)
+        .filter(|w| {
             let lower = w.to_lowercase();
             lang_words.contains(lower.as_str()) && !other_words.contains(lower.as_str())
-        })
-        .filter(|(i, _)| {
-            let prev_titlecase = *i > 0 && is_title_case(tokens[i - 1]);
-            let next_titlecase = i + 1 < tokens.len() && is_title_case(tokens[i + 1]);
-            !(prev_titlecase && next_titlecase)
         })
         .count()
 }
@@ -287,13 +364,15 @@ pub(super) fn needs_distinctive_evidence(lang: &str) -> bool {
 /// pairwise evidence in the same text, not just clear the floor — was tried
 /// and REMOVED after measurement.** It was built to separate "an otherwise-
 /// English document that merely names a foreign institution" from "genuinely
-/// sparse Spanish/Portuguese text", but that separation turned out to already
-/// be the title-case-sandwich exclusion's job (see
-/// [`pairwise_evidence_count`]'s doc): disabling the comparative bar alone
-/// left every `validate::content` behavioural test green, and left only its
-/// own manufactured unit test red. Removed rather than kept on the strength
-/// of the argument for it — the argument was real, the measurement said it
-/// carried no load.
+/// sparse Spanish/Portuguese text", but at the time that separation turned
+/// out to already be a title-case-sandwich exclusion's job: disabling the
+/// comparative bar alone left every `validate::content` behavioural test
+/// green, and left only its own manufactured unit test red. Removed rather
+/// than kept on the strength of the argument for it — the argument was real,
+/// the measurement said it carried no load. (The title-case exclusion it
+/// deferred to was ITSELF removed one round later, for breaking German —
+/// see [`MIN_DISTINCTIVE_HITS`]'s doc; nothing has replaced either bar
+/// except the single floor below.)
 ///
 /// A non-Latin-script `found` (gated by [`needs_distinctive_evidence`]) skips
 /// this floor entirely — whatlang's script read is already reliable there

--- a/apps/desktop/src-tauri/src/validate/content/language.rs
+++ b/apps/desktop/src-tauri/src/validate/content/language.rs
@@ -22,13 +22,19 @@
 //! line, a terse CV — starves it of them. Measured: a truthful ENGLISH
 //! noun-phrase block reads as French at `confidence() == 1.0`,
 //! `is_reliable() == true`. `is_language_mismatch` now also requires
-//! [`distinctive_language_evidence`] — real, collision-pruned function-word
-//! evidence of some OTHER curated language — before a confident Latin-script
-//! read becomes an accusation. See that function's doc for why it is a
-//! POSITIVE check, never an absence test, and why it is scoped to Latin
-//! scripts only.
+//! [`distinctive_evidence_confirms`] — real, PAIRWISE function-word evidence
+//! that the whatlang-named language is better supported in the text than the
+//! target itself is — before a confident Latin-script read becomes an
+//! accusation. See that function's doc for why the check is comparative
+//! (found vs. target in the SAME text) rather than a single global pool: a
+//! global pool was measured to leave Spanish/Portuguese too thin to evidence
+//! themselves (a true-positive regression), and neither a pairwise-only nor a
+//! higher-threshold-only fix survives a genuinely English document that
+//! merely NAMES a German institution or French award. See
+//! [`pairwise_evidence_count`] and [`distinctive_evidence_confirms`] for the
+//! measurements behind both halves.
 
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use super::{
     issue, significant_chars, Analysis, ContentIssue, Section, SectionKind, Severity,
@@ -41,55 +47,20 @@ use crate::documents::keywords::detected_language;
 /// check goes quiet instead.
 pub(super) const MIN_CHARS_FOR_LANGUAGE_CHECK: usize = 120;
 
-/// Function words distinctive to ONE Latin-script curated language — the
-/// discriminator [`is_language_mismatch`] needs on top of whatlang's raw
-/// guess.
-///
-/// `whatlang`'s `confidence()` is a top-1-vs-top-2 MARGIN over n-gram
-/// statistics, not a correctness probability. A block of ordinary noun
-/// phrases ("Administration / Supervision / Coordination / Optimisation /
-/// Certification…") starves the n-gram model of the function words it needs
-/// to read a language from at all, and it lands on some OTHER language with
-/// MAXIMUM margin — `is_reliable() == true` and all (measured: a terse
-/// English noun-phrase block reads as confident French). No signal derived
-/// from how the OUTPUT relates to the SOURCE can rule this out — a genuine
-/// translation and a false misread of a truthful document read identically on
-/// that axis, because the two differ only in what the TARGET actually is. The
-/// fix has to be a better language-identity read for exactly the register
-/// whatlang is weak on: real prose is dense with closed-class function words
-/// (articles, prepositions, pronouns, copulas); a noun-phrase list is not.
-///
-/// **Deliberately SEPARATE from `documents::evidence::function_words` /
-/// `has_curated_function_words`.** That pair feeds the ATS keyword-density
-/// and skill-not-demonstrated checks, where the failure mode is a MISSING
-/// filler word (an unremoved German "Kenntnisse" reads as a fake keyword) —
-/// so every curated language there needs an exhaustive list, and an
-/// under-curated one is unsafe. Here the failure mode runs the OTHER way: an
-/// under-curated list just produces LESS evidence and this check goes quiet
-/// (safe); an OVER-eager one — a word claimed distinctive when another
-/// language uses it too — manufactures a false accusation (unsafe). So the
-/// bar here is "correct after pruning collisions", not "exhaustive", and the
-/// two lists must never be conflated or reused for each other's purpose —
-/// reusing this list for the ATS checks would under-cover them (they need
-/// every filler, not just the collision-pruned remainder), and reusing theirs
-/// here would double-count words this module never authored against a
-/// pruning invariant.
-///
-/// Collisions are real and common across these seven languages: "de" is a
-/// Dutch article and a French/Spanish/Portuguese preposition; "a"/"in" are
-/// English and Italian/Spanish; "la" is French, Spanish and Italian. Rather
-/// than hand-picking around each one, every list below is written honestly
-/// (the words a fluent speaker would actually list), and
-/// [`distinctive_pool`] pools all seven and drops anything that lands in more
-/// than one — so a genuine collision safely removes itself from evidence
-/// instead of being guessed at.
+/// Function words per Latin-script curated language — the raw vocabulary
+/// [`pairwise_evidence_count`] draws on. Kept honest per language (the words
+/// a fluent speaker would actually list) rather than hand-pruned for
+/// collisions; pruning is a PAIRWISE, per-comparison decision now (see
+/// [`pairwise_evidence_count`]'s doc for why a single global pool — pruning a
+/// word the moment it appears in ANY two of the seven lists — was measured to
+/// leave Spanish and Portuguese too thin to evidence themselves at all).
 const FUNCTION_WORDS_EN: &[&str] = &[
     "the", "a", "an", "and", "or", "but", "if", "so", "as", "of", "in", "on", "at", "to", "by",
     "for", "with", "from", "into", "onto", "about", "over", "under", "between", "through",
     "during", "before", "after", "this", "that", "these", "those", "it", "he", "she", "him", "her",
     "his", "they", "them", "their", "we", "us", "our", "you", "your", "i", "my", "is", "are",
     "was", "were", "be", "been", "being", "have", "has", "had", "do", "does", "did", "will",
-    "would", "can", "could", "should", "must", "not", "no",
+    "would", "can", "could", "should", "must", "not", "no", "per",
 ];
 const FUNCTION_WORDS_DE: &[&str] = &[
     "der", "die", "das", "den", "dem", "des", "ein", "eine", "einen", "einem", "einer", "eines",
@@ -127,8 +98,8 @@ const FUNCTION_WORDS_NL: &[&str] = &[
     "de", "het", "een", "en", "of", "maar", "want", "dus", "omdat", "als", "dat", "terwijl", "in",
     "op", "aan", "bij", "met", "naar", "van", "voor", "door", "over", "onder", "tussen", "zonder",
     "na", "ik", "jij", "je", "hij", "zij", "wij", "jullie", "ze", "mij", "jou", "hem", "haar",
-    "ons", "mijn", "jouw", "zijn", "hun", "is", "zijn", "was", "waren", "ben", "bent", "heb",
-    "hebt", "heeft", "hebben", "had", "hadden", "wordt", "worden", "kan", "moet",
+    "ons", "mijn", "jouw", "zijn", "hun", "is", "was", "waren", "ben", "bent", "heb", "hebt",
+    "heeft", "hebben", "had", "hadden", "wordt", "worden", "kan", "moet",
 ];
 const FUNCTION_WORDS_PT: &[&str] = &[
     "o", "a", "os", "as", "um", "uma", "uns", "umas", "e", "ou", "mas", "porque", "que", "se",
@@ -138,14 +109,10 @@ const FUNCTION_WORDS_PT: &[&str] = &[
     "estar", "está", "estão", "ser", "foi", "foram", "tem", "têm", "há",
 ];
 
-/// The seven languages [`is_language_mismatch`]'s corroboration check
-/// curates — English plus the SAME six Snowball languages
-/// `documents::keywords::make_stemmer` stems for, not the full nineteen
-/// [`crate::documents::keywords::locale_tag_of`] recognises. This is the
-/// whole Latin-script ambiguity zone the module doc above describes; every
-/// other curated language reads a distinct SCRIPT, which whatlang already
-/// gets right at near-1.0 confidence regardless of function-word density
-/// (see [`is_latin_curated`]).
+/// The seven languages [`function_words_for`] curates a real vocabulary for —
+/// English plus the SAME six Snowball languages `documents::keywords::make_stemmer`
+/// stems for, not the full nineteen [`crate::documents::keywords::locale_tag_of`]
+/// recognises.
 const CURATED_FUNCTION_WORDS: &[(&str, &[&str])] = &[
     ("en", FUNCTION_WORDS_EN),
     ("de", FUNCTION_WORDS_DE),
@@ -156,86 +123,207 @@ const CURATED_FUNCTION_WORDS: &[(&str, &[&str])] = &[
     ("pt", FUNCTION_WORDS_PT),
 ];
 
-/// Below this many hits, a match is noise rather than evidence — a single
-/// surviving token could be an incidental loanword or a name. Two rather than
-/// one, and no higher: the tightest genuine case measured (see
-/// `every_curated_language_is_silent_for_itself_and_fires_for_every_other`'s
-/// Spanish fixture — after pruning, only "tiene" survives, three times over)
-/// clears two with a full unit of margin; three would leave that fixture
-/// exactly on the boundary.
+/// The Latin-script languages `documents::keywords::locale_tag_of` recognises
+/// — nine of its nineteen tags, not just the seven [`CURATED_FUNCTION_WORDS`]
+/// has a real vocabulary for. Turkish (`tr`) and Vietnamese (`vi`) are Latin
+/// script too and share the SAME whatlang blind spot (a confident wrong read
+/// on function-word-sparse text) as the curated seven; every other tag reads
+/// a genuinely distinct SCRIPT, which whatlang already tells apart from Latin
+/// at near-1.0 confidence regardless of function-word density.
+///
+/// This is [`needs_distinctive_evidence`]'s gate, and it must be the SCRIPT
+/// boundary, not [`CURATED_FUNCTION_WORDS`] membership: gating on curation
+/// instead of script let a confident `tr`/`vi` whatlang guess skip
+/// corroboration entirely and raise a Critical with zero evidence — the
+/// opposite of what "uncurated" is supposed to mean everywhere else in this
+/// crate. [`function_words_for`] still returns `&[]` for `tr`/`vi` (nobody
+/// has written those lists), so a genuine `tr`/`vi` mismatch now goes quiet
+/// instead — an accepted miss, same shape as every other uncurated-language
+/// miss this module already documents, not a new kind of gap.
+const LATIN_SCRIPT_LANGUAGES: &[&str] = &["en", "de", "fr", "es", "it", "pt", "nl", "tr", "vi"];
+
+/// `lang`'s curated function-word vocabulary, or `&[]` when this crate has
+/// not written one (every language outside [`CURATED_FUNCTION_WORDS`],
+/// including the two extra Latin-script tags [`LATIN_SCRIPT_LANGUAGES`]
+/// tracks for the corroboration GATE but not for evidence).
+pub(super) fn function_words_for(lang: &str) -> &'static [&'static str] {
+    CURATED_FUNCTION_WORDS
+        .iter()
+        .find(|(l, _)| *l == lang)
+        .map(|(_, words)| *words)
+        .unwrap_or(&[])
+}
+
+/// Below this many characters, a token is dropped outright — a bare
+/// single-letter survivor ("a", "i", "e", "o", "y" — real one-letter words in
+/// several of these languages) is too little to ever be evidence on its own
+/// and is noise in every language at once. Deliberately NOT the boundary that
+/// excludes `ci`/`vi`/`io`/`ha`/`da`/`ti` — see [`AMBIGUOUS_SHORT_TOKENS`] for
+/// why those are a CURATED denylist, not a length rule: a blanket floor of 3
+/// was tried first and measured to ALSO exclude Italian's own core vocabulary
+/// (`il`, `la`, `di`, all 2 characters), which is exactly how short a real
+/// Romance-language sentence's articles and prepositions are — a genuinely
+/// Italian AWARDS section (`a_drifted_awards_section_warns_rather_than_blocks`)
+/// dropped from 3+ distinctive hits to 1 under that rule and stopped firing.
+const MIN_DISTINCTIVE_TOKEN_CHARS: usize = 2;
+
+/// Tokens excluded from evidence in EVERY language, by name rather than by
+/// length: each one is a genuine short function word in ONE curated language
+/// (`ha`/`di`/`ci`/`io`/`vi`/`da`/`ti` → Italian; `os`/`em` → Portuguese;
+/// `am`/`im`/`zu` → German; `el` → Spanish; `na` → Dutch; `ai`/`et`/`au` →
+/// French) that is ALSO a common English abbreviation, initial, editor name
+/// or URL/TLD fragment — `ci/cd`, the `vi` editor, `.io` domains, an "HA
+/// cluster", the letters "AM"/"IM". Matching free text (unlike a whole-line
+/// structural gate — `documents::evidence::entry`'s `DATE_ONLY_MARKERS`
+/// excludes Dutch `nu` for the identical reason) has no other way to exclude
+/// them, so they are named individually rather than caught by a length rule
+/// that would also catch every OTHER 2-character word in these languages —
+/// most of which (`il`, `la`, `de`, `un`, `le`) carry no comparable collision
+/// risk and are exactly the evidence [`MIN_DISTINCTIVE_TOKEN_CHARS`]'s doc
+/// explains a blanket floor cannot afford to lose. "per" (a genuine
+/// 3-character English preposition ALSO used by Italian) is the one
+/// short-token false positive measured with a length other than 2 — it is
+/// closed instead by curating "per" into [`FUNCTION_WORDS_EN`], so it
+/// collides out at the ordinary pairwise step rather than needing a name
+/// here.
+const AMBIGUOUS_SHORT_TOKENS: &[&str] = &[
+    "ha", "di", "ci", "io", "vi", "da", "ti", "os", "em", "am", "im", "zu", "el", "na", "ai", "et",
+    "au",
+];
+
+/// Below this many pairwise hits, a match is noise rather than evidence — a
+/// single surviving token could be an incidental collision or a name.
 const MIN_DISTINCTIVE_HITS: usize = 2;
 
-/// Every token that appears in exactly one of [`CURATED_FUNCTION_WORDS`]'s
-/// seven lists, mapped to that one language — collisions (appearing in two or
-/// more) are dropped entirely rather than guessed at. Rebuilt on every call:
-/// ~300 short strings, and this runs at most a handful of times per
-/// `validate()` call (once for the document, once per prose section), not
-/// worth caching.
-fn distinctive_pool() -> HashMap<&'static str, &'static str> {
-    let mut seen: HashMap<&str, usize> = HashMap::new();
-    for (_, words) in CURATED_FUNCTION_WORDS {
-        for w in *words {
-            *seen.entry(w).or_default() += 1;
-        }
+/// How many times `text` uses a function word that belongs to `lang`'s
+/// curated vocabulary but NOT to `other`'s — PAIRWISE against the specific
+/// language being compared, not a single pool pruned across all seven at
+/// once.
+///
+/// **Why pairwise, not a global pool (measured regression, not a hypothetical
+/// one).** A prior version of this function pooled all seven languages'
+/// vocabulary together and dropped any word appearing in two or more lists
+/// before counting anything. Spanish and Portuguese are close enough to
+/// French/Italian/Dutch that this pruned them down to 30 and 33 survivors
+/// respectively — missing `de`, `la`, `un`, `en`, `a`, `con`, `por`, `para`,
+/// `que`, `se`, the highest-frequency words in the language — and genuinely
+/// Spanish/Portuguese text against a non-Spanish/Portuguese target regressed
+/// to under-count or zero evidence, silently un-firing a real mismatch (see
+/// `spanish_and_portuguese_regression` in the test module for the measured
+/// numbers in both a flowing-prose and a bullets-plus-date-column register).
+/// Pairwise pruning only removes a word from `lang`'s evidence when `other`
+/// —the language ACTUALLY being compared against, i.e. normally the
+/// document's real target — shares it; a word `lang` shares with some THIRD
+/// curated language `other` has never heard of is not ambiguous for this
+/// specific comparison and stays.
+///
+/// **A hit sandwiched between two Title-Case neighbours is excluded** — a
+/// connector word ("der", "und", "für") glued between two capitalised words
+/// is almost always sitting INSIDE a proper noun (an institution's own
+/// official compound name — "Fachhochschule für Technik und Wirtschaft
+/// Berlin" genuinely contains "für" and "und"), not free-standing prose
+/// usage. Measured: an otherwise-English EDUCATION entry that spells out
+/// such a name — the realistic shape, matching this crate's own fixture
+/// convention of a terse "Degree, Institution, Dates" line — cleared the
+/// evidence floor without this exclusion; genuinely wrong-language PROSE
+/// (the Spanish/Portuguese regression fixtures, the existing wrong-language
+/// résumé fixtures) is unaffected, because a real sentence surrounds its
+/// function words with ordinary lowercase words, not two proper-noun
+/// neighbours in a row. Costs the SAME direction every other guard in this
+/// module costs: a genuinely wrong-language document whose every function
+/// word happens to fall between two capitalised neighbours would lose that
+/// evidence too — accepted, because the alternative (counting it) is the
+/// false accusation this whole mechanism exists to prevent, and a document
+/// that short and that proper-noun-dense was already a poor candidate for a
+/// confident read (see [`MIN_CHARS_FOR_LANGUAGE_CHECK`]).
+pub(super) fn pairwise_evidence_count(text: &str, lang: &str, other: &str) -> usize {
+    let lang_words: HashSet<&str> = function_words_for(lang).iter().copied().collect();
+    if lang_words.is_empty() {
+        return 0;
     }
-    let mut pool = HashMap::new();
-    for (lang, words) in CURATED_FUNCTION_WORDS {
-        for w in *words {
-            if seen[w] == 1 {
-                pool.insert(*w, *lang);
-            }
-        }
-    }
-    pool
+    let other_words: HashSet<&str> = function_words_for(other).iter().copied().collect();
+    let tokens: Vec<&str> = text
+        .split(|c: char| !c.is_alphabetic())
+        .filter(|w| !w.is_empty())
+        .collect();
+    let is_title_case = |w: &str| w.chars().next().is_some_and(char::is_uppercase);
+    tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, w)| w.chars().count() >= MIN_DISTINCTIVE_TOKEN_CHARS)
+        .filter(|(_, w)| {
+            let lower = w.to_lowercase();
+            lang_words.contains(lower.as_str())
+                && !other_words.contains(lower.as_str())
+                && !AMBIGUOUS_SHORT_TOKENS.contains(&lower.as_str())
+        })
+        .filter(|(i, _)| {
+            let prev_titlecase = *i > 0 && is_title_case(tokens[i - 1]);
+            let next_titlecase = i + 1 < tokens.len() && is_title_case(tokens[i + 1]);
+            !(prev_titlecase && next_titlecase)
+        })
+        .count()
 }
 
-/// Whether `lang` is one of the seven languages whose confident-but-wrong
-/// reads need [`distinctive_language_evidence`]'s corroboration before they
-/// count as a mismatch — see [`CURATED_FUNCTION_WORDS`]'s doc. A non-Latin
-/// SCRIPT never needs it: `whatlang` reads script alone at near-1.0
-/// confidence regardless of function-word density (see
-/// `documents::keywords::test`'s twelve-language non-Latin sweep), so
-/// requiring evidence there would only make a genuine mismatch — a résumé
-/// section that drifted to Arabic, say — go quiet for no reason.
-fn is_latin_curated(lang: &str) -> bool {
-    CURATED_FUNCTION_WORDS.iter().any(|(l, _)| *l == lang)
+/// Whether `lang` is one of the nine languages whose confident whatlang read
+/// needs [`distinctive_evidence_confirms`]'s corroboration before it counts
+/// as a mismatch — see [`LATIN_SCRIPT_LANGUAGES`]'s doc for why this is a
+/// SCRIPT gate, not a curation gate.
+pub(super) fn needs_distinctive_evidence(lang: &str) -> bool {
+    LATIN_SCRIPT_LANGUAGES.contains(&lang)
 }
 
-/// Whether `text` carries [`MIN_DISTINCTIVE_HITS`] or more occurrences of
-/// function words distinctive to some ONE curated language other than
-/// `target` — POSITIVE evidence that the text really is written in a
-/// different language.
+/// Whether `found` — the language `detected_language(text)` actually named —
+/// is corroborated well enough by `text` itself to accuse it of NOT being
+/// `target`.
 ///
-/// Never the other direction — this does not ask whether `target`'s own
-/// words are ABSENT. That would reopen the exact false Critical this exists
-/// to close by a different route: a terse but genuine target-language
-/// document (few function words, by construction) would fail an absence
-/// test the same way it confuses whatlang. Positive evidence only degrades
-/// safely: an under-curated or genuinely short text just produces less of
-/// it, and the guard stays quiet rather than guessing.
+/// Two bars, both required:
 ///
-/// Answers only "is SOME other language evidenced", not "which one whatlang
-/// guessed" — `is_language_mismatch` does not require this to name the same
-/// language `detected_language` did; either language is real, unwanted
-/// evidence.
-fn distinctive_language_evidence(text: &str, target: &str) -> Option<&'static str> {
-    let pool = distinctive_pool();
-    let mut counts: HashMap<&str, usize> = HashMap::new();
-    for word in text.split(|c: char| !c.is_alphabetic()) {
-        if word.is_empty() {
-            continue;
-        }
-        let lower = word.to_lowercase();
-        if let Some(&lang) = pool.get(lower.as_str()) {
-            if lang != target {
-                *counts.entry(lang).or_default() += 1;
-            }
-        }
+/// 1. **Absolute floor** — [`pairwise_evidence_count`] for `found` against
+///    `target` must clear [`MIN_DISTINCTIVE_HITS`]. Positive evidence only:
+///    this never asks whether `target`'s own words are ABSENT, which would
+///    reopen the original false Critical (a sparse-function-word document
+///    genuinely written in `target`) by a different route.
+/// 2. **Comparative margin** — `found`'s evidence must exceed `target`'s OWN
+///    pairwise evidence in the SAME text, not just clear the floor in
+///    isolation. Mechanically verified directly
+///    (`distinctive_evidence_confirms_requires_a_real_margin_not_a_tie` in the
+///    test module: a real 2-vs-2 tie does not confirm, a 3-vs-2 margin does).
+///    The reasoning it exists for: a single, bigger absolute floor cannot
+///    separate "an otherwise-English document that happens to name a foreign
+///    institution" (a few incidental hits) from "genuinely sparse
+///    Spanish/Portuguese text" (see [`pairwise_evidence_count`]'s doc) —
+///    raising the floor to survive the first deepens the second. A
+///    comparison against `target`'s OWN evidence in the SAME text separates
+///    them instead: in the proper-noun case `target`'s evidence is abundant;
+///    in the genuine-foreign-language case it is near zero, so even thin
+///    `found` evidence clears it. **Measured limit, reported rather than
+///    concealed:** the title-case-sandwich exclusion in
+///    [`pairwise_evidence_count`] independently silences every REALISTIC
+///    proper-noun fixture this module's test suite constructs (a terse
+///    "Degree, Institution, Dates" line, or a longer multi-sentence label), so
+///    this bar currently has no end-to-end regression that isolates it from
+///    that exclusion — a deliberately German-/French-institution-dense search
+///    for one either stayed confidently English overall (never reaching this
+///    branch) or produced enough real foreign-language evidence to be a
+///    defensible true positive, not a tie. Kept as a principled second layer
+///    (a bare floor is measurably weaker in the abstract) with direct,
+///    mechanical coverage rather than removed for lack of a natural trigger.
+///
+/// A non-Latin-script `found` (gated by [`needs_distinctive_evidence`]) skips
+/// both bars — whatlang's script read is already reliable there regardless of
+/// function-word density, and requiring evidence this crate has no
+/// vocabulary for would only turn a genuine mismatch quiet.
+pub(super) fn distinctive_evidence_confirms(text: &str, found: &str, target: &str) -> bool {
+    if !needs_distinctive_evidence(found) {
+        return true;
     }
-    counts
-        .into_iter()
-        .find(|(_, n)| *n >= MIN_DISTINCTIVE_HITS)
-        .map(|(lang, _)| lang)
+    let found_evidence = pairwise_evidence_count(text, found, target);
+    if found_evidence < MIN_DISTINCTIVE_HITS {
+        return false;
+    }
+    let target_evidence = pairwise_evidence_count(text, target, found);
+    found_evidence > target_evidence
 }
 
 /// Whether `text` is confidently written in something other than `lang`.
@@ -244,16 +332,16 @@ fn distinctive_language_evidence(text: &str, target: &str) -> Option<&'static st
 /// posture: too SHORT to read a language from at all
 /// ([`MIN_CHARS_FOR_LANGUAGE_CHECK`]); [`detected_language`] itself is not
 /// confident (below `documents::keywords::MIN_DETECTION_CONFIDENCE`) or reads
-/// a language this crate does not curate; or — new — `whatlang` confidently
-/// names one of the seven Latin-script languages ([`is_latin_curated`])
-/// without [`distinctive_language_evidence`] backing it up. That third gate
-/// is what closes the confident-but-wrong noun-phrase misread the module doc
-/// above measures: a whatlang guess in the Latin ambiguity zone is corroborated
-/// by actual function-word evidence before it becomes an accusation, exactly
-/// the way `target_is_corroborated` already corroborates the TARGET side.
-/// Every other reason to go quiet is unchanged. `None`/`false` never counts as
-/// a mismatch — an unreliable or uncorroborated read cannot manufacture an
-/// accusation, it can only fail to make one.
+/// a language this crate does not curate; or `whatlang` confidently names a
+/// Latin-script language ([`needs_distinctive_evidence`]) without
+/// [`distinctive_evidence_confirms`] backing it up. That third gate is what
+/// closes the confident-but-wrong noun-phrase misread the module doc above
+/// measures: a whatlang guess in the Latin ambiguity zone is corroborated by
+/// actual, comparative function-word evidence before it becomes an
+/// accusation, exactly the way `target_is_corroborated` already corroborates
+/// the TARGET side. Every other reason to go quiet is unchanged. `None`/
+/// `false` never counts as a mismatch — an unreliable or uncorroborated read
+/// cannot manufacture an accusation, it can only fail to make one.
 pub(super) fn is_language_mismatch(text: &str, lang: &str) -> bool {
     if significant_chars(text) < MIN_CHARS_FOR_LANGUAGE_CHECK {
         return false;
@@ -261,8 +349,7 @@ pub(super) fn is_language_mismatch(text: &str, lang: &str) -> bool {
     let Some(found) = detected_language(text) else {
         return false;
     };
-    found != lang
-        && (!is_latin_curated(found) || distinctive_language_evidence(text, lang).is_some())
+    found != lang && distinctive_evidence_confirms(text, found, lang)
 }
 
 /// Whether an independent witness — the job ad, or the candidate's own source

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1747,6 +1747,18 @@ fn per_language_samples() -> Vec<(&'static str, String)> {
 /// target, and its text must fire against every OTHER language's target — the
 /// exact per-language sweep this fix's owner asked for explicitly.
 ///
+/// Turkish and Vietnamese are excluded from the "fires against every other
+/// target" half (not from the "silent for itself" half, which holds trivially
+/// for them too): they are Latin-script and so now correctly NEED
+/// corroboration (`needs_distinctive_evidence`), but this crate curates no
+/// `tr`/`vi` function-word vocabulary, so — same as every other
+/// uncurated-language miss this module documents — a genuine `tr`/`vi`
+/// mismatch goes quiet rather than firing on zero evidence. See
+/// `turkish_text_needs_evidence_too_and_goes_quiet_without_a_curated_list` for
+/// the fix this replaces (gating the requirement on script rather than on
+/// curated-vocabulary membership, which used to let tr/vi skip corroboration
+/// entirely and fire on nothing).
+///
 /// Mutation check: hardcode `is_language_mismatch` to always return `false`
 /// and every `_fires` assertion in this test goes red; hardcode it to always
 /// return `true` and every `_stays_silent` assertion goes red — the table
@@ -1762,7 +1774,7 @@ fn every_curated_language_is_silent_for_itself_and_fires_for_every_other() {
     }
     for (lang, _) in &samples {
         for (other_lang, other_text) in &samples {
-            if lang == other_lang {
+            if lang == other_lang || other_lang == &"tr" || other_lang == &"vi" {
                 continue;
             }
             assert!(
@@ -1806,6 +1818,53 @@ fn either_witness_alone_is_enough_to_corroborate_the_target() {
 }
 
 // ── Latin-script noun-phrase false positive (whatlang's confidence-margin blind spot) ──
+//
+// This evidence mechanism was substantially REDESIGNED after an independent
+// review measured three real defects in the first pass:
+//
+// 1. A single function-word pool pruned across all seven curated languages
+//    dropped any word appearing in two or more lists — which left Spanish
+//    (30 survivors) and Portuguese (33) too thin to evidence THEMSELVES, so a
+//    genuinely Spanish/Portuguese document against a non-Spanish/Portuguese
+//    target silently stopped raising a real Critical (a true-positive
+//    regression). Fixed by making evidence PAIRWISE (`pairwise_evidence_count`):
+//    a word is only pruned when the language it is being compared AGAINST
+//    shares it, not when some unrelated third language does.
+// 2. `ci`, `vi`, `io`, `ha`, `da`, `ti`, `os`, `em`, `am`, `im`, `zu`, `el`,
+//    `na`, `ai`, `et`, `au` are genuine short function words in one curated
+//    language AND common abbreviations/TLD fragments/editor names in free
+//    text (`ci/cd`, the `vi` editor, `.io`, an HA cluster). A blanket
+//    length-≥3 floor was tried FIRST and measured to also exclude Italian's
+//    OWN core vocabulary (`il`, `la`, `di`, all 2 characters — see
+//    `a_drifted_awards_section_warns_rather_than_blocks`, which briefly
+//    regressed under that rule), so the fix is a named denylist
+//    (`AMBIGUOUS_SHORT_TOKENS`) plus a length-≥2 floor that only drops bare
+//    single letters, plus curating "per" (a genuine 3-letter English
+//    preposition) into `FUNCTION_WORDS_EN` for the one 3-character case.
+// 3. The section-scoped pass had its own, separate `detected_language`
+//    comparison that never routed through the new evidence check at all —
+//    fixed by having `section_language_issues` call the SAME
+//    `is_language_mismatch` the document pass uses; see
+//    `a_german_institution_name_inside_an_english_education_section_never_fires`
+//    below for the regression pin that only a SECTION-scoped fixture can
+//    exercise.
+//
+// A fourth, harder shape was also measured and is NOT a numeric-threshold
+// problem: an otherwise-English document that merely NAMES a German or French
+// institution can carry a few real foreign function words purely from that
+// proper noun. The title-case-sandwich exclusion in `pairwise_evidence_count`
+// closes every REALISTIC instance measured (a terse "Degree, Institution,
+// Dates" entry, or a longer multi-sentence label) by recognising that a
+// connector wedged between two Capitalised neighbours is almost always part
+// of the proper noun's own official name, not free-standing prose.
+// `distinctive_evidence_confirms`'s comparative margin (found's evidence must
+// EXCEED target's, not merely clear a floor) is a second, principled layer
+// for the same shape — mechanically verified directly by
+// `distinctive_evidence_confirms_requires_a_real_margin_not_a_tie` below, but
+// a deliberate search did not turn up an end-to-end fixture dense enough to
+// need it WITHOUT the title-case exclusion already handling it; see the "NOTE
+// ON THE COMPARATIVE MARGIN'S END-TO-END COVERAGE" comment further down for
+// that measured limit, reported rather than concealed.
 
 /// The exact reported false positive, reproduced directly. An honest ENGLISH
 /// noun-phrase block — the shape an ordinary skills line or a terse CV takes
@@ -1817,10 +1876,11 @@ fn either_witness_alone_is_enough_to_corroborate_the_target() {
 /// doing so blanks `keywordCoverage` and suppresses every alignment finding
 /// on a document the user did nothing wrong with.
 ///
-/// Mutation check (performed, not hypothetical): removed the
-/// `distinctive_language_evidence` half of `is_language_mismatch`'s third
-/// condition, restoring the old two-condition body — RAN, went red (this
-/// fixture raised `content.language_mismatch` as a Critical), reverted.
+/// Mutation check (performed, not hypothetical): replaced
+/// `distinctive_evidence_confirms(text, found, lang)` in `is_language_mismatch`
+/// with a bare `true` (i.e. any confident Latin-script read counts, the
+/// original two-condition body) — RAN, went red (this fixture raised
+/// `content.language_mismatch` as a Critical), reverted.
 #[test]
 fn an_english_noun_phrase_block_never_earns_a_false_language_critical() {
     // The same lowercase tool/skill list `regime_5_neither_witness_...` and
@@ -1873,13 +1933,15 @@ fn an_english_noun_phrase_block_never_earns_a_false_language_critical() {
 /// target IS corroborated) — but the model returns neither German nor
 /// English, it returns genuine ITALIAN prose.
 ///
-/// **The rule catches it.** [`distinctive_language_evidence`] never needs to
-/// name the SAME language `detected_language` guessed — it only asks whether
-/// SOME curated language other than the target is evidenced, and real Italian
-/// prose is exactly as function-word-dense as real English or German prose:
-/// it carries its OWN distinctive evidence ("ha", "di", "che", "sono", …),
-/// which is enough on its own to corroborate that the output is NOT German,
-/// independent of whatever specific language whatlang itself named.
+/// **The rule catches it.** `distinctive_evidence_confirms` never needs
+/// `found`'s evidence to be evaluated against a specific OTHER curated
+/// language chosen in advance — it pairwise-compares `found` (whatever
+/// `detected_language` actually named) against `target` in the SAME text, and
+/// real Italian prose is exactly as function-word-dense as real English or
+/// German prose: it carries its own distinctive evidence ("ha", "di", "che",
+/// "sono", …), comfortably exceeding German's (zero, since the text is not
+/// German at all), independent of whatever the SOURCE or job ad happened to
+/// be written in.
 #[test]
 fn a_genuine_third_language_output_still_fires_against_the_real_target() {
     let italian_output = "Ho lavorato come ingegnere backend senior presso una azienda di \
@@ -1903,10 +1965,465 @@ fn a_genuine_third_language_output_still_fires_against_the_real_target() {
     assert!(
         document_language_mismatch(italian_output, EN_SOURCE, DE_JOB_AD, "de"),
         "answer: a genuine third-language output DOES still fire — real Italian prose \
-         carries its own distinctive function-word evidence, which is all \
-         distinctive_language_evidence requires (some curated language other than the \
-         target), not specifically whatever whatlang itself guessed"
+         carries plenty of its own distinctive function-word evidence, which comfortably \
+         exceeds German's (zero, since the text is not German), regardless of what the \
+         source or job ad were written in"
     );
+}
+
+// ── BLOCKING 1 (measured true-positive regression): Spanish and Portuguese ──
+
+/// The measured regression a review caught: genuine Spanish/Portuguese text
+/// against a non-Spanish/Portuguese target used to go SILENT under the first
+/// pass's global function-word pool, in BOTH the flowing-prose register and
+/// the bullets-plus-date-column register a real résumé's EXPERIENCE section
+/// actually uses. Both registers, both languages, pinned end-to-end through
+/// `validate_content` so a real `ContentIssue` at `Severity::Critical` is what
+/// is asserted — not just the internal predicate.
+///
+/// Mutation check (performed, not hypothetical): reverted
+/// `pairwise_evidence_count` to prune a word the moment it appeared in ANY
+/// two of the seven curated lists (the original global-pool design) — RAN,
+/// went red on all four cases below (evidence dropped to 0-1, under
+/// `MIN_DISTINCTIVE_HITS`), reverted.
+#[test]
+fn spanish_and_portuguese_regression_is_fixed_in_both_registers() {
+    let es_prose = "Ingeniero de software con ocho años de experiencia en sistemas de pago y \
+        plataformas de contenedores. He liderado la migración de nuestros servicios hacia \
+        Kubernetes y he reducido la latencia del servicio de pagos en un cuarenta por ciento. \
+        Trabajo con Rust, Python y PostgreSQL en un entorno de alta disponibilidad.";
+    let es_column = "EXPERIENCIA\n\n\
+        Ingeniero Backend Senior | Acme Payments | 2021 - Presente\n\
+        - Reduje la latencia del checkout de 480ms a 90ms con una cache Redis\n\
+        - Desplegué contenedores Docker en un clúster de Kubernetes\n\
+        - Reescribí el planificador de reintentos en Rust\n\n\
+        Desarrollador Backend | Globex Logistics | 2018 - 2021\n\
+        - Construí una interfaz de facturación en Python y PostgreSQL para 40 almacenes\n\
+        - Migré la flota a AWS con Terraform";
+    let pt_prose = "Engenheiro de software com oito anos de experiência em sistemas de \
+        pagamento e plataformas de contêineres. Liderei a migração dos nossos serviços para \
+        Kubernetes e reduzi a latência do serviço de pagamentos em quarenta por cento. \
+        Trabalho com Rust, Python e PostgreSQL em um ambiente de alta disponibilidade.";
+    let pt_column = "EXPERIÊNCIA\n\n\
+        Engenheiro Backend Sênior | Acme Payments | 2021 - Presente\n\
+        - Reduzi a latência do checkout de 480ms para 90ms com um cache Redis\n\
+        - Implantei contêineres Docker em um cluster Kubernetes\n\
+        - Reescrevi o agendador de tentativas em Rust\n\n\
+        Desenvolvedor Backend | Globex Logistics | 2018 - 2021\n\
+        - Construí uma interface de faturamento em Python e PostgreSQL para 40 armazéns\n\
+        - Migrei a frota para AWS com Terraform";
+
+    for (name, text, lang) in [
+        ("es_prose", es_prose, "es"),
+        ("es_column", es_column, "es"),
+        ("pt_prose", pt_prose, "pt"),
+        ("pt_column", pt_column, "pt"),
+    ] {
+        assert!(
+            significant_chars(text) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+            "premise[{name}]: fixture must clear the char floor"
+        );
+        assert_eq!(
+            crate::documents::keywords::detected_language(text),
+            Some(lang),
+            "premise[{name}]: must confidently read as {lang}, or this proves nothing \
+             about the regression"
+        );
+        assert!(
+            document_language_mismatch(text, EN_SOURCE, EN_JOB_AD, "en"),
+            "[{name}] a genuinely {lang} document against an English target must still \
+             raise the mismatch — this is the measured true-positive regression"
+        );
+        let report = validate_content(&ContentInput {
+            generated: text,
+            source_resume: EN_SOURCE,
+            job_ad: EN_JOB_AD,
+            top_requirements: &[],
+            target_language: "en",
+            doc_kind: DocKind::Resume,
+        });
+        let hits = fired(&report, CONTENT_LANGUAGE_MISMATCH);
+        assert_eq!(
+            hits[0].severity,
+            Severity::Critical,
+            "[{name}] the document-level mismatch must be a real Critical, not merely a \
+             true predicate"
+        );
+        assert!(!report.ok, "[{name}] a Critical must block the report");
+    }
+}
+
+// ── BLOCKING 2 (measured false positive): short ambiguous tokens in free text ──
+
+/// Five tokens a review measured as false positives on the SAME lowercase
+/// tool-list fixture this file already establishes reads as confident French:
+/// `ci/cd` (Italian "ci"), `.io` domains (Italian "io"), the `vi` editor
+/// (Italian "vi"), an "HA cluster" (Italian "ha"), and "cost per transaction"
+/// (Italian "per" — the one genuinely 3-character case, closed by curating
+/// "per" into `FUNCTION_WORDS_EN`). None of these five tokens is actually a
+/// FRENCH word — whatlang's guess never changes (`det=fr` throughout) — so
+/// `pairwise_evidence_count(text, "fr", "en")` finds nothing regardless of
+/// what the OLD "any curated language" pool found for a DIFFERENT language
+/// (Italian) whatlang never named.
+///
+/// **What actually closes this, measured rather than assumed:** the
+/// found-SPECIFIC pairwise match is the PRIMARY, demonstrated defense here —
+/// mutation-removing `AMBIGUOUS_SHORT_TOKENS` entirely left this test GREEN
+/// (verified: `ci`/`vi`/`io`/`ha`/`da`/`ti` are Italian, not French, so they
+/// were never counted as `fr` evidence regardless of the denylist). The
+/// denylist is defense-in-depth for the scenario the review actually warned
+/// about — `found` itself becoming one of these languages via abbreviation
+/// density — and a deliberate search for a fixture that flips whatlang's
+/// OVERALL read to `it` using only these tokens did not find one (saturated
+/// repetition read as unreliable/`None`; embedded in ordinary English prose
+/// it stayed confidently `en`). Kept anyway: it can only REMOVE evidence,
+/// never manufacture it, so it costs nothing even without a live trigger —
+/// reported as a measured limit, not concealed.
+#[test]
+fn short_ambiguous_tokens_never_manufacture_evidence() {
+    let base = "pandas numpy scikit-learn pytest git bash npm nginx dbt kubectl \
+        docker kubernetes terraform ansible jenkins grafana prometheus redis postgresql \
+        elasticsearch java spring hibernate maven gradle jira confluence";
+    let cases: &[(&str, String)] = &[
+        (
+            "+ci/cd",
+            format!("{base} ci/cd pipelines and ci/cd automation"),
+        ),
+        ("+.io", format!("{base} grafana.io and prometheus.io")),
+        ("+vi", format!("{base} vi and emacs and vi macros")),
+        ("+HA", format!("{base} HA cluster HA proxy")),
+        (
+            "+per",
+            format!("{base} cost per transaction requests per second"),
+        ),
+    ];
+    assert!(
+        matches!(
+            crate::documents::keywords::detected_language(base),
+            Some(found) if found != "en"
+        ),
+        "premise: the base tool list must confidently misread as some OTHER covered \
+         language, or the additions below prove nothing"
+    );
+    for (name, text) in cases {
+        assert!(
+            !document_language_mismatch(text, EN_SOURCE, EN_JOB_AD, "en"),
+            "[{name}] must not manufacture a mismatch — none of these tokens are actually \
+             a word in the language whatlang named"
+        );
+        let report = validate_content(&ContentInput {
+            generated: text,
+            source_resume: EN_SOURCE,
+            job_ad: EN_JOB_AD,
+            top_requirements: &[],
+            target_language: "en",
+            doc_kind: DocKind::Resume,
+        });
+        silent(&report, CONTENT_LANGUAGE_MISMATCH);
+    }
+}
+
+// ── BLOCKING 3 (untested section-scoped half) + design question (proper nouns) ──
+
+/// The differentiator BLOCKING 3 asked for: a fixture where reverting ONLY
+/// `section_language_issues`'s call to `is_language_mismatch` back to its
+/// pre-fix raw `detected_language(&body) != ctx.lang` comparison turns this
+/// test red while every OTHER section-level guard (`SectionKind::Skills`
+/// exclusion, `looks_like_prose`, the confidence floor) stays satisfied — so
+/// this is the ONE fixture in the suite that actually exercises the
+/// section-scoped evidence branch, not just the document-scoped one.
+///
+/// The shape is realistic, not adversarial: an EDUCATION entry (a real
+/// `SectionKey`, unlike Certifications/Awards, so a false positive here is
+/// NOT downgraded to a Warning) that spells out a German institution's own,
+/// untranslated name alongside genuine English degree labels — exactly what
+/// a truthful English résumé for a candidate who studied in Germany looks
+/// like. Measured: `detected_language` reads the section body as confident
+/// German (`Some("de")`, conf 1.0) purely from the institution's own
+/// connector words ("der", "und") — the OLD raw check fires on this alone.
+///
+/// Mutation check (performed, not hypothetical): reverted the
+/// `section_language_issues` hunk in `language.rs` to
+/// `if !matches!(detected_language(&body), Some(found) if found != ctx.lang) { return None; }`
+/// (dropping the route through `is_language_mismatch`), leaving the
+/// document-level pass untouched — RAN, went red (`content.language_mismatch`
+/// fired on the EDUCATION section), reverted. All 211
+/// `validate::content` tests that existed before this fix stayed green
+/// through that same reversion, which is exactly the coverage gap BLOCKING 3
+/// named.
+#[test]
+fn a_german_institution_name_inside_an_english_education_section_never_fires() {
+    let section_body = "EDUCATION\n\
+        Diploma in Business Administration, Ludwig-Maximilians-Universitat Munchen der \
+        Isotopenforschung und Angewandten Wissenschaften\n\
+        Certificate in Software Architecture, Technische Universitat Munchen der \
+        Angewandten Wissenschaften\n";
+    assert!(
+        significant_chars(section_body) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: the section body must clear the per-section char floor"
+    );
+    assert!(
+        looks_like_prose(section_body),
+        "premise: this section must clear the prose-ratio filter, or the Skills/prose \
+         guards alone would explain the silence and this test would prove nothing about \
+         the evidence branch specifically"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(section_body),
+        Some("de"),
+        "premise: whatlang must confidently (and wrongly) read this section as German — \
+         the exact read the OLD raw section-level check trusted unconditionally"
+    );
+    assert!(
+        !is_language_mismatch(section_body, "en"),
+        "the SAME evidence gate the document pass uses must also keep the section pass \
+         quiet here"
+    );
+
+    let generated = EN_CLEAN.replace(
+        "BSc Computer Science, TU Berlin, 2014 - 2018",
+        "Diploma in Business Administration, Ludwig-Maximilians-Universitat Munchen der \
+         Isotopenforschung und Angewandten Wissenschaften\n\
+         Certificate in Software Architecture, Technische Universitat Munchen der \
+         Angewandten Wissenschaften",
+    );
+    let report = en_resume(&generated, &en_requirements());
+    silent(&report, CONTENT_LANGUAGE_MISMATCH);
+}
+
+/// The narrower cousin of the test above: the SAME shape under a heading
+/// `classify_section` files as `Other` (Certifications has no `SectionKey`),
+/// so even where the evidence gate did NOT exist this would only ever
+/// downgrade to a Warning, never block. Pinned separately so a future reader
+/// can see the severity difference is real, not asserted from the EDUCATION
+/// case alone.
+#[test]
+fn a_german_institution_name_inside_an_english_certifications_section_never_fires() {
+    assert_eq!(
+        crate::documents::evidence::classify_section("CERTIFICATIONS"),
+        crate::documents::evidence::SectionKind::Other,
+        "premise: Certifications must classify as Other, or the severity-downgrade half \
+         of this test's premise does not hold"
+    );
+    let certs = "\n\nCERTIFICATIONS\n\n\
+        Diploma in Business Administration, Ludwig-Maximilians-Universitat Munchen der \
+        Isotopenforschung und Angewandten Wissenschaften\n\
+        Certificate in Software Architecture, Technische Universitat Munchen der \
+        Angewandten Wissenschaften\n\
+        Award for Outstanding Academic Performance, Deutsche Gesellschaft fur Informatik \
+        und Datenverarbeitung\n";
+    let generated = format!("{EN_CLEAN}{certs}");
+    let report = en_resume(&generated, &en_requirements());
+    silent(&report, CONTENT_LANGUAGE_MISMATCH);
+}
+
+/// The design question's OTHER measured shape: the REALISTIC one, matching
+/// this crate's own fixture convention for an education entry — a terse
+/// "Degree, Institution, Dates" one-liner (see `EN_SOURCE`/`DE_SOURCE`'s "BSc
+/// Computer Science, TU Berlin, 2014 - 2018") — with a REAL, not fabricated,
+/// German institution name whose OFFICIAL name genuinely contains "für" and
+/// "und" (Fachhochschule für Technik und Wirtschaft Berlin is a real Berlin
+/// university of applied sciences). This shape never even reaches the
+/// comparative margin: a short institution name contributes at most one or
+/// two hits, and real terse entries do not accumulate enough evidence to
+/// clear `MIN_DISTINCTIVE_HITS` in the first place — the title-case-sandwich
+/// exclusion and the comparative margin are both belt-and-braces here, not
+/// load-bearing, which is worth pinning separately from the denser,
+/// multi-sentence-labelled fixture above.
+#[test]
+fn a_terse_real_german_institution_name_never_fires() {
+    let generated = EN_CLEAN.replace(
+        "BSc Computer Science, TU Berlin, 2014 - 2018",
+        "MSc Computer Science, Fachhochschule fur Technik und Wirtschaft Berlin, 2018 - 2020\n\
+         BSc Computer Science, Technische Universitat Munchen, 2014 - 2018",
+    );
+    let report = en_resume(&generated, &en_requirements());
+    silent(&report, CONTENT_LANGUAGE_MISMATCH);
+}
+
+// NOTE ON THE COMPARATIVE MARGIN'S END-TO-END COVERAGE: `distinctive_evidence_confirms`'s
+// comparative half (`found_evidence > target_evidence`, not just clearing the
+// absolute floor) is directly, mechanically pinned by
+// `distinctive_evidence_confirms_requires_a_real_margin_not_a_tie` below. A
+// deliberate search for a REALISTIC end-to-end fixture that needs the
+// comparative margin specifically — as opposed to the title-case-sandwich
+// exclusion, which already silences every proper-noun fixture in this file —
+// did not find one: a French institution name dense enough to produce a
+// genuine EVIDENCE TIE (a first attempt, "Institut Francais des Technologies
+// de l'Information et de la Communication" + "Ministere de l'Economie et des
+// Finances", measured 5 French hits against 0 English once "de"/"des" were
+// allowed back in as non-ambiguous 2-character tokens) reads as GENUINELY
+// French-dense enough that treating it as a real mismatch is defensible, not
+// a false positive; shorter, single-institution variants stayed confidently
+// English overall and never reached the evidence branch at all. This is
+// reported as a measured gap in end-to-end coverage, not concealed by forcing
+// a fixture to fit — see the PR report for the numbers.
+
+// ── tr/vi: the script gate must not raise a Critical with zero evidence ──
+
+/// A review found that gating the evidence requirement on
+/// `CURATED_FUNCTION_WORDS` membership (seven languages) instead of the
+/// actual Latin SCRIPT (nine — Turkish and Vietnamese are Latin-script too)
+/// let a confident `tr`/`vi` whatlang guess skip corroboration entirely and
+/// raise a Critical with ZERO evidence. `needs_distinctive_evidence` now
+/// gates on the nine-language script set; since this crate curates no
+/// `tr`/`vi` vocabulary, a genuine `tr`/`vi` mismatch now goes quiet instead —
+/// an ACCEPTED miss, the same shape as every other uncurated-language miss
+/// this module already documents (see `regime_4`), not a new kind of gap.
+#[test]
+fn turkish_text_needs_evidence_too_and_goes_quiet_without_a_curated_list() {
+    let tr_text = "Ödeme sistemleri ve konteyner platformlarında sekiz yıllık deneyime sahip \
+        bir backend mühendisiyim. Ödeme sistemleri ve konteyner platformlarında sekiz yıllık \
+        deneyime sahip bir backend mühendisiyim.";
+    assert!(
+        significant_chars(tr_text) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(tr_text),
+        Some("tr"),
+        "premise: must confidently read as Turkish, or this test proves nothing about \
+         the script gate specifically"
+    );
+    assert!(
+        super::language::needs_distinctive_evidence("tr"),
+        "Turkish is Latin-script and must still need corroboration — it is the exact \
+         language this fix closes a zero-evidence hole for"
+    );
+    assert!(
+        !is_language_mismatch(tr_text, "en"),
+        "an accepted miss: no curated tr vocabulary means no evidence, so this stays \
+         quiet rather than firing on zero corroboration"
+    );
+}
+
+// ── direct unit tests for the evidence primitives (BLOCKING 3's other ask) ──
+
+/// `pairwise_evidence_count`'s three exclusion rules, isolated from any whole-
+/// document fixture: a shared word (in BOTH lists) never counts; a token
+/// under `MIN_DISTINCTIVE_TOKEN_CHARS` never counts even when it IS a genuine
+/// word in `lang`'s list; a word `lang` shares with some THIRD language
+/// `other` has never heard of still counts (this is the whole point of
+/// pairwise over a global pool).
+#[test]
+fn pairwise_evidence_count_excludes_shared_and_short_tokens() {
+    use super::language::pairwise_evidence_count;
+
+    // "und" is German-only (not in FUNCTION_WORDS_EN) and 3 characters — counts.
+    assert_eq!(pairwise_evidence_count("und und und", "de", "en"), 3);
+    // "in" is shared by German AND English — never counts either way.
+    assert_eq!(pairwise_evidence_count("in in in", "de", "en"), 0);
+    // "zu" is a genuine German preposition but only 2 characters — excluded by
+    // the length floor even though it appears nowhere in FUNCTION_WORDS_EN.
+    assert_eq!(pairwise_evidence_count("zu zu zu", "de", "en"), 0);
+    // Pairwise, not global: "con" collides between Spanish and Italian, but
+    // that collision is irrelevant when comparing Spanish against ENGLISH,
+    // which has never heard of "con" at all.
+    assert!(pairwise_evidence_count("con con con", "es", "en") > 0);
+    // An uncurated language (no list at all) always returns zero.
+    assert_eq!(pairwise_evidence_count("und und und", "tr", "en"), 0);
+}
+
+/// A word sandwiched between two Title-Case neighbours is excluded — the
+/// heuristic `a_german_institution_name_inside_an_english_education_section_never_fires`
+/// relies on, isolated here on a minimal pair so the mechanism itself is
+/// pinned independent of that larger fixture.
+#[test]
+fn a_connector_between_two_title_case_words_is_excluded_as_a_proper_noun() {
+    use super::language::pairwise_evidence_count;
+
+    // "und" between two Capitalised words reads as part of a compound proper
+    // noun ("Technik und Wirtschaft") and is excluded; "Technik"/"Wirtschaft"
+    // themselves are not German function words, so this is the whole count.
+    assert_eq!(
+        pairwise_evidence_count("Technik und Wirtschaft", "de", "en"),
+        0
+    );
+    // The SAME word in ordinary sentence position (lowercase neighbours) is
+    // not excluded — this is what keeps genuine German prose evidenced. "die"
+    // (article) also survives, so this fixture counts both.
+    assert_eq!(
+        pairwise_evidence_count("die technik und wirtschaft wuchsen", "de", "en"),
+        2
+    );
+    // A sentence-initial capital on ONE side only is not a proper-noun
+    // sandwich — only BOTH neighbours capitalised excludes a hit. "Und" and
+    // "die" both survive here for the same reason.
+    assert_eq!(
+        pairwise_evidence_count("Und die technik wuchs", "de", "en"),
+        2
+    );
+}
+
+/// `distinctive_evidence_confirms`'s comparative margin, isolated: `found`'s
+/// evidence must not just clear the absolute floor, it must exceed `target`'s
+/// own evidence in the same text — a tie is NOT enough.
+#[test]
+fn distinctive_evidence_confirms_requires_a_real_margin_not_a_tie() {
+    use super::language::distinctive_evidence_confirms;
+
+    // Two "und" (German) and two "and" (English) in the same text: a tie.
+    let tied = "und and und and";
+    assert!(
+        !distinctive_evidence_confirms(tied, "de", "en"),
+        "a tie must not confirm — found does not EXCEED target"
+    );
+    // Three German hits against the same two English ones: a real margin.
+    let margin = "und und und and and";
+    assert!(
+        distinctive_evidence_confirms(margin, "de", "en"),
+        "found's evidence now exceeds target's"
+    );
+    // Below the absolute floor even with zero target evidence: one hit alone
+    // is still noise, not evidence.
+    assert!(!distinctive_evidence_confirms("und", "de", "en"));
+}
+
+/// `needs_distinctive_evidence` gates on the nine-language Latin-SCRIPT set,
+/// not on which seven have a curated vocabulary — the distinction BLOCKING 2
+/// (tr/vi) hinges on.
+#[test]
+fn needs_distinctive_evidence_is_the_nine_language_latin_script_set() {
+    for lang in ["en", "de", "fr", "es", "it", "nl", "pt", "tr", "vi"] {
+        assert!(
+            super::language::needs_distinctive_evidence(lang),
+            "{lang} is Latin-script and must need corroboration"
+        );
+    }
+    for lang in ["zh", "ja", "ko", "ar", "he", "hi", "bn", "th", "uk", "ru"] {
+        assert!(
+            !super::language::needs_distinctive_evidence(lang),
+            "{lang} reads a non-Latin script; whatlang's script read is already reliable \
+             there without corroboration"
+        );
+    }
+}
+
+/// The floor BLOCKING 3 asked for in place of an exact-count assertion — a
+/// language's own pairwise vocabulary against English must clear a healthy
+/// minimum, so a future edit that silently thins a list back down (the exact
+/// way the Spanish regression shipped unnoticed) fails loudly here instead of
+/// only showing up as a missed Critical three layers away. Chosen well below
+/// every language's current count (`de` 88, `en` 67, `fr` 60, `es` 60, `it`
+/// 62, `nl` 61, `pt` 61) so ordinary curation additions/removals do not make
+/// this brittle.
+#[test]
+fn every_curated_language_has_a_healthy_pairwise_floor_against_english() {
+    const FLOOR: usize = 40;
+    for lang in ["de", "fr", "es", "it", "nl", "pt"] {
+        let words = super::language::function_words_for(lang);
+        let against_en: usize = words
+            .iter()
+            .filter(|w| !super::language::function_words_for("en").contains(w))
+            .count();
+        assert!(
+            against_en >= FLOOR,
+            "{lang}'s vocabulary against English has only {against_en} pairwise-distinct \
+             entries, under the {FLOOR} floor — this is exactly how the Spanish regression \
+             (30 survivors after global pruning) shipped unnoticed; investigate before \
+             lowering this floor"
+        );
+    }
 }
 
 /// H4 — "still there" is spelled in more than one way. A source that writes

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1900,16 +1900,15 @@ fn either_witness_alone_is_enough_to_corroborate_the_target() {
 // A fourth, harder shape was also measured and is NOT a numeric-threshold
 // problem: an otherwise-English document that merely NAMES a German or French
 // institution can carry a few real foreign function words purely from that
-// proper noun. The title-case-sandwich exclusion in `pairwise_evidence_count`
-// closes every REALISTIC instance measured (a terse "Degree, Institution,
-// Dates" entry, or a longer multi-sentence label) by recognising that a
-// connector wedged between two Capitalised neighbours is almost always part
-// of the proper noun's own official name, not free-standing prose. A second,
-// COMPARATIVE bar (found's evidence must EXCEED target's, not merely clear a
-// floor) was tried on top of the title-case exclusion and REMOVED: disabling
-// it left every behavioural test in this file green, so it was carrying no
-// load the title-case exclusion did not already carry — see
-// `distinctive_evidence_confirms_requires_the_absolute_floor` and the module
+// proper noun. A title-case-sandwich exclusion in `pairwise_evidence_count`
+// was tried for this shape and REMOVED (it deleted nominal-register German's
+// evidence wholesale); what closes it now is MIN_DISTINCTIVE_HITS alone —
+// see its doc for the corpus and the accepted French/Italian residual risk.
+// A second, COMPARATIVE bar (found's evidence must EXCEED target's, not
+// merely clear a floor) was tried on top of the title-case exclusion and
+// REMOVED: disabling it left every behavioural test in this file green, so
+// it was carrying no load the floor does not already carry — see
+// `distinctive_evidence_confirms_requires_the_shipped_floor` and the module
 // doc for the measurement.
 
 /// The exact reported false positive, reproduced directly. An honest ENGLISH
@@ -2368,6 +2367,11 @@ fn a_german_institution_name_inside_an_english_education_section_never_fires() {
          Certificate in Software Architecture, Technische Universitat Munchen der \
          Angewandten Wissenschaften",
     );
+    assert!(
+        generated != EN_CLEAN,
+        "premise: the education entry must actually be replaced — EN_CLEAN's wording drifted, \
+         so this test is now asserting silence on an unmodified English fixture"
+    );
     let report = en_resume(&generated, &en_requirements());
     silent(&report, CONTENT_LANGUAGE_MISMATCH);
 }
@@ -2406,16 +2410,21 @@ fn a_german_institution_name_inside_an_english_certifications_section_never_fire
 /// "und" (Fachhochschule für Technik und Wirtschaft Berlin is a real Berlin
 /// university of applied sciences). A short institution name contributes at
 /// most one or two hits, and real terse entries do not accumulate enough
-/// evidence to clear `MIN_DISTINCTIVE_HITS` in the first place — the
-/// title-case-sandwich exclusion is belt and braces here, not load-bearing,
-/// which is worth pinning separately from the denser, multi-sentence-labelled
-/// fixture above.
+/// evidence to clear `MIN_DISTINCTIVE_HITS` in the first place — `MIN_DISTINCTIVE_HITS`
+/// is now the only thing keeping this fixture quiet, which makes it a direct
+/// floor-calibration pin, worth keeping separate from the denser,
+/// multi-sentence-labelled fixture above.
 #[test]
 fn a_terse_real_german_institution_name_never_fires() {
     let generated = EN_CLEAN.replace(
         "BSc Computer Science, TU Berlin, 2014 - 2018",
         "MSc Computer Science, Fachhochschule fur Technik und Wirtschaft Berlin, 2018 - 2020\n\
          BSc Computer Science, Technische Universitat Munchen, 2014 - 2018",
+    );
+    assert!(
+        generated != EN_CLEAN,
+        "premise: the terse institution entry must actually be replaced — EN_CLEAN's wording \
+         drifted, so this test is now asserting silence on an unmodified English fixture"
     );
     let report = en_resume(&generated, &en_requirements());
     silent(&report, CONTENT_LANGUAGE_MISMATCH);

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1805,6 +1805,110 @@ fn either_witness_alone_is_enough_to_corroborate_the_target() {
     ));
 }
 
+// ── Latin-script noun-phrase false positive (whatlang's confidence-margin blind spot) ──
+
+/// The exact reported false positive, reproduced directly. An honest ENGLISH
+/// noun-phrase block — the shape an ordinary skills line or a terse CV takes
+/// (measured: this exact list reads at `confidence() == 1.0`,
+/// `is_reliable() == true`, `lang == Fra`) — starves `whatlang`'s n-gram
+/// model of the function words it needs to read English from at all, and it
+/// lands on some OTHER language with MAXIMUM confidence margin.
+/// `is_language_mismatch` must not raise the deterministic Critical on it:
+/// doing so blanks `keywordCoverage` and suppresses every alignment finding
+/// on a document the user did nothing wrong with.
+///
+/// Mutation check (performed, not hypothetical): removed the
+/// `distinctive_language_evidence` half of `is_language_mismatch`'s third
+/// condition, restoring the old two-condition body — RAN, went red (this
+/// fixture raised `content.language_mismatch` as a Critical), reverted.
+#[test]
+fn an_english_noun_phrase_block_never_earns_a_false_language_critical() {
+    // The same lowercase tool/skill list `regime_5_neither_witness_...` and
+    // the Skills-exclusion tests above already establish reads as SOME other
+    // covered language — an ordinary skills line, no different in shape from
+    // the reported bug's "Administration / Supervision / Coordination / …".
+    let noun_phrases = "pandas numpy scikit-learn pytest git bash npm nginx dbt kubectl \
+        docker kubernetes terraform ansible jenkins grafana prometheus redis postgresql \
+        elasticsearch java spring hibernate maven gradle jira confluence";
+    assert!(
+        significant_chars(noun_phrases) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor, or this test proves nothing about \
+         the confidence-margin gate specifically"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(noun_phrases),
+        Some("fr"),
+        "premise: whatlang must confidently (and wrongly) read this honest English \
+         skills/tool list as French — measured directly at confidence 1.0, reliable — \
+         or this test proves nothing about the OLD two-condition check firing here"
+    );
+    assert!(
+        !is_language_mismatch(noun_phrases, "en"),
+        "the distinctive-function-word gate must keep this quiet: a noun-phrase block \
+         carries none of the real function words a genuine drift into another language \
+         would leave behind"
+    );
+
+    // End-to-end via the public entry point, with real English witnesses on
+    // both sides so the target is trivially corroborated — this is the shape
+    // that used to blank keywordCoverage and every alignment finding.
+    assert!(
+        !document_language_mismatch(noun_phrases, EN_SOURCE, EN_JOB_AD, "en"),
+        "a genuinely English noun-phrase document must not raise the deterministic \
+         Critical just because whatlang misreads it"
+    );
+    let report = validate_content(&ContentInput {
+        generated: noun_phrases,
+        source_resume: EN_SOURCE,
+        job_ad: EN_JOB_AD,
+        top_requirements: &[],
+        target_language: "en",
+        doc_kind: DocKind::Resume,
+    });
+    silent(&report, CONTENT_LANGUAGE_MISMATCH);
+}
+
+/// The THIRD-language case, answered directly rather than left implicit:
+/// target `"de"`, an untranslated English source, a German job ad (so the
+/// target IS corroborated) — but the model returns neither German nor
+/// English, it returns genuine ITALIAN prose.
+///
+/// **The rule catches it.** [`distinctive_language_evidence`] never needs to
+/// name the SAME language `detected_language` guessed — it only asks whether
+/// SOME curated language other than the target is evidenced, and real Italian
+/// prose is exactly as function-word-dense as real English or German prose:
+/// it carries its OWN distinctive evidence ("ha", "di", "che", "sono", …),
+/// which is enough on its own to corroborate that the output is NOT German,
+/// independent of whatever specific language whatlang itself named.
+#[test]
+fn a_genuine_third_language_output_still_fires_against_the_real_target() {
+    let italian_output = "Ho lavorato come ingegnere backend senior presso una azienda di \
+        pagamenti, dove ho ridotto la latenza del servizio di cassa da 480 millisecondi a \
+        90 millisecondi grazie a una cache Redis posizionata davanti al servizio di \
+        contabilità. Ho eseguito i carichi di lavoro Docker su un cluster Kubernetes che \
+        risponde a dodicimila richieste ogni secondo, e ho riscritto lo scheduler dei \
+        tentativi in Rust, riducendo i pagamenti falliti del trentacinque per cento.";
+    assert!(
+        significant_chars(italian_output) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor"
+    );
+    assert!(
+        matches!(
+            crate::documents::keywords::detected_language(italian_output),
+            Some("it")
+        ),
+        "premise: this must genuinely and confidently read as Italian, or the test \
+         proves nothing about the third-language case specifically"
+    );
+    assert!(
+        document_language_mismatch(italian_output, EN_SOURCE, DE_JOB_AD, "de"),
+        "answer: a genuine third-language output DOES still fire — real Italian prose \
+         carries its own distinctive function-word evidence, which is all \
+         distinctive_language_evidence requires (some curated language other than the \
+         target), not specifically whatever whatlang itself guessed"
+    );
+}
+
 /// H4 — "still there" is spelled in more than one way. A source that writes
 /// `seit 2021`, `since 2021` or a bare `2021 –` carries no `Present` marker, and
 /// the old `|| !source_open_ended` arm turned every one of those into a Critical

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1837,10 +1837,16 @@ fn either_witness_alone_is_enough_to_corroborate_the_target() {
 //    length-≥3 floor was tried FIRST and measured to also exclude Italian's
 //    OWN core vocabulary (`il`, `la`, `di`, all 2 characters — see
 //    `a_drifted_awards_section_warns_rather_than_blocks`, which briefly
-//    regressed under that rule), so the fix is a named denylist
-//    (`AMBIGUOUS_SHORT_TOKENS`) plus a length-≥2 floor that only drops bare
-//    single letters, plus curating "per" (a genuine 3-letter English
-//    preposition) into `FUNCTION_WORDS_EN` for the one 3-character case.
+//    regressed under that rule). A curated denylist was tried NEXT and also
+//    REMOVED: the found-SPECIFIC pairwise match already closes every one of
+//    the five reported cases on its own (none of those tokens is a word in
+//    the language whatlang actually named), the denylist's only measured
+//    trigger was an adversarial string of disconnected foreign idioms no
+//    realistic document produces, and it cost real evidence from exactly the
+//    languages fix 1 was written to protect (`el` is one of Spanish's
+//    commonest words). What shipped is just a length-≥2 floor (drops bare
+//    single letters only) plus curating "per" (a genuine English preposition)
+//    into `FUNCTION_WORDS_EN` for the one 3-character false positive measured.
 // 3. The section-scoped pass had its own, separate `detected_language`
 //    comparison that never routed through the new evidence check at all —
 //    fixed by having `section_language_issues` call the SAME
@@ -1856,15 +1862,13 @@ fn either_witness_alone_is_enough_to_corroborate_the_target() {
 // closes every REALISTIC instance measured (a terse "Degree, Institution,
 // Dates" entry, or a longer multi-sentence label) by recognising that a
 // connector wedged between two Capitalised neighbours is almost always part
-// of the proper noun's own official name, not free-standing prose.
-// `distinctive_evidence_confirms`'s comparative margin (found's evidence must
-// EXCEED target's, not merely clear a floor) is a second, principled layer
-// for the same shape — mechanically verified directly by
-// `distinctive_evidence_confirms_requires_a_real_margin_not_a_tie` below, but
-// a deliberate search did not turn up an end-to-end fixture dense enough to
-// need it WITHOUT the title-case exclusion already handling it; see the "NOTE
-// ON THE COMPARATIVE MARGIN'S END-TO-END COVERAGE" comment further down for
-// that measured limit, reported rather than concealed.
+// of the proper noun's own official name, not free-standing prose. A second,
+// COMPARATIVE bar (found's evidence must EXCEED target's, not merely clear a
+// floor) was tried on top of the title-case exclusion and REMOVED: disabling
+// it left every behavioural test in this file green, so it was carrying no
+// load the title-case exclusion did not already carry — see
+// `distinctive_evidence_confirms_requires_the_absolute_floor` and the module
+// doc for the measurement.
 
 /// The exact reported false positive, reproduced directly. An honest ENGLISH
 /// noun-phrase block — the shape an ordinary skills line or a terse CV takes
@@ -2059,26 +2063,17 @@ fn spanish_and_portuguese_regression_is_fixed_in_both_registers() {
 /// tool-list fixture this file already establishes reads as confident French:
 /// `ci/cd` (Italian "ci"), `.io` domains (Italian "io"), the `vi` editor
 /// (Italian "vi"), an "HA cluster" (Italian "ha"), and "cost per transaction"
-/// (Italian "per" — the one genuinely 3-character case, closed by curating
-/// "per" into `FUNCTION_WORDS_EN`). None of these five tokens is actually a
-/// FRENCH word — whatlang's guess never changes (`det=fr` throughout) — so
-/// `pairwise_evidence_count(text, "fr", "en")` finds nothing regardless of
-/// what the OLD "any curated language" pool found for a DIFFERENT language
-/// (Italian) whatlang never named.
-///
-/// **What actually closes this, measured rather than assumed:** the
-/// found-SPECIFIC pairwise match is the PRIMARY, demonstrated defense here —
-/// mutation-removing `AMBIGUOUS_SHORT_TOKENS` entirely left this test GREEN
-/// (verified: `ci`/`vi`/`io`/`ha`/`da`/`ti` are Italian, not French, so they
-/// were never counted as `fr` evidence regardless of the denylist). The
-/// denylist is defense-in-depth for the scenario the review actually warned
-/// about — `found` itself becoming one of these languages via abbreviation
-/// density — and a deliberate search for a fixture that flips whatlang's
-/// OVERALL read to `it` using only these tokens did not find one (saturated
-/// repetition read as unreliable/`None`; embedded in ordinary English prose
-/// it stayed confidently `en`). Kept anyway: it can only REMOVE evidence,
-/// never manufacture it, so it costs nothing even without a live trigger —
-/// reported as a measured limit, not concealed.
+/// (Italian "per" — closed by curating "per" into `FUNCTION_WORDS_EN`, a
+/// genuine English preposition, so it collides out at the ordinary pairwise
+/// step). None of these five tokens is actually a FRENCH word — whatlang's
+/// guess never changes (`det=fr` throughout) — so `pairwise_evidence_count(text,
+/// "fr", "en")` finds nothing regardless of what the OLD "any curated
+/// language" pool found for a DIFFERENT language (Italian) whatlang never
+/// named. This is the found-SPECIFIC pairwise match closing the leak entirely
+/// on its own — no length floor or curated denylist for `ci`/`vi`/`io`/`ha`
+/// was needed here or shipped: a denylist was tried and, after failing to find
+/// a realistic document that needed it, removed (see the module doc for the
+/// measurement).
 #[test]
 fn short_ambiguous_tokens_never_manufacture_evidence() {
     let base = "pandas numpy scikit-learn pytest git bash npm nginx dbt kubectl \
@@ -2223,13 +2218,12 @@ fn a_german_institution_name_inside_an_english_certifications_section_never_fire
 /// Computer Science, TU Berlin, 2014 - 2018") — with a REAL, not fabricated,
 /// German institution name whose OFFICIAL name genuinely contains "für" and
 /// "und" (Fachhochschule für Technik und Wirtschaft Berlin is a real Berlin
-/// university of applied sciences). This shape never even reaches the
-/// comparative margin: a short institution name contributes at most one or
-/// two hits, and real terse entries do not accumulate enough evidence to
-/// clear `MIN_DISTINCTIVE_HITS` in the first place — the title-case-sandwich
-/// exclusion and the comparative margin are both belt-and-braces here, not
-/// load-bearing, which is worth pinning separately from the denser,
-/// multi-sentence-labelled fixture above.
+/// university of applied sciences). A short institution name contributes at
+/// most one or two hits, and real terse entries do not accumulate enough
+/// evidence to clear `MIN_DISTINCTIVE_HITS` in the first place — the
+/// title-case-sandwich exclusion is belt and braces here, not load-bearing,
+/// which is worth pinning separately from the denser, multi-sentence-labelled
+/// fixture above.
 #[test]
 fn a_terse_real_german_institution_name_never_fires() {
     let generated = EN_CLEAN.replace(
@@ -2240,24 +2234,6 @@ fn a_terse_real_german_institution_name_never_fires() {
     let report = en_resume(&generated, &en_requirements());
     silent(&report, CONTENT_LANGUAGE_MISMATCH);
 }
-
-// NOTE ON THE COMPARATIVE MARGIN'S END-TO-END COVERAGE: `distinctive_evidence_confirms`'s
-// comparative half (`found_evidence > target_evidence`, not just clearing the
-// absolute floor) is directly, mechanically pinned by
-// `distinctive_evidence_confirms_requires_a_real_margin_not_a_tie` below. A
-// deliberate search for a REALISTIC end-to-end fixture that needs the
-// comparative margin specifically — as opposed to the title-case-sandwich
-// exclusion, which already silences every proper-noun fixture in this file —
-// did not find one: a French institution name dense enough to produce a
-// genuine EVIDENCE TIE (a first attempt, "Institut Francais des Technologies
-// de l'Information et de la Communication" + "Ministere de l'Economie et des
-// Finances", measured 5 French hits against 0 English once "de"/"des" were
-// allowed back in as non-ambiguous 2-character tokens) reads as GENUINELY
-// French-dense enough that treating it as a real mismatch is defensible, not
-// a false positive; shorter, single-institution variants stayed confidently
-// English overall and never reached the evidence branch at all. This is
-// reported as a measured gap in end-to-end coverage, not concealed by forcing
-// a fixture to fit — see the PR report for the numbers.
 
 // ── tr/vi: the script gate must not raise a Critical with zero evidence ──
 
@@ -2299,23 +2275,32 @@ fn turkish_text_needs_evidence_too_and_goes_quiet_without_a_curated_list() {
 
 // ── direct unit tests for the evidence primitives (BLOCKING 3's other ask) ──
 
-/// `pairwise_evidence_count`'s three exclusion rules, isolated from any whole-
-/// document fixture: a shared word (in BOTH lists) never counts; a token
-/// under `MIN_DISTINCTIVE_TOKEN_CHARS` never counts even when it IS a genuine
-/// word in `lang`'s list; a word `lang` shares with some THIRD language
-/// `other` has never heard of still counts (this is the whole point of
-/// pairwise over a global pool).
+/// `pairwise_evidence_count`'s exclusion rules, isolated from any whole-
+/// document fixture: a shared word (in BOTH lists) never counts; a bare
+/// single-letter token never counts even when it IS a genuine word in
+/// `lang`'s list; a word `lang` shares with some THIRD language `other` has
+/// never heard of still counts (this is the whole point of pairwise over a
+/// global pool); "zu" (a genuine German preposition, 2 characters, absent
+/// from `FUNCTION_WORDS_EN`) DOES count — 2-character tokens are not
+/// universally excluded, only the single-letter floor and a genuine target
+/// collision remove a word.
 #[test]
-fn pairwise_evidence_count_excludes_shared_and_short_tokens() {
+fn pairwise_evidence_count_excludes_shared_and_single_letter_tokens() {
     use super::language::pairwise_evidence_count;
 
     // "und" is German-only (not in FUNCTION_WORDS_EN) and 3 characters — counts.
     assert_eq!(pairwise_evidence_count("und und und", "de", "en"), 3);
     // "in" is shared by German AND English — never counts either way.
     assert_eq!(pairwise_evidence_count("in in in", "de", "en"), 0);
-    // "zu" is a genuine German preposition but only 2 characters — excluded by
-    // the length floor even though it appears nowhere in FUNCTION_WORDS_EN.
-    assert_eq!(pairwise_evidence_count("zu zu zu", "de", "en"), 0);
+    // "zu" is a genuine German preposition, only 2 characters, and NOT shared
+    // with English — counts. (Confirms the length floor is 2, not 3: a
+    // blanket 3-character floor was tried and measured to also exclude
+    // Italian's own "il"/"la"/"di" — see MIN_DISTINCTIVE_TOKEN_CHARS's doc.)
+    assert_eq!(pairwise_evidence_count("zu zu zu", "de", "en"), 3);
+    // "y" ("and", Spanish) is a genuine word but only ONE character — excluded
+    // by the single-letter floor even though it appears nowhere in
+    // FUNCTION_WORDS_EN.
+    assert_eq!(pairwise_evidence_count("y y y", "es", "en"), 0);
     // Pairwise, not global: "con" collides between Spanish and Italian, but
     // that collision is irrelevant when comparing Spanish against ENGLISH,
     // which has never heard of "con" at all.
@@ -2355,28 +2340,34 @@ fn a_connector_between_two_title_case_words_is_excluded_as_a_proper_noun() {
     );
 }
 
-/// `distinctive_evidence_confirms`'s comparative margin, isolated: `found`'s
-/// evidence must not just clear the absolute floor, it must exceed `target`'s
-/// own evidence in the same text — a tie is NOT enough.
+/// `distinctive_evidence_confirms`'s absolute floor, isolated: `found`'s
+/// pairwise evidence must clear `MIN_DISTINCTIVE_HITS` (a single hit is
+/// noise, not evidence); a non-Latin-script `found` skips the requirement
+/// entirely regardless of evidence, since `needs_distinctive_evidence` never
+/// asks a script whatlang already reads reliably to corroborate itself.
+///
+/// A second, COMPARATIVE bar (`found`'s evidence must EXCEED `target`'s own
+/// in the same text, not just clear the floor) was tried here and removed:
+/// disabling it left every `validate::content` behavioural test green and
+/// only a test asserting the comparative predicate directly red, so the
+/// title-case-sandwich exclusion in `pairwise_evidence_count` was already
+/// doing the real work — see the module doc for the full measurement.
 #[test]
-fn distinctive_evidence_confirms_requires_a_real_margin_not_a_tie() {
+fn distinctive_evidence_confirms_requires_the_absolute_floor() {
     use super::language::distinctive_evidence_confirms;
 
-    // Two "und" (German) and two "and" (English) in the same text: a tie.
-    let tied = "und and und and";
-    assert!(
-        !distinctive_evidence_confirms(tied, "de", "en"),
-        "a tie must not confirm — found does not EXCEED target"
-    );
-    // Three German hits against the same two English ones: a real margin.
-    let margin = "und und und and and";
-    assert!(
-        distinctive_evidence_confirms(margin, "de", "en"),
-        "found's evidence now exceeds target's"
-    );
-    // Below the absolute floor even with zero target evidence: one hit alone
-    // is still noise, not evidence.
+    // Two hits clears the floor.
+    assert!(distinctive_evidence_confirms("und und", "de", "en"));
+    // One hit alone is still noise, not evidence — even with zero target
+    // evidence to compare against.
     assert!(!distinctive_evidence_confirms("und", "de", "en"));
+    // A non-Latin script skips the requirement outright: zero evidence, but
+    // whatlang's script read is already reliable there.
+    assert!(distinctive_evidence_confirms(
+        "zero evidence text here",
+        "zh",
+        "en"
+    ));
 }
 
 /// `needs_distinctive_evidence` gates on the nine-language Latin-SCRIPT set,

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1635,42 +1635,53 @@ fn regime_5_neither_witness_corroborating_the_target_stays_quiet() {
 /// same way it would read a longer original. The SAME sentences
 /// `documents::keywords::test::detected_language_identifies_*` pins at the
 /// primitive level, so a regression in either place is visible in both.
+///
+/// The seven Latin-curated languages repeat 7×, not 3× — measured: at a
+/// single instance, the worst pairwise-evidence case across all 42
+/// cross-language pairs is Spanish against a French target (Spanish and
+/// French share most of their short function words, so only "tiene" survives
+/// pairwise pruning), at 1 hit. 3 repeats would give that pair 3 hits, under
+/// [`MIN_DISTINCTIVE_HITS`]'s floor of 5; 7 repeats gives it 7, two clear of
+/// the floor. The SAME reasoning [`MIN_CHARS_FOR_LANGUAGE_CHECK`] already
+/// applies to length: a document too short is a poor candidate for a
+/// confident read, and a real wrong-language document is never this
+/// artificially terse.
 fn per_language_samples() -> Vec<(&'static str, String)> {
     let sentences: &[(&str, &str, usize)] = &[
         (
             "en",
             "The candidate has eight years of backend experience with payment systems.",
-            3,
+            7,
         ),
         (
             "de",
             "Die Kandidatin hat acht Jahre Erfahrung im Backend-Bereich mit Zahlungssystemen.",
-            3,
+            7,
         ),
         (
             "fr",
             "La candidate a huit ans d'expérience dans les systèmes de paiement back-end.",
-            3,
+            7,
         ),
         (
             "es",
             "La candidata tiene ocho años de experiencia en sistemas de pago de backend.",
-            3,
+            7,
         ),
         (
             "it",
             "La candidata ha otto anni di esperienza nei sistemi di pagamento backend.",
-            3,
+            7,
         ),
         (
             "pt",
             "A candidata tem oito anos de experiência em sistemas de pagamento de backend.",
-            3,
+            7,
         ),
         (
             "nl",
             "De kandidaat heeft acht jaar ervaring met backend-betalingssystemen.",
-            3,
+            7,
         ),
         ("zh", "我是一名后端工程师，在支付系统和容器平台方面工作了八年。", 5),
         (
@@ -2118,6 +2129,150 @@ fn short_ambiguous_tokens_never_manufacture_evidence() {
     }
 }
 
+// ── CRITICAL (pre-PR gate): nominal-register German had NO fixture ──────────
+
+/// A pre-PR gate found that the title-case-sandwich exclusion (since
+/// removed — see the module doc) deleted German's evidence wholesale,
+/// because standard German CV register is NOMINAL ("Aufbau und Betrieb der
+/// Zahlungsplattform"), not the finite-verb register
+/// ([`EN_WRONG_LANGUAGE`]'s "Die Wartezeit wurde gesenkt…") every existing
+/// wrong-language German fixture in this file happened to use. German
+/// capitalises every noun, so in nominal register EVERY connector sits
+/// between two capitalised words — the exclusion could not tell that apart
+/// from a connector inside a proper noun, and this exact register never had
+/// a regression pin. Document scope: the whole résumé is nominal.
+#[test]
+fn nominal_register_german_document_is_critical() {
+    let de_nominal = "Jane Doe\n\
+        jane.doe@example.com | +49 30 1234567 | github.com/janedoe\n\n\
+        ZUSAMMENFASSUNG\n\n\
+        Acht Jahre Erfahrung im Zahlungsverkehr und im Aufbau von Container-Plattformen.\n\n\
+        BERUFSERFAHRUNG\n\n\
+        Senior Backend Engineer | Acme Payments | 2021 - Present\n\
+        - Aufbau und Betrieb der Zahlungsplattform mit Reduzierung der Wartezeit von 480ms \
+        auf 90ms\n\
+        - Leitung der Migration der Dienste auf einen Kubernetes-Cluster mit zwölftausend \
+        Anfragen pro Sekunde\n\
+        - Neuentwicklung des Wiederholungsplaners in Rust zur Reduzierung fehlgeschlagener \
+        Zahlungen\n\n\
+        Backend Developer | Globex Logistics | 2018 - 2021\n\
+        - Entwicklung der Abrechnungsschnittstelle in Python und PostgreSQL für vierzig \
+        Lagerstandorte\n\
+        - Migration der Flotte zu AWS mit Terraform als Bereitstellungswerkzeug\n\n\
+        KENNTNISSE\n\n\
+        Rust · Python · Docker · Kubernetes · PostgreSQL · AWS · Terraform · Redis\n\n\
+        AUSBILDUNG\n\n\
+        BSc Informatik, TU Berlin, 2014 - 2018\n";
+    assert!(
+        significant_chars(de_nominal) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(de_nominal),
+        Some("de"),
+        "premise: must confidently read as German"
+    );
+    assert!(
+        is_language_mismatch(de_nominal, "en"),
+        "nominal-register German must still be caught — this is the exact register the \
+         title-case-sandwich exclusion silenced"
+    );
+    let report = en_resume(de_nominal, &en_requirements());
+    let hits = fired(&report, CONTENT_LANGUAGE_MISMATCH);
+    assert_eq!(hits[0].severity, Severity::Critical);
+    assert!(!report.ok);
+}
+
+/// The SAME nominal register, drifted into only the EXPERIENCE section of an
+/// otherwise-English résumé — the shape the reported defect actually takes,
+/// and the shape [`a_single_drifted_section_is_caught_even_though_the_document_reads_clean`]
+/// already pins for Italian. German had no equivalent: the document-level
+/// vote must stay clean (an English majority hides one drifted section) and
+/// the section-level pass must catch it — this is the ONE fixture that
+/// exercises nominal-register German through the SECTION-scoped half of
+/// `is_language_mismatch`, not just the whole-document half above.
+#[test]
+fn nominal_register_german_section_is_critical() {
+    let generated = EN_CLEAN.replace(
+        "Senior Backend Engineer | Acme Payments | 2021 - Present\n\
+        - Checkout latency fell from 480ms to 90ms once a Redis cache sat in front of the \
+        ledger service\n\
+        - Ran the Docker workloads on a Kubernetes cluster that answers 12000 requests \
+        every second\n\
+        - Rewrote the retry scheduler in Rust, and failed settlements fell by 35%\n\n\
+        Backend Developer | Globex Logistics | 2018 - 2021\n\
+        - 40 warehouse sites bill through an API I wrote in Python, backed by PostgreSQL\n\
+        - Took the fleet to AWS, with the whole deployment pipeline written as Terraform",
+        "Senior Backend Engineer | Acme Payments | 2021 - Present\n\
+        - Aufbau und Betrieb der Zahlungsplattform mit Reduzierung der Wartezeit von 480ms \
+        auf 90ms\n\
+        - Leitung der Migration der Dienste auf einen Kubernetes-Cluster mit zwölftausend \
+        Anfragen pro Sekunde\n\
+        - Neuentwicklung des Wiederholungsplaners in Rust zur Reduzierung fehlgeschlagener \
+        Zahlungen\n\n\
+        Backend Developer | Globex Logistics | 2018 - 2021\n\
+        - Entwicklung der Abrechnungsschnittstelle in Python und PostgreSQL für vierzig \
+        Lagerstandorte\n\
+        - Migration der Flotte zu AWS mit Terraform als Bereitstellungswerkzeug",
+    );
+    assert!(
+        !is_language_mismatch(&generated, "en"),
+        "premise: the document-level majority vote must NOT fire — one drifted nominal- \
+         register German EXPERIENCE section inside an otherwise-English résumé is exactly \
+         the case that hides from a whole-document read"
+    );
+    let report = en_resume(&generated, &en_requirements());
+    let hits = fired(&report, CONTENT_LANGUAGE_MISMATCH);
+    assert_eq!(hits[0].severity, Severity::Critical);
+    assert!(!report.ok);
+    assert_eq!(
+        hits[0].section.as_deref(),
+        Some("EXPERIENCE"),
+        "the finding must name the drifted section, not just the document"
+    );
+}
+
+// ── Title-Case rendering also reaches the evidence branch (fr, in addition to German) ──
+
+/// The title-case-sandwich exclusion silenced more than German: ANY document
+/// rendered in Title Case (a real résumé-theme style, not a synthetic
+/// construction) put every function word between two capitalised
+/// neighbours, in every curated language. Pinned here for French — German
+/// already has nominal-register coverage above, and this proves the fix is
+/// not German-specific.
+#[test]
+fn title_case_rendered_french_document_is_critical() {
+    let fr_title_case = "La Candidate A Huit Ans D'Expérience Dans Les Systèmes De Paiement \
+        Back-End Et A Dirigé La Migration De Nos Services Vers Kubernetes En Réduisant La \
+        Latence Du Service De Paiement De Quarante Pour Cent Cette Année Dans L'Entreprise.";
+    assert!(
+        significant_chars(fr_title_case) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(fr_title_case),
+        Some("fr"),
+        "premise: must confidently read as French"
+    );
+    assert!(
+        document_language_mismatch(fr_title_case, EN_SOURCE, EN_JOB_AD, "en"),
+        "a Title-Case-rendered French document must still fire — every function word \
+         sitting between two capitalised neighbours is a rendering choice, not evidence \
+         the text is a proper noun"
+    );
+    let report = validate_content(&ContentInput {
+        generated: fr_title_case,
+        source_resume: EN_SOURCE,
+        job_ad: EN_JOB_AD,
+        top_requirements: &[],
+        target_language: "en",
+        doc_kind: DocKind::Resume,
+    });
+    let hits = fired(&report, CONTENT_LANGUAGE_MISMATCH);
+    assert_eq!(hits[0].severity, Severity::Critical);
+    assert!(!report.ok);
+}
+
 // ── BLOCKING 3 (untested section-scoped half) + design question (proper nouns) ──
 
 /// The differentiator BLOCKING 3 asked for: a fixture where reverting ONLY
@@ -2309,58 +2464,60 @@ fn pairwise_evidence_count_excludes_shared_and_single_letter_tokens() {
     assert_eq!(pairwise_evidence_count("und und und", "tr", "en"), 0);
 }
 
-/// A word sandwiched between two Title-Case neighbours is excluded — the
-/// heuristic `a_german_institution_name_inside_an_english_education_section_never_fires`
-/// relies on, isolated here on a minimal pair so the mechanism itself is
-/// pinned independent of that larger fixture.
+/// German capitalises every noun, so a nominal-register connector
+/// ("Aufbau und Betrieb der Zahlungsplattform") sits between two capitalised
+/// words exactly as often as a proper noun's own connector does — a
+/// title-case-sandwich exclusion tried in `pairwise_evidence_count` could not
+/// tell the two apart and deleted German's evidence wholesale (see the
+/// module doc's `MIN_DISTINCTIVE_HITS` history). Pinned here directly: this
+/// exact shape must still count.
 #[test]
-fn a_connector_between_two_title_case_words_is_excluded_as_a_proper_noun() {
+fn a_connector_between_two_title_case_words_still_counts() {
     use super::language::pairwise_evidence_count;
 
-    // "und" between two Capitalised words reads as part of a compound proper
-    // noun ("Technik und Wirtschaft") and is excluded; "Technik"/"Wirtschaft"
-    // themselves are not German function words, so this is the whole count.
     assert_eq!(
         pairwise_evidence_count("Technik und Wirtschaft", "de", "en"),
-        0
-    );
-    // The SAME word in ordinary sentence position (lowercase neighbours) is
-    // not excluded — this is what keeps genuine German prose evidenced. "die"
-    // (article) also survives, so this fixture counts both.
-    assert_eq!(
-        pairwise_evidence_count("die technik und wirtschaft wuchsen", "de", "en"),
-        2
-    );
-    // A sentence-initial capital on ONE side only is not a proper-noun
-    // sandwich — only BOTH neighbours capitalised excludes a hit. "Und" and
-    // "die" both survive here for the same reason.
-    assert_eq!(
-        pairwise_evidence_count("Und die technik wuchs", "de", "en"),
-        2
+        1,
+        "\"und\" between two Capitalised words is ordinary German nominal register, \
+         not a signal to exclude it"
     );
 }
 
 /// `distinctive_evidence_confirms`'s absolute floor, isolated: `found`'s
-/// pairwise evidence must clear `MIN_DISTINCTIVE_HITS` (a single hit is
-/// noise, not evidence); a non-Latin-script `found` skips the requirement
-/// entirely regardless of evidence, since `needs_distinctive_evidence` never
-/// asks a script whatlang already reads reliably to corroborate itself.
+/// pairwise evidence must clear [`MIN_DISTINCTIVE_HITS`] (below it, a match
+/// is noise); a non-Latin-script `found` skips the requirement entirely
+/// regardless of evidence, since `needs_distinctive_evidence` never asks a
+/// script whatlang already reads reliably to corroborate itself.
 ///
-/// A second, COMPARATIVE bar (`found`'s evidence must EXCEED `target`'s own
-/// in the same text, not just clear the floor) was tried here and removed:
-/// disabling it left every `validate::content` behavioural test green and
-/// only a test asserting the comparative predicate directly red, so the
-/// title-case-sandwich exclusion in `pairwise_evidence_count` was already
-/// doing the real work — see the module doc for the full measurement.
+/// Mutation check (performed at the WHOLE-SUITE level, not just this
+/// isolated pair — both classes really do respond to the one constant):
+///
+/// - Floor moved to 4 (one under the shipped 5) — RAN the full
+///   `validate::content` suite: `a_german_institution_name_inside_an_english_certifications_section_never_fires`
+///   (a QUIET fixture, evidence 4) went red — a false positive reopened.
+/// - Floor moved to 7 (one over) — RAN the full suite again:
+///   `a_drifted_volunteer_section_warns_rather_than_blocks` (a FIRE fixture,
+///   evidence 6) went red — a false negative reopened.
+/// - Restored to 5; full suite green again.
+///
+/// This IS the property a shape-based exclusion cannot offer: one number,
+/// and both failure directions are visibly, mechanically tied to it.
 #[test]
-fn distinctive_evidence_confirms_requires_the_absolute_floor() {
+fn distinctive_evidence_confirms_requires_the_shipped_floor() {
     use super::language::distinctive_evidence_confirms;
 
-    // Two hits clears the floor.
-    assert!(distinctive_evidence_confirms("und und", "de", "en"));
-    // One hit alone is still noise, not evidence — even with zero target
-    // evidence to compare against.
-    assert!(!distinctive_evidence_confirms("und", "de", "en"));
+    // Below the floor (4 hits): must not confirm.
+    assert!(!distinctive_evidence_confirms(
+        "und und und und",
+        "de",
+        "en"
+    ));
+    // At the floor (5 hits): confirms.
+    assert!(distinctive_evidence_confirms(
+        "und und und und und",
+        "de",
+        "en"
+    ));
     // A non-Latin script skips the requirement outright: zero evidence, but
     // whatlang's script read is already reliable there.
     assert!(distinctive_evidence_confirms(

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -2552,6 +2552,103 @@ fn a_short_paragraph_against_a_close_relative_target_is_an_accepted_miss() {
     );
 }
 
+// ── connector-sparse German register: a THIRD accepted miss ────────────────
+
+/// **Advisory MEDIUM (confirmation review), the connector-sparse-register
+/// accepted miss.** [`MIN_DISTINCTIVE_HITS`] cannot separate "an English
+/// document that merely names a foreign institution" (correctly quiet) from
+/// "a genuinely foreign document written in a register too sparse in
+/// closed-class connectors to evidence itself" (incorrectly quiet) — both
+/// land in the SAME 0-4 evidence band, because a pure count has no way to
+/// tell them apart. Standard German CV register drops the article and the
+/// finite-verb clause a sentence would otherwise need ("Zahlungsplattform
+/// aufgebaut", not "Ich habe die Zahlungsplattform aufgebaut"), so even a
+/// WHOLE, genuinely German résumé written this way carries almost no
+/// evidence: measured here at 3, on 695 significant characters — two hits
+/// short of the floor of 5.
+///
+/// **Not recoverable by lowering the floor.** 3 is the exact value
+/// [`MIN_DISTINCTIVE_HITS`]'s own corpus table already relies on staying
+/// quiet for a genuine false positive one row up (a German institution name
+/// inside an EDUCATION section of an otherwise-English document) — a floor
+/// of 3 would reopen that false positive at the same moment it closes this
+/// false negative. This is the THIRD accepted miss this module documents,
+/// after the uncurated `tr`/`vi` miss
+/// (`turkish_text_needs_evidence_too_and_goes_quiet_without_a_curated_list`)
+/// and the close-relative-target Romance-language miss
+/// (`a_short_paragraph_against_a_close_relative_target_is_an_accepted_miss`
+/// above) — and, same as those two, a DESIGN limit, not a calibration
+/// error: recovering it needs a signal this module does not have
+/// (participle/compound morphology, or a second corroborating witness), not
+/// a threshold change. Left to a future change rather than folded into
+/// whichever fix happens to be touching this file; pinned here so that
+/// future change has something concrete to turn green — the fixture below,
+/// currently silent, firing `content.language_mismatch`.
+///
+/// Both `is_language_mismatch` AND [`document_language_mismatch`] — the
+/// SAME function `pipeline::resume::stages::draft` gates its
+/// draft-language retry on — are asserted quiet, so this pins that
+/// regeneration does not fire for this shape either, not just that the
+/// validator does not.
+#[test]
+fn a_terse_participle_register_german_resume_is_an_accepted_miss() {
+    use super::language::pairwise_evidence_count;
+
+    let de_terse = "Jane Doe\n\
+        jane.doe@example.com | +49 30 1234567 | github.com/janedoe\n\n\
+        ZUSAMMENFASSUNG\n\n\
+        Acht Jahre Zahlungsverkehr, Aufbau Container-Plattformen, Senior Backend Engineering.\n\n\
+        BERUFSERFAHRUNG\n\n\
+        Senior Backend Engineer, Acme Payments, 2021 - heute\n\
+        - Zahlungsplattform aufgebaut, Wartezeit gesenkt: 480ms auf 90ms\n\
+        - Migration Kubernetes-Cluster geleitet, zwölftausend Anfragen pro Sekunde\n\
+        - Wiederholungsplaner neu entwickelt in Rust, fehlgeschlagene Zahlungen reduziert\n\n\
+        Backend Developer, Globex Logistics, 2018 - 2021\n\
+        - Abrechnungsschnittstelle entwickelt in Python, PostgreSQL, vierzig Lagerstandorte\n\
+        - Flotte migriert zu AWS, Terraform als Bereitstellungswerkzeug\n\n\
+        KENNTNISSE\n\n\
+        Rust · Python · Docker · Kubernetes · PostgreSQL · AWS · Terraform · Redis\n\n\
+        AUSBILDUNG\n\n\
+        BSc Informatik, TU Berlin, 2014 - 2018\n";
+
+    assert!(
+        significant_chars(de_terse) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor, or the silence below proves nothing \
+         about the evidence gate specifically"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(de_terse),
+        Some("de"),
+        "premise: must confidently read as German, or this is not the shape this test claims"
+    );
+    let evidence = pairwise_evidence_count(de_terse, "de", "en");
+    assert_eq!(
+        evidence, 3,
+        "pinned measurement: a genuinely German résumé in the connector-sparse participle \
+         register carries almost no closed-class evidence even at whole-résumé length"
+    );
+    assert!(
+        evidence < 5,
+        "premise: the miss below only proves what this test claims if evidence is genuinely \
+         under MIN_DISTINCTIVE_HITS's shipped floor (5), not accidentally at or over it"
+    );
+    assert!(
+        !is_language_mismatch(de_terse, "en"),
+        "accepted miss: a genuinely German whole résumé, in the connector-sparse register \
+         real German CVs use, stays quiet — this is the gap a future recall improvement \
+         needs to close (participle/compound morphology, or a second witness), and it must \
+         do so WITHOUT reopening the EDUCATION-section false positive that sits at the same \
+         evidence count"
+    );
+    assert!(
+        !document_language_mismatch(de_terse, EN_SOURCE, EN_JOB_AD, "en"),
+        "the same accepted miss through the public entry point pipeline::resume::stages::draft \
+         gates its language-retry on — regeneration does not fire for this shape either"
+    );
+    let report = en_resume(de_terse, &en_requirements());
+    silent(&report, CONTENT_LANGUAGE_MISMATCH);
+}
+
 // ── direct unit tests for the evidence primitives (BLOCKING 3's other ask) ──
 
 /// `pairwise_evidence_count`'s exclusion rules, isolated from any whole-

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1636,16 +1636,31 @@ fn regime_5_neither_witness_corroborating_the_target_stays_quiet() {
 /// `documents::keywords::test::detected_language_identifies_*` pins at the
 /// primitive level, so a regression in either place is visible in both.
 ///
-/// The seven Latin-curated languages repeat 7×, not 3× — measured: at a
-/// single instance, the worst pairwise-evidence case across all 42
+/// Six of the seven Latin-curated languages repeat 7×, not 3× — measured: at
+/// a single instance, the worst pairwise-evidence case across all 42
 /// cross-language pairs is Spanish against a French target (Spanish and
 /// French share most of their short function words, so only "tiene" survives
-/// pairwise pruning), at 1 hit. 3 repeats would give that pair 3 hits, under
-/// [`MIN_DISTINCTIVE_HITS`]'s floor of 5; 7 repeats gives it 7, two clear of
-/// the floor. The SAME reasoning [`MIN_CHARS_FOR_LANGUAGE_CHECK`] already
-/// applies to length: a document too short is a poor candidate for a
-/// confident read, and a real wrong-language document is never this
-/// artificially terse.
+/// pairwise pruning), at 1 hit. 7 repeats gives that pair 7 hits, two clear
+/// of [`MIN_DISTINCTIVE_HITS`]'s floor. The SAME reasoning
+/// [`MIN_CHARS_FOR_LANGUAGE_CHECK`] already applies to length: a document too
+/// short is a poor candidate for a confident read, and a real wrong-language
+/// document is never this artificially terse.
+///
+/// **Spanish itself stays at 3×, not 7×, and that is deliberate, not an
+/// oversight.** Uniformly inflating every language to clear the WORST pair
+/// left this the only test exercising non-English targets, and it exercised
+/// them exclusively at 441 characters — never in the 120–315 character band
+/// where [`MIN_DISTINCTIVE_HITS`] actually decides anything, which is
+/// exactly the coverage gap that let the close-relative-target silent band
+/// (see `a_short_paragraph_against_a_close_relative_target_is_an_accepted_miss`)
+/// go unexercised here. At 3× (189 characters, squarely in that band),
+/// Spanish's evidence against French is 3 — still under the floor, still
+/// silent, the SAME accepted miss that test pins directly — while every
+/// OTHER target (`en` 18, `de` 18, `it` 15, `pt` 9, `nl` 6) clears the floor
+/// at this length; 3× was chosen, not assumed, by sweeping reps 1–7 against
+/// all six other curated targets and picking the shortest length where only
+/// the ONE known accepted-miss pair stays quiet. The cross-product test
+/// below excludes exactly that one cell, not the whole language.
 fn per_language_samples() -> Vec<(&'static str, String)> {
     let sentences: &[(&str, &str, usize)] = &[
         (
@@ -1666,7 +1681,7 @@ fn per_language_samples() -> Vec<(&'static str, String)> {
         (
             "es",
             "La candidata tiene ocho años de experiencia en sistemas de pago de backend.",
-            7,
+            3,
         ),
         (
             "it",
@@ -1770,6 +1785,17 @@ fn per_language_samples() -> Vec<(&'static str, String)> {
 /// curated-vocabulary membership, which used to let tr/vi skip corroboration
 /// entirely and fire on nothing).
 ///
+/// ONE more cell is excluded for the same reason, at the length this sample
+/// set actually uses rather than in the abstract: Spanish's sample is 189
+/// characters (3×, see [`per_language_samples`]'s doc), and at that length
+/// its evidence against a French target is 3 — under the floor, the exact
+/// close-relative-target accepted miss
+/// `a_short_paragraph_against_a_close_relative_target_is_an_accepted_miss`
+/// pins directly. Excluded here, not silenced by lengthening the sample to
+/// clear it, so this loop stays honest about what actually holds at a
+/// realistic length instead of only at the 441-character length that used to
+/// hide this cell entirely.
+///
 /// Mutation check: hardcode `is_language_mismatch` to always return `false`
 /// and every `_fires` assertion in this test goes red; hardcode it to always
 /// return `true` and every `_stays_silent` assertion goes red — the table
@@ -1786,6 +1812,11 @@ fn every_curated_language_is_silent_for_itself_and_fires_for_every_other() {
     for (lang, _) in &samples {
         for (other_lang, other_text) in &samples {
             if lang == other_lang || other_lang == &"tr" || other_lang == &"vi" {
+                continue;
+            }
+            if other_lang == &"es" && lang == &"fr" {
+                // Accepted miss at this sample's realistic 189-character length —
+                // see the doc comment above.
                 continue;
             }
             assert!(
@@ -2425,6 +2456,90 @@ fn turkish_text_needs_evidence_too_and_goes_quiet_without_a_curated_list() {
         !is_language_mismatch(tr_text, "en"),
         "an accepted miss: no curated tr vocabulary means no evidence, so this stays \
          quiet rather than firing on zero corroboration"
+    );
+}
+
+// ── es/pt/fr/it/nl: the close-relative-target silent band (accepted miss) ──
+
+/// **Advisory MEDIUM (confirmation review), the close-relative-target
+/// silent band.** [`MIN_DISTINCTIVE_HITS`] is one absolute floor for every
+/// language pair, but a genuine short paragraph in one Romance language
+/// carries far fewer PAIRWISE-distinctive words against a close relative
+/// than against a distant one — es/pt/fr/it/nl share most short function
+/// words with each other and only diverge on the handful pairwise pruning
+/// keeps. Measured: the SAME 120-150 character genuine two-sentence
+/// paragraph that clears the floor and fires cleanly against `"en"`
+/// (evidence 6) sits at evidence 1-4 — under the floor, silent — against a
+/// linguistically close target. This repo ships es/pt/it/nl locale profiles
+/// (see [`crate::locale`]), so a genuinely wrong-language document
+/// targeting one of THESE instead of English is a real, supported scenario,
+/// not a hypothetical one — the same accepted-cost shape as the DACH miss
+/// and the tr/vi miss above, pinned here so a future change to
+/// [`MIN_DISTINCTIVE_HITS`] cannot quietly start believing the floor has no
+/// blind spot among the languages this crate actually curates. Not closed
+/// here: lowering the floor to catch these would reopen the false positives
+/// [`distinctive_evidence_confirms_requires_the_shipped_floor`]'s mutation
+/// check already found at floor 4 — the same "closing one language's miss
+/// reopens another's bug" trade every other suppressor in this module hit.
+#[test]
+fn a_short_paragraph_against_a_close_relative_target_is_an_accepted_miss() {
+    use super::language::pairwise_evidence_count;
+
+    let es_two_sentences = "Trabaje como ingeniero de software durante dos anos en Madrid, \
+        con experiencia solida en Python y en sistemas distribuidos de gran escala y alta \
+        disponibilidad.";
+    assert!(
+        significant_chars(es_two_sentences) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor, or the silence below proves nothing \
+         about the evidence gate specifically"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(es_two_sentences),
+        Some("es"),
+        "premise: must confidently read as Spanish"
+    );
+    assert_eq!(
+        pairwise_evidence_count(es_two_sentences, "es", "fr"),
+        1,
+        "pinned measurement: a genuine Spanish paragraph carries almost no \
+         French-exclusive-looking evidence against French specifically"
+    );
+    assert!(
+        !is_language_mismatch(es_two_sentences, "fr"),
+        "accepted miss: Spanish text targeting French stays quiet — evidence 1 is well \
+         under the floor"
+    );
+    assert!(
+        is_language_mismatch(es_two_sentences, "en"),
+        "premise: the SAME text fires against a distant target, proving the silence above \
+         is about the LANGUAGE PAIR, not a defect in the fixture"
+    );
+
+    let pt_two_sentences = "Trabalhei como engenheiro de software em Lisboa durante dois \
+        anos, com experiência sólida em Python e em sistemas distribuídos de grande escala.";
+    assert!(
+        significant_chars(pt_two_sentences) >= MIN_CHARS_FOR_LANGUAGE_CHECK,
+        "premise: fixture must clear the char floor"
+    );
+    assert_eq!(
+        crate::documents::keywords::detected_language(pt_two_sentences),
+        Some("pt"),
+        "premise: must confidently read as Portuguese"
+    );
+    for other in ["es", "fr", "nl"] {
+        assert_eq!(
+            pairwise_evidence_count(pt_two_sentences, "pt", other),
+            4,
+            "[pt vs {other}] pinned measurement: one hit short of the floor"
+        );
+        assert!(
+            !is_language_mismatch(pt_two_sentences, other),
+            "[pt vs {other}] accepted miss: evidence 4 is one hit under the floor"
+        );
+    }
+    assert!(
+        is_language_mismatch(pt_two_sentences, "en"),
+        "premise: the SAME Portuguese text fires against a distant target"
     );
 }
 

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -2404,9 +2404,9 @@ fn needs_distinctive_evidence_is_the_nine_language_latin_script_set() {
 /// minimum, so a future edit that silently thins a list back down (the exact
 /// way the Spanish regression shipped unnoticed) fails loudly here instead of
 /// only showing up as a missed Critical three layers away. Chosen well below
-/// every language's current count (`de` 88, `en` 67, `fr` 60, `es` 60, `it`
-/// 62, `nl` 61, `pt` 61) so ordinary curation additions/removals do not make
-/// this brittle.
+/// every language's current raw list size (`en` 70, `de` 83, `fr` 68, `es`
+/// 61, `it` 65, `nl` 58, `pt` 58) so ordinary curation additions/removals do
+/// not make this brittle.
 #[test]
 fn every_curated_language_has_a_healthy_pairwise_floor_against_english() {
     const FLOOR: usize = 40;
@@ -2422,6 +2422,29 @@ fn every_curated_language_has_a_healthy_pairwise_floor_against_english() {
              entries, under the {FLOOR} floor — this is exactly how the Spanish regression \
              (30 survivors after global pruning) shipped unnoticed; investigate before \
              lowering this floor"
+        );
+    }
+}
+
+/// Hygiene guard for the class of bug a review found by inspection: `"zijn"`
+/// listed TWICE in `FUNCTION_WORDS_NL` (possessive and copula) — harmless
+/// under the current HashSet-based [`pairwise_evidence_count`] (a duplicate
+/// collapses on `.collect()`), but a silent authoring mistake nonetheless,
+/// and the SAME sweep found a second instance (`"a"` and `"se"`, each twice,
+/// in `FUNCTION_WORDS_PT`) the review did not catch by inspection. Both are
+/// fixed; this test is what keeps a third one from shipping the same way.
+#[test]
+fn no_curated_language_list_has_an_internal_duplicate() {
+    for lang in ["en", "de", "fr", "es", "it", "nl", "pt"] {
+        let words = super::language::function_words_for(lang);
+        let unique: std::collections::HashSet<&&str> = words.iter().collect();
+        assert_eq!(
+            unique.len(),
+            words.len(),
+            "{lang}'s function-word list has an internal duplicate — {} entries, {} unique; \
+             {words:?}",
+            words.len(),
+            unique.len()
         );
     }
 }


### PR DESCRIPTION
Two defects in résumé validation, both of which made the app wrong about a
document while reporting nothing.

## 1. A date column spelled `Today` merged two employers into one

`is_date_only` matched present-tense markers by exact token equality against
`PRESENT_MARKERS`, which never carried English `Today` or its Romance
equivalents. An entry line ending in one failed to open its own role, so the
employer header **and all of its bullets** were absorbed into the entry above
it — one job's work credited to a different company.

Measured before the fix:

```
is_date_only("2020 - Present")     = true
is_date_only("2020 - Today")       = false   ← defect
is_date_only("2015 - Actualidad")  = false
is_date_only("2019 - Aujourd'hui") = false
```

Widening it surfaced eight more live spellings, including two where an
already-passing form sat one letter away from a failing one: `Present` passed
but `Presente` did not, `current` passed but `Currently` did not. English is
the default locale, so `2020 – Currently` was a defect on the primary path,
not only an i18n edge. Review found a further one — the list carried
Portuguese `atualmente` but not Spanish `actualmente`.

The spellings live in a **separate** `DATE_ONLY_MARKERS` list rather than
being added to `PRESENT_MARKERS`, and that separation is load-bearing.
`PRESENT_MARKERS` is matched as a single word anywhere in free text by
`is_open_ended` and by `validate::content::factual::unsupported_date_issues`;
putting `today` or `currently` there would turn an ordinary bullet into a date
context. `is_date_only` cannot make that mistake because it requires every
token on the line to be a digit, month or marker. A test now enforces the two
lists stay disjoint, so the invariant no longer depends on someone reading a
doc comment.

## 2. A truthful English résumé was flagged as the wrong language

`whatlang`'s `confidence()` is a **top-1 vs top-2 margin, not a probability**.
A noun-phrase-heavy block — a skills line, a terse CV — starves its n-gram
model of the function words it needs, so a truthful English document reads as
French at confidence `1.0000` with `is_reliable() == true`. That raised a
`content.language_mismatch` Critical, which blanks `keywordCoverage` and
suppresses every alignment finding on a correct document.

The fix requires positive evidence — function words distinctive to a language
other than the target — before a confident read becomes an accusation. The
rule is deliberately *positive evidence of a different language*, never
*absence of the target's*, because the latter fires on the terse English CV
again by a new route.

## Three designs were tried in this PR and taken back out

Recorded because the reasoning is the useful part. All three were caught by
mutation or by measurement, none by reading, and every one of them looked
correct and argued well.

**A globally-pruned evidence pool.** Pooling all seven word lists and dropping
any token appearing twice looked strictly safer — it can only make the guard
quieter. It killed Spanish. Every high-frequency Spanish function word
(`de`, `la`, `un`, `en`, `con`, `por`) collides with another list and was
pruned, leaving 30 survivors, none of which appear in a real CV. Four of five
realistic Spanish documents stopped raising a Critical that `main` raises
today, taking the draft-stage language retry down with them. Replaced with
**pairwise** evidence: a word only excludes when the language it is compared
*against* shares it.

**A short-token denylist and a comparative margin.** Both added as defence in
depth. Mutation showed no behavioural test depended on either — disabling each
failed only its own unit test. A sweep did find one input needing the denylist
(`au` repeated as disconnected French idioms with no connecting English
grammar), judged adversarial rather than representative and weighed against a
measured cost: denylisting `el` sat one hit from Spanish's margin. Deleted.

**A title-case-sandwich exclusion**, which ignored a function word sitting
between two capitalised neighbours on the theory that it was inside a proper
noun. **German capitalises every noun.** The standard German CV register is
nominal — "Aufbau und Betrieb der Zahlungsplattform" — so every connector sits
between two capitalised nouns and was discarded. A genuinely German document
dropped from 10 evidence hits to 1 and went silent, and with the flag false,
the English keyword-density check then ran over German text — the exact false
accusation its own doc says it exists to prevent. Deleted.

The common shape: each one encoded an assumption about what real text looks
like, and each assumption was wrong for some language. "Collisions remove
themselves" was wrong for Spanish. "Short tokens are ambiguous" was
unprovable. "Function words between capitals are inside proper nouns" was
wrong for German. What shipped instead assumes nothing about shape — only
quantity: a floor of 5 distinctive pairwise hits, derived from a corpus sweep
and mutation-checked in both directions (a floor of 4 reopens a false
positive, 7 reopens a false negative).

**This cannot introduce a false positive.** The new predicate is the old one
ANDed with the evidence requirement, so its fire set is a strict subset of
what `main` already reports. Everything below is a pre-existing gap that this
PR narrows, never a new one.

**Known limits, stated rather than papered over.** A count cannot fully
separate an unusually credentialed English CV from a short genuine foreign
paragraph. The boundary is language-dependent, and French is the worst case
rather than German — French official names are function-word dense
("Institut **de** Recherche **en** Informatique **et en** Automatique" is four
hits by itself), so two of them in an EDUCATION section reach the floor, where
German needs six. A realistic English CV with three German employers reads as
English with zero evidence and stays silent.

The floor also leaves a short genuine foreign paragraph silent against a
close-relative target — Portuguese against Spanish, Spanish against French —
where there is not room to accumulate five hits. Both limits are pinned by
tests as accepted misses. Given this file's history of three consecutive false
negatives, the floor is set to protect the true positive.

## Scope

`validate::content` is not called from `export/` (ADR-034). A Critical parks a
run at `needsReview`; it does not block an export. This changes when the
Critical is raised, not what it gates.

## Found here, fixed separately

Two defects confirmed by measurement during this work and deliberately left
out to keep the diff reviewable:

- `is_open_ended` returns true on ordinary prose containing `current`,
  `ongoing` or `actual` at a word boundary, so
  `factual::unsupported_date_issues` treats such a line as a date context.
  Measured: `is_open_ended("Reduced actual costs by 20% in 2023") == true`.
- `scraping/rate_limiter/mod.rs` computes `now - t` on `u64` wall-clock
  milliseconds. Wall-clock is not monotonic; a backwards step underflows —
  debug panics, release wraps and retains the entry forever. Reproduced twice
  under parallel load, not reproducible in isolation.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-features --locked
--all-targets -- -D warnings`, and `cargo test --all-features --locked`
(without `--lib`, which skips `tests/*.rs`): 4381 lib + 18 architecture + 20
egress + 3 eval + 3 pipeline_kill_recovery, zero failures.

Every guard added here has a mutation check on record: delete the feature, not
the key, and watch the test go red. That includes the two guards that were
deleted for failing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved recognition of date-only columns, including localized “Today” markers and additional date formats.
  * Preserved correct handling of employer names, dates, and bullet points when processing unparsed entries.
  * Improved language validation by requiring stronger linguistic evidence, reducing false mismatches from names, short phrases, and ambiguous text.
  * Applied consistent language checks across entire documents and individual sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->