### PR TITLE
fix(ats): stop false date-context criticals, and route translation through the active provider

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -1096,24 +1096,6 @@ pub fn resolve_by_name(name: &str, base_url: Option<String>) -> AppResult<Box<dy
     Ok(resolve(provider_id, base_url))
 }
 
-/// Discover a reachable local chat model for `provider_id`.
-///
-/// Returns `Some(model_name)` only when the provider is reachable and has an
-/// available chat model. CLI agents and cloud providers always return `None`.
-pub async fn reachable_chat_model(provider_id: ProviderId) -> Option<String> {
-    match provider_id {
-        ProviderId::Ollama => {
-            let (reachable, model) = ollama::reachable_model().await;
-            if reachable {
-                model
-            } else {
-                None
-            }
-        }
-        _ => None,
-    }
-}
-
 // ── Embeddings ────────────────────────────────────────────────────────────────
 
 /// Vector-FORMAT version — bumped whenever the ALGORITHM that produces a
@@ -1313,10 +1295,19 @@ pub fn friendly_api_error(
     }
 }
 
-/// Map a *transport* failure (the `send()` that raced a completion HTTP call
-/// never got a response at all) to `AppError::Timeout` or `AppError::Network`.
-/// Distinct from [`friendly_api_error`], which maps a response the server DID
-/// send back.
+/// Map a *transport* failure (the `send()` that raced an HTTP call never got a
+/// response at all) to `AppError::Timeout` or `AppError::Network`. Distinct
+/// from [`friendly_api_error`], which maps a response the server DID send
+/// back.
+///
+/// Named for its original completion call sites but equally correct for any
+/// other request against the same pooled client (list-models, model-pull,
+/// embeddings, tool-calling): the classification below depends only on
+/// `is_timeout()`, never on what the request was *for*. Ollama's embed path
+/// (`ollama::embed_with`) once mapped every transport failure — including a
+/// real embed-timeout while the daemon was up and busy — to "unreachable",
+/// which sent two separate investigations to the wrong root cause; it now
+/// routes through here too.
 ///
 /// `is_timeout()` walks `e`'s WHOLE source chain, not just this crate's own
 /// `.timeout()` call: it also matches an inner `hyper::Error::is_timeout()`

--- a/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/ollama.rs
@@ -392,7 +392,11 @@ impl AiProvider for OllamaClient {
                 "Ollama returned status: {}",
                 r.status()
             ))),
-            Err(e) => Err(AppError::Network(format!("Ollama unreachable: {e}"))),
+            Err(e) => Err(map_completion_transport_error(
+                e,
+                "Ollama",
+                timeouts::LIST_MODELS,
+            )),
         }
     }
 
@@ -451,7 +455,11 @@ impl AiProvider for OllamaClient {
             Ok(r) => r,
             Err(e) => {
                 trace.end(None, false);
-                return Err(AppError::Network(format!("Ollama unreachable: {e}")));
+                return Err(map_completion_transport_error(
+                    e,
+                    "Ollama",
+                    timeouts::OLLAMA_COMPLETION_BASELINE,
+                ));
             }
         };
         let status = resp.status();
@@ -510,7 +518,7 @@ async fn fetch_tag_models() -> AppResult<Vec<Value>> {
         .timeout(timeouts::LIST_MODELS)
         .send()
         .await
-        .map_err(|e| AppError::Network(format!("Ollama unreachable: {e}")))?;
+        .map_err(|e| map_completion_transport_error(e, "Ollama", timeouts::LIST_MODELS))?;
     if !resp.status().is_success() {
         return Err(AppError::Provider(format!(
             "Ollama returned status: {}",
@@ -552,9 +560,11 @@ pub(super) fn is_embedding_only_model(name: &str) -> bool {
 }
 
 /// The first model in an `/api/tags` body that can actually hold a chat turn.
-/// `None` when the user has ONLY embedding models installed — which is the
-/// honest answer: the caller then skips translation rather than burning a
-/// guaranteed 400 on every job ad. Pure + unit-tested.
+/// `None` when the user has ONLY embedding models installed. Used only for the
+/// system-health panel's "detected local chat model" display
+/// (`commands::system::system_health`) — job-ad translation reads the user's
+/// own ACTIVE model instead (`commands::translation::resolve_translation_target`),
+/// never this first-installed guess. Pure + unit-tested.
 pub(super) fn first_chat_model(body: &Value) -> Option<String> {
     body.get("models")
         .and_then(|m| m.as_array())
@@ -565,14 +575,13 @@ pub(super) fn first_chat_model(body: &Value) -> Option<String> {
         .map(String::from)
 }
 
-/// `(reachable, first_CHAT_model_name)` — the local health probe, and the source
-/// of the model the translation path uses.
+/// `(reachable, first_CHAT_model_name)` — the local health probe behind
+/// `system_health`'s "ai.ready"/"ai.model" fields.
 ///
-/// The chat filter is not cosmetic: this returned `arr.first()` unconditionally,
-/// so a user whose first `/api/tags` entry was `qwen3-embedding:8b` had every
-/// job-ad translation POST that model to `/api/chat` and take a 400. Eight of
-/// them in one reported session, silently — `translate_text` falls back to the
-/// untranslated original on any error, so the only trace was an `ok=false` span.
+/// The chat filter is not cosmetic: this once returned `arr.first()`
+/// unconditionally, so a user whose first `/api/tags` entry was
+/// `qwen3-embedding:8b` saw that reported as the "detected" chat model. Job-ad
+/// translation no longer calls this at all — see `first_chat_model`'s doc.
 pub async fn reachable_model() -> (bool, Option<String>) {
     match crate::net::http::shared()
         .get(format!("{}/api/tags", host()))
@@ -633,7 +642,11 @@ pub async fn embed_with(model: &str, text: &str) -> AppResult<Vec<f64>> {
         timeouts::OLLAMA_EMBED,
     )
     .await
-    .map_err(|e| format!("Ollama unreachable: {e}"))?;
+    // A real `OLLAMA_EMBED` timeout (Ollama up but busy — a cold model load is
+    // the ordinary case) used to be reported identically to a genuine
+    // connection failure ("Ollama unreachable"), which sent two separate
+    // investigations to the wrong root cause. Distinguish them.
+    .map_err(|e| map_completion_transport_error(e, "Ollama", timeouts::OLLAMA_EMBED))?;
     let status = resp.status();
     if !status.is_success() {
         let body_text =
@@ -866,7 +879,7 @@ pub async fn pull(app: &AppHandle, job_id: &str, model: &str) -> AppResult<()> {
         .json(&json!({ "model": model, "stream": true }))
         .send()
         .await
-        .map_err(|e| format!("Ollama unreachable: {e}"))?;
+        .map_err(|e| map_completion_transport_error(e, "Ollama", timeouts::MODEL_PULL))?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -1056,9 +1069,10 @@ async fn stream_chat(
     // Retried on a transient 429/5xx: this is only the handshake, so a retry
     // re-sends a request that emitted no deltas. Treating it as terminal is what
     // turned a provider rate-limit into a lost multi-minute generation.
+    let deadline = timeouts::stream_deadline(req.effort.as_deref());
     let response = super::retry::send_stream_with_retry(
         || crate::net::http::shared().post(&endpoint).json(&body),
-        timeouts::stream_deadline(req.effort.as_deref()),
+        deadline,
     )
     .await;
 
@@ -1066,7 +1080,7 @@ async fn stream_chat(
         Ok(r) => r,
         Err(e) => {
             trace.end(None, false);
-            return Err(AppError::Network(format!("Ollama unreachable: {e}")));
+            return Err(map_completion_transport_error(e, "Ollama", deadline));
         }
     };
 

--- a/apps/desktop/src-tauri/src/commands/translation.rs
+++ b/apps/desktop/src-tauri/src/commands/translation.rs
@@ -1,19 +1,22 @@
 //! Optional, local-only job-ad translation.
 //!
-//! When a job ad's detected language differs from the resume locale and a
-//! local provider (Ollama) is configured, the JD is translated before keyword
-//! extraction so ATS matching happens in the resume language. Shared platform
-//! infrastructure on top of the centralized provider layer: it routes through
-//! the same resolve() + AiProvider::complete() path as every other completion,
-//! so no provider-specific assumption leaks here.
+//! When a job ad's detected language differs from the resume locale and the
+//! user's ACTIVE AI provider (`ai_config::AiConfigStore::active_config` — the
+//! SAME provider chat/document generation reads, never a stand-in) is local,
+//! the JD is translated before keyword extraction so ATS matching happens in
+//! the resume language. Shared platform infrastructure on top of the
+//! centralized provider layer: it routes through the same resolve() +
+//! AiProvider::complete() path as every other completion, so no
+//! provider-specific assumption leaks here. Always the user's own active
+//! model — never an arbitrary pick (see [`resolve_translation_target`]).
 //!
 //! Guardrails, all of which fall back to the original text (never an error):
 //! cloud providers are excluded (ProviderId::is_local() gate) so translation
 //! never incurs an unexpected API cost; uncertain detection, an unmapped
-//! language, same-language, no reachable local model, or any LLM failure all
-//! return the original text. Results are cached in-memory for the process,
-//! keyed by job id AND a hash of the source text (see [`TranslationCache`]),
-//! under a size cap.
+//! language, same-language, no active provider, no model configured for a
+//! non-CLI-agent provider, or any LLM failure all return the original text.
+//! Results are cached in-memory for the process, keyed by job id AND a hash
+//! of the source text (see [`TranslationCache`]), under a size cap.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -22,7 +25,7 @@ use tauri::{AppHandle, Manager};
 use whatlang::Lang;
 
 use super::ai_provider::{resolve, ProviderId};
-use crate::documents::{sha256_hex, DocumentStore};
+use crate::documents::sha256_hex;
 
 /// Process-scoped translation cache, keyed by job id AND source text. Managed
 /// Tauri state.
@@ -116,25 +119,20 @@ pub async fn translate_if_needed(
         return text.to_string();
     }
 
-    // 3. Active provider must be LOCAL. Cloud providers are excluded so
-    //    translation can never incur an unexpected API cost. The server-side
-    //    active provider is the persisted embedding config (defaults to
-    //    Ollama): the only provider/model selection available without a
-    //    request-supplied provider.
-    let Some(store) = app.try_state::<DocumentStore>() else {
-        return text.to_string();
-    };
-    let cfg = store.embedding_config();
-    if !provider_allows_translation(&cfg.provider) {
-        return text.to_string();
-    }
-
-    // 4. Resolve a reachable local chat model via the provider layer.
-    //    Re-parse is infallible: provider_allows_translation confirmed it parses.
-    let Ok(provider_id) = ProviderId::parse(&cfg.provider) else {
-        return text.to_string();
-    };
-    let Some(model) = super::ai_provider::reachable_chat_model(provider_id).await else {
+    // 3-4. Resolve the provider + model from the user's ACTIVE AI config —
+    //    the SAME store chat/document generation reads
+    //    (`ai_config::AiConfigStore::active_config`), never a stand-in. Cloud
+    //    providers are excluded so translation can never incur an unexpected
+    //    API cost, even though autopilot can call this on up to
+    //    `SEMANTIC_RERANK_MAX` (20) postings per scheduled run, indefinitely.
+    //    Always the user's OWN active model — never an arbitrary pick (see
+    //    `resolve_translation_target`'s doc comment for why that matters).
+    let cfg = app
+        .state::<crate::ai_config::AiConfigStore>()
+        .active_config();
+    let Some((provider_id, model)) =
+        resolve_translation_target(cfg.active_provider.as_deref(), cfg.model.as_deref())
+    else {
         return text.to_string();
     };
 
@@ -145,7 +143,7 @@ pub async fn translate_if_needed(
          programming languages, framework names, and proper nouns exactly as written. \
          Return only the translated text, no explanations."
     );
-    let provider = resolve(provider_id, cfg.base_url.clone());
+    let provider = resolve(provider_id, cfg.base_url);
     match provider
         .complete(app, &model, &system, text, Some(0.1))
         .await
@@ -170,6 +168,33 @@ pub async fn translate_if_needed(
             text.to_string()
         }
     }
+}
+
+/// Resolve `(provider_id, model)` for a translation request from the active
+/// AI config — `None` means skip translation and fall back to the original
+/// text: no active provider, a metered (non-local) provider, or a model
+/// [`ProviderId::validate_model`] rejects (empty on anything but a CLI
+/// agent, which validly falls back to the tool's own default). Pure, so it
+/// is directly unit-testable without an `AppHandle` — extracted for the same
+/// reason `pipeline::Completer::resolve_parts` is.
+///
+/// Always the user's OWN active model — never an arbitrary pick. A previous
+/// version of this path picked whatever chat model Ollama's `/api/tags`
+/// happened to list first, which once sent a 27B model to translate one job
+/// ad: 117 seconds, starving the concurrent embedding calls' 15s timeout for
+/// the whole run.
+fn resolve_translation_target(
+    active_provider: Option<&str>,
+    model: Option<&str>,
+) -> Option<(ProviderId, String)> {
+    let active_provider = active_provider?;
+    if !provider_allows_translation(active_provider) {
+        return None;
+    }
+    let provider_id = ProviderId::parse(active_provider).ok()?;
+    let model = model.unwrap_or_default().to_string();
+    provider_id.validate_model(&model).ok()?;
+    Some((provider_id, model))
 }
 
 /// Map a `whatlang::Lang` to a BCP-47 tag for the languages we translate
@@ -391,6 +416,79 @@ mod tests {
             lang_display(lang_to_bcp47(Lang::Jpn).unwrap()),
             lang_display(lang_to_bcp47(Lang::Kor).unwrap()),
             "Japanese and Korean BCP-47 tags must not be swapped"
+        );
+    }
+
+    // ── resolve_translation_target (item 1+2: active provider, own model) ──────
+
+    #[test]
+    fn claude_code_active_provider_uses_its_own_active_model() {
+        assert_eq!(
+            resolve_translation_target(Some("claude-code"), Some("opus")),
+            Some((ProviderId::ClaudeCode, "opus".to_string()))
+        );
+    }
+
+    #[test]
+    fn claude_code_with_no_configured_model_falls_back_to_the_tools_own_default() {
+        // CLI agents validly run with an empty model (the tool's own default) —
+        // `validate_model` allows it, so translation must still proceed rather
+        // than skip.
+        assert_eq!(
+            resolve_translation_target(Some("claude-code"), None),
+            Some((ProviderId::ClaudeCode, String::new()))
+        );
+    }
+
+    #[test]
+    fn ollama_uses_the_configured_model_never_an_arbitrary_one() {
+        // Two distinct configured models must echo back UNCHANGED — proof this
+        // is never a hardcoded or "first installed" pick, only ever what the
+        // caller passed in as the active model.
+        assert_eq!(
+            resolve_translation_target(Some("ollama"), Some("qwen3.6:27b-q4_K_M")),
+            Some((ProviderId::Ollama, "qwen3.6:27b-q4_K_M".to_string()))
+        );
+        assert_eq!(
+            resolve_translation_target(Some("ollama"), Some("gemma4:9b")),
+            Some((ProviderId::Ollama, "gemma4:9b".to_string()))
+        );
+    }
+
+    #[test]
+    fn ollama_with_no_configured_model_skips_translation() {
+        // Unlike a CLI agent, Ollama has no "tool's own default" to fall back
+        // to — an unconfigured model must skip, never silently pick one.
+        assert_eq!(resolve_translation_target(Some("ollama"), None), None);
+    }
+
+    #[test]
+    fn metered_providers_skip_translation_regardless_of_model() {
+        for provider in [
+            "openai",
+            "anthropic",
+            "gemini",
+            "ollama-cloud",
+            "openai-compatible",
+        ] {
+            assert_eq!(
+                resolve_translation_target(Some(provider), Some("some-model")),
+                None,
+                "{provider} must never receive a translation call"
+            );
+        }
+    }
+
+    #[test]
+    fn no_active_provider_skips_translation() {
+        assert_eq!(resolve_translation_target(None, Some("opus")), None);
+    }
+
+    #[test]
+    fn unknown_provider_string_skips_translation() {
+        assert_eq!(
+            resolve_translation_target(Some("unknown-provider"), Some("x")),
+            None
         );
     }
 }

--- a/apps/desktop/src-tauri/src/commands/translation.rs
+++ b/apps/desktop/src-tauri/src/commands/translation.rs
@@ -24,7 +24,7 @@ use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
 use whatlang::Lang;
 
-use super::ai_provider::{resolve, ProviderId};
+use super::ai_provider::{ollama, resolve, ProviderId};
 use crate::documents::sha256_hex;
 
 /// Process-scoped translation cache, keyed by job id AND source text. Managed
@@ -127,14 +127,32 @@ pub async fn translate_if_needed(
     //    `SEMANTIC_RERANK_MAX` (20) postings per scheduled run, indefinitely.
     //    Always the user's OWN active model — never an arbitrary pick (see
     //    `resolve_translation_target`'s doc comment for why that matters).
-    let cfg = app
-        .state::<crate::ai_config::AiConfigStore>()
-        .active_config();
+    let Some(ai_config) = app.try_state::<crate::ai_config::AiConfigStore>() else {
+        return text.to_string();
+    };
+    let cfg = ai_config.active_config();
     let Some((provider_id, model)) =
         resolve_translation_target(cfg.active_provider.as_deref(), cfg.model.as_deref())
     else {
         return text.to_string();
     };
+
+    // Ollama specifically: a fast reachability probe before the completion
+    // call — the same HEALTH-timeout (3s) check the now-deleted
+    // `reachable_chat_model` used to gate on before this function switched
+    // from the embedding config to the active-provider config. Without it, an
+    // unreachable OR merely slow/busy local daemon eats the full completion
+    // deadline (minutes, scaled by effort — see `timeouts::OLLAMA_COMPLETION_BASELINE`)
+    // per translation attempt instead of a fast skip, which is exactly the
+    // run-starving shape this file's own module doc + this fix's own commit
+    // message describe. A CLI agent has no analogous cheap health check and
+    // is not gated here — its own `.complete()` call fails fast when the
+    // binary is missing or unauthenticated.
+    if provider_id == ProviderId::Ollama
+        && !should_attempt_translation(provider_id, ollama::reachable_model().await.0)
+    {
+        return text.to_string();
+    }
 
     // 5. Translate through the centralized provider layer.
     let target_display = lang_display(target_lang);
@@ -195,6 +213,17 @@ fn resolve_translation_target(
     let model = model.unwrap_or_default().to_string();
     provider_id.validate_model(&model).ok()?;
     Some((provider_id, model))
+}
+
+/// Whether `translate_if_needed` should proceed to the completion call, given
+/// whether Ollama's fast reachability probe (if it ran) reported the daemon
+/// reachable. Only [`ProviderId::Ollama`] is gated by `ollama_reachable` — a
+/// CLI agent has no analogous cheap health check, so it always proceeds and
+/// relies on its own `.complete()` call failing fast when the binary is
+/// missing or unauthenticated. Pure, so the gate is unit-testable without a
+/// live Ollama daemon.
+fn should_attempt_translation(provider_id: ProviderId, ollama_reachable: bool) -> bool {
+    provider_id != ProviderId::Ollama || ollama_reachable
 }
 
 /// Map a `whatlang::Lang` to a BCP-47 tag for the languages we translate
@@ -490,5 +519,31 @@ mod tests {
             resolve_translation_target(Some("unknown-provider"), Some("x")),
             None
         );
+    }
+
+    // ── should_attempt_translation (Ollama reachability gate) ──────────────
+
+    #[test]
+    fn an_unreachable_ollama_daemon_is_gated_before_the_completion_call() {
+        assert!(!should_attempt_translation(ProviderId::Ollama, false));
+        assert!(should_attempt_translation(ProviderId::Ollama, true));
+    }
+
+    #[test]
+    fn a_cli_agent_has_no_reachability_gate() {
+        // CLI agents have no cheap health check, so `ollama_reachable` (always
+        // `false` here — the caller never runs the probe for a non-Ollama
+        // provider) must not skip them.
+        for provider in [
+            ProviderId::ClaudeCode,
+            ProviderId::Codex,
+            ProviderId::GeminiCli,
+            ProviderId::Antigravity,
+        ] {
+            assert!(
+                should_attempt_translation(provider, false),
+                "{provider:?} must proceed regardless of the (irrelevant) Ollama probe"
+            );
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/documents/embedding.rs
+++ b/apps/desktop/src-tauri/src/documents/embedding.rs
@@ -1,0 +1,221 @@
+//! Embedding round-trips + the posting-vector cache resolver.
+//!
+//! Split out of `documents/mod.rs` (R8's hard LOC cap) — a self-contained
+//! concern: routes through the centralized provider layer using the
+//! persisted embedding config, so embeddings are provider-aware (Ollama /
+//! OpenAI / Gemini) and every vector is tagged with the space that produced
+//! it. No provider/endpoint strings live here. Every item below is
+//! re-exported at `documents::` (see the `mod embedding;` line in
+//! `documents/mod.rs`) so this split is invisible to every existing
+//! `crate::documents::X` call site.
+
+use tauri::{AppHandle, Manager};
+
+use super::{DocumentStore, EmbeddingConfig};
+use crate::commands::ai_provider::{EmbeddingVector, ProviderId};
+use crate::error::AppResult;
+use crate::observability::sanitize_reason;
+
+pub async fn embed(app: &AppHandle, text: &str) -> AppResult<EmbeddingVector> {
+    let cfg = app.state::<DocumentStore>().embedding_config();
+    let provider = ProviderId::parse(&cfg.provider).map_err(|e| {
+        tracing::warn!(
+            "embed failed: unknown embedding provider '{}': {e}",
+            cfg.provider
+        );
+        e
+    })?;
+    let result = crate::commands::ai_provider::embed_text(
+        app,
+        provider,
+        &cfg.model,
+        cfg.base_url.clone(),
+        text,
+    )
+    .await;
+    // The model, not just the provider — answering "which embedding model
+    // actually ran?" used to require watching Ollama's API from outside.
+    match &result {
+        Ok(_) => tracing::debug!(provider = %cfg.provider, model = %cfg.model, "embed ok"),
+        // `e` can be `AppError::Network` wrapping a raw `reqwest::Error` —
+        // Gemini authenticates via a `?key=` query param, so an unsanitized
+        // transport-failure message here could echo it straight into the log.
+        Err(e) => tracing::warn!(
+            provider = %cfg.provider,
+            model = %cfg.model,
+            "embed failed: {}",
+            sanitize_reason(&e.to_string())
+        ),
+    }
+    result
+}
+
+/// Lowercase-hex SHA-256 of `text`. Deterministic and stable across process
+/// restarts (unlike `DefaultHasher`/`RandomState`), so it is safe as the
+/// cross-session cache guard for both `posting_vectors.text_hash` and
+/// `match_scores.job_text_hash`. Single source of the hash for both caches.
+pub(crate) fn sha256_hex(text: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(text.as_bytes());
+    h.finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut acc, b| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{b:02x}");
+            acc
+        })
+}
+
+/// Whether `id` belongs to a synthetic, content-addressed SCORING identity
+/// (`adhoc:…` from the extension bridge, `autopilot:…` / `autopilot-resume:…`
+/// from the headless re-rank) rather than a real `documents` row.
+///
+/// The app-wide convention for such an id is a `<namespace>:` prefix; a real
+/// document id is `doc-<millis>-<uuid8>` (see `make_doc_id`) and never
+/// contains a colon. Used by `upsert_vector_with_conn` to keep the DOCUMENT
+/// index free of rows that have no document: nothing would ever delete them
+/// (document delete and re-embed both iterate real documents; `prune_caches`
+/// only touches `posting_vectors`/`match_scores`), and
+/// `DocumentStore::count_vectors_in_space` counts every row — so one orphan
+/// makes the Embeddings panel report "N/N indexed, stale 0" over an index that
+/// is genuinely stale.
+pub(crate) fn is_synthetic_scoring_id(id: &str) -> bool {
+    id.contains(':')
+}
+
+/// Cache-precedence predicate for the posting-vector cache: a cached row is a
+/// HIT iff its embedding space matches the `active` config AND it was stored for
+/// the exact text we're requesting (`requested_hash == cached.text_hash`). A
+/// `None` row (no cached vector) is always a miss. This is the single source of
+/// the resolver's cache-hit decision — [`posting_vector_or_embed`] calls it so a
+/// reverted/loosened check fails a unit test (see documents/test.rs).
+pub(crate) fn posting_vector_is_fresh(
+    active: &EmbeddingConfig,
+    requested_hash: &str,
+    cached: Option<&(EmbeddingVector, String)>,
+) -> bool {
+    match cached {
+        Some((v, stored_hash)) => active.matches(&v.space) && stored_hash == requested_hash,
+        None => false,
+    }
+}
+
+/// ONE embedding round-trip, behind a seam.
+///
+/// The scoring kernel's only reach into the provider layer. It is a trait (not
+/// a bare `AppHandle` call) because this crate has no `tauri::test` mock-app
+/// harness: with the round-trip behind a seam, "how many provider calls did
+/// this score make, on what bytes, and what did each one cost" is a plain unit
+/// test over a real [`DocumentStore`] instead of a hand-retyped mirror of the
+/// kernel's own cache logic — which is exactly the shape that let an
+/// untranslated-hash charge predicate pass review.
+/// `pub(crate)`, not `pub`: the choke point is only a guarantee while every
+/// implementor is in this crate and reachable from `embed_charged`.
+#[async_trait::async_trait]
+pub(crate) trait Embedder: Send + Sync {
+    /// `None` on any failure — the caller degrades to keyword-only scoring.
+    async fn embed_one(&self, text: &str) -> Option<EmbeddingVector>;
+}
+
+/// A budget consulted immediately before each ACTUAL embedding round-trip.
+///
+/// The charge belongs HERE, at the call, evaluated on the exact bytes the call
+/// consumes — never in a caller that predicts the call from earlier state. The
+/// two answers diverge in practice: a caller sees the pre-translation blob (so
+/// its hash never matches the cached row for a translated posting → it charges
+/// on every total cache hit), and it cannot see the résumé-side embed at all
+/// (an evicted résumé vector then makes a real, uncharged round-trip). Same
+/// rule as `extension_bridge::answer_assist`: charge immediately before the
+/// work that reaches the provider, once per round-trip, and not at all when a
+/// cached path short-circuits.
+///
+/// `Err` means the ceiling refused: the round-trip must NOT happen.
+/// `pub(crate)` for the same reason as [`Embedder`]: "charged exactly once" is
+/// only a guarantee while every implementor is in this crate.
+pub(crate) trait EmbedBudget: Send + Sync {
+    fn charge_one_embed(&self) -> AppResult<()>;
+}
+
+/// Charge (if a budget is present) and then make one embedding round-trip.
+///
+/// The single choke point for every provider call the scoring kernel makes, so
+/// "charged exactly once per actual embed" is a property of one function rather
+/// than a convention each call site has to remember. A refused charge returns
+/// `None` — the same degrade-to-keyword-only signal as a failed embed.
+pub(crate) async fn embed_charged<E: Embedder + ?Sized>(
+    embedder: &E,
+    budget: Option<&dyn EmbedBudget>,
+    text: &str,
+) -> Option<EmbeddingVector> {
+    if let Some(budget) = budget {
+        if let Err(e) = budget.charge_one_embed() {
+            log::info!("[embed] round-trip refused by the daily ceiling: {e}");
+            return None;
+        }
+    }
+    embedder.embed_one(text).await
+}
+
+/// Production [`Embedder`]: the app's configured embedding provider.
+///
+/// `embed` already logs its own failure (see its doc), so `.ok()` here only
+/// discards the error from this `Option`-returning seam.
+pub(crate) struct AppEmbedder<'a>(pub &'a AppHandle);
+
+#[async_trait::async_trait]
+impl Embedder for AppEmbedder<'_> {
+    async fn embed_one(&self, text: &str) -> Option<EmbeddingVector> {
+        embed(self.0, text).await.ok()
+    }
+}
+
+/// Resolve the embedding for a job posting's (possibly translated) `text`,
+/// using the persisted `posting_vectors` cache. A hit avoids the embed call
+/// entirely. The cache is guarded by BOTH the active embedding space and a
+/// `text_hash` of the exact `text` passed here, so a stale or wrong-language
+/// row is a natural miss. Does NOT touch `PostingsCache` (raw-text vectors).
+///
+/// `budget` is charged only on the miss path, immediately before the call —
+/// see [`EmbedBudget`]. `active` comes from the caller (which already resolved
+/// it for its own cache key) so the hit decision and the score are computed
+/// against one snapshot of the embedding space.
+pub(crate) async fn posting_vector_or_embed<E: Embedder + ?Sized>(
+    store: &DocumentStore,
+    active: &EmbeddingConfig,
+    embedder: &E,
+    budget: Option<&dyn EmbedBudget>,
+    job_id: &str,
+    text: &str,
+) -> Option<EmbeddingVector> {
+    // Snapshot everything from the store before any await — the store methods
+    // each take/release the lock internally and return owned values, so no DB
+    // lock is held across the embed call below.
+    let hash = sha256_hex(text);
+    let cached = store.get_posting_vector(job_id);
+    // Single cache-hit decision (space + text_hash), shared with its unit test.
+    if posting_vector_is_fresh(active, &hash, cached.as_ref()) {
+        return cached.map(|(v, _)| v); // cache hit — no embed, no charge
+    }
+    let v = embed_charged(embedder, budget, text).await?;
+    // Best-effort cache write: the embed already succeeded, so a failed upsert
+    // must not fail the score — it only means the NEXT call re-embeds (and
+    // re-charges) this posting. Logged rather than dropped, because a
+    // persistently failing write is invisible otherwise and reads downstream as
+    // "the cache never hits". Never the text — but `job_id` is NOT always the
+    // opaque `board:external-id` shape it looks like: `breezy`/`pinpoint`/
+    // `themuse` build their [`crate::scraping::JobPosting::id`] as
+    // `format!("{BOARD_ID}:{url}")`, embedding the posting's full URL. Redact
+    // it with the same shape-based classifier the error already goes through,
+    // rather than hashing — that would cost every OTHER board's (the
+    // majority) debuggable `greenhouse:12345`-style id to close a leak only
+    // these three have.
+    if let Err(e) = store.upsert_posting_vector(job_id, &hash, &v) {
+        log::warn!(
+            "[documents] posting vector not cached for {}: {}",
+            crate::observability::redact_token(job_id),
+            sanitize_reason(&e.to_string())
+        );
+    }
+    Some(v)
+}

--- a/apps/desktop/src-tauri/src/documents/evidence/entry.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/entry.rs
@@ -448,11 +448,19 @@ pub fn is_open_ended(s: &str) -> bool {
         || s.trim_end().ends_with(['-', '–', '—'])
 }
 
-/// True when `s` carries a year (1900–2099) or reads as an open-ended span —
-/// the shape a date span has. Shared with the content validators so "what
-/// counts as a date" is decided in one place.
+/// True when `s` carries a year (1900–2099) — the shape a date span has.
+/// Shared with the content validators so "what counts as a date" is decided
+/// in one place.
+///
+/// **Not `|| is_open_ended(s)` — that disjunct is dead.** [`is_open_ended`]
+/// requires a year in `s` before any of its own branches run (see its doc),
+/// so it can never be true while `years_in(s)` is empty, and `years_in(s)`
+/// being non-empty already makes this function true on its own. ORing it in
+/// therefore can never change the result; it used to, back when
+/// `is_open_ended`'s first branch matched a bare present-tense marker with no
+/// year anywhere.
 pub fn looks_like_date_span(s: &str) -> bool {
-    !years_in(s).is_empty() || is_open_ended(s)
+    !years_in(s).is_empty()
 }
 
 /// A CLOSED span: two years with nothing between them but a span separator and
@@ -667,30 +675,35 @@ pub(super) fn is_date_only(s: &str) -> bool {
 /// True when one pipe/middot SEGMENT is the entry's date column: it carries a
 /// YEAR.
 ///
-/// Stricter than [`looks_like_date_span`] in exactly one dimension, and that is
-/// the point. `looks_like_date_span` is also satisfied by a bare present-tense
-/// marker with no year anywhere ([`is_open_ended`] fires on the word alone), and
-/// [`PRESENT_MARKERS`] is a list of ordinary words that real employers are named
-/// after — Current (current.com) and Current Health are both real, and "Aktuell"
-/// opens plenty of German company names. Such a segment was selected as the date
-/// column AND filtered out of the label segments, so the job TITLE was recorded
-/// as the employer and the employer as the date span.
+/// Same test as [`looks_like_date_span`] today, kept as its own named
+/// function so this call site reads as "is this segment a date column" —
+/// [`is_open_ended`] no longer independently supplies a positive here without
+/// a year (see its doc), which is what used to make the two diverge: a bare
+/// present-tense marker with no year anywhere used to satisfy
+/// `looks_like_date_span` on its own, and [`PRESENT_MARKERS`] is a list of
+/// ordinary words that real employers are named after — Current
+/// (current.com) and Current Health are both real, and "Aktuell" opens
+/// plenty of German company names. Such a segment used to get selected as
+/// the date column AND filtered out of the label segments, so the job TITLE
+/// was recorded as the employer and the employer as the date span.
 ///
-/// Deliberately NOT [`is_date_only`], which the review suggested: it is both too
-/// loose and too tight here. Too loose because a bare "Current" satisfies it
-/// (every word is a present marker, and `is_open_ended` supplies the structure),
-/// which is the failing case itself; too tight because it rejects a lone year,
-/// and this arm has always read `Senior Engineer | Acme Corp | 2022` as an entry
-/// with a one-year column. Its word test would additionally reject spellings the
-/// PARSER accepts and hands us — "2018 to 2021", "2021 bis Heute",
-/// "Jan 2018 through Mar 2021" all carry a word that is neither month, number
-/// nor marker — turning a fixed false employer into a lost date column.
+/// Deliberately NOT [`is_date_only`], which the review suggested: it is too
+/// tight here, rejecting a lone year — this arm has always read
+/// `Senior Engineer | Acme Corp | 2022` as an entry with a one-year column.
+/// Its word test would additionally reject spellings the PARSER accepts and
+/// hands us — "2018 to 2021", "2021 bis Heute", "Jan 2018 through Mar 2021"
+/// all carry a word that is neither month, number nor marker — turning a
+/// fixed false employer into a lost date column. (It is no longer "too
+/// loose" the way it once was: `is_date_only("Current")` is false today too,
+/// for the same year-required reason `is_open_ended` no longer fires on the
+/// word alone — but the lone-year rejection above still makes it the wrong
+/// test for this call site.)
 ///
 /// The residual is the pre-existing one, unchanged: a label that happens to
 /// carry a year ("2020 Ventures") still reads as the date column. Telling that
 /// apart needs the word test this rejects.
 pub(super) fn is_date_column_segment(s: &str) -> bool {
-    !years_in(s).is_empty()
+    looks_like_date_span(s)
 }
 
 /// Split `text` into `(label, dates)` when it ends in a `, <dates>` column —

--- a/apps/desktop/src-tauri/src/documents/evidence/entry.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/entry.rs
@@ -364,11 +364,16 @@ pub fn split_entry(line: &ParsedLine) -> (String, String, String) {
 /// Present-tense markers a date span can end with, in the languages the résumé
 /// pipeline supports.
 ///
-/// **Always matched with [`contains_word`], never as a bare substring.** Every
-/// entry here hides inside an ordinary word: `present` in "presented", `now` in
-/// "knowledge", `current` in "currently", `actual` in "actually". A substring
-/// comparison turns each of those into a date context and, downstream, into a
-/// false `factual.unsupported_date` Critical on a truthful bullet.
+/// Matched only through [`PRESENT_MARKER_ADJACENT_RE`] — a year immediately in
+/// front of the marker — never as a bare word search over arbitrary text.
+/// Word boundaries alone ([`contains_word`]) fixed the SUBSTRING failure
+/// (`present` inside "presented", `now` inside "knowledge"), but every entry
+/// here is ALSO an ordinary word on its own (`current`, `ongoing`, `now`,
+/// `actual`…), so a bare word-boundary search over a whole bullet still read
+/// "Reduced actual costs by 20% in 2023" and "...while keeping the ongoing
+/// migration on schedule" as date contexts and, downstream, produced a false
+/// `factual.unsupported_date` Critical on a truthful bullet. Requiring
+/// adjacency to a year is what a standalone word search cannot express.
 pub const PRESENT_MARKERS: &[&str] = &[
     "present", "current", "now", "ongoing", "heute", "aktuell", "laufend", "actuel", "actual",
     "attuale", "heden", "atual",
@@ -381,6 +386,21 @@ pub const PRESENT_MARKERS: &[&str] = &[
 static OPEN_ENDED_OPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b(?:since|seit|from|ab|depuis|desde|dal|vanaf|sinds)\s+(?:\p{L}+\.?\s+)?(?:19|20)\d{2}\b")
         .unwrap()
+});
+
+/// A [`PRESENT_MARKERS`] word immediately after a year, with nothing between
+/// but a span separator (`-`, `to`, `bis`, …): `2021 – Present`, `2019 to
+/// Present`, `2016-Present`. This is the structural signal that tells a
+/// genuine date span apart from a present-tense word sitting many words away
+/// from an unrelated year — see [`PRESENT_MARKERS`]'s doc for the false
+/// positives an unanchored word search produced. Built from [`PRESENT_MARKERS`]
+/// so the regex vocabulary can never drift from the word list it matches.
+static PRESENT_MARKER_ADJACENT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    let markers = PRESENT_MARKERS.join("|");
+    Regex::new(&format!(
+        r"(?i)\b(?:19|20)\d{{2}}\s*(?:[-–—/]|\bto\b|\bbis\b|\buntil\b|\bhasta\b|\bau\b|\bà\b|\ba\b|\btot\b|\bfino\b|\baté\b)\s*(?:{markers})\b"
+    ))
+    .unwrap()
 });
 
 /// True when `needle` (lowercase) occurs in `haystack` (lowercase) at word
@@ -408,18 +428,24 @@ pub fn contains_word(haystack_lower: &str, needle_lower: &str) -> bool {
 /// validator that only knows `Present` treats every other spelling as a closed
 /// span:
 ///
-/// 1. a present-tense marker (`2021 – Present`, `2021 – Heute`), word-bounded;
+/// 1. a present-tense marker right after a year (`2021 – Present`, `2021 –
+///    Heute`) — [`PRESENT_MARKER_ADJACENT_RE`];
 /// 2. an open-ended opener with a year (`since 2021`, `seit 2021`, `from 2021`);
 /// 3. a trailing dash with a year in front of it (`2021 –`).
+///
+/// **A bare marker with no year anywhere in `s` is not open-ended.** `s` must
+/// carry a year before any other branch is even tried — the same non-answer
+/// [`DATE_ONLY_MARKERS`] already gives for a bare `"Today"`. A whole-line
+/// caller asking whether a SOURCE résumé shows an ongoing role needs the year
+/// to already be on that line; a caller holding only a bare fragment (no year
+/// to anchor a marker to) has no date span to name one way or the other.
 pub fn is_open_ended(s: &str) -> bool {
-    let lower = s.to_lowercase();
-    if PRESENT_MARKERS.iter().any(|m| contains_word(&lower, m)) {
-        return true;
-    }
     if years_in(s).is_empty() {
         return false;
     }
-    OPEN_ENDED_OPENER_RE.is_match(s) || lower.trim_end().ends_with(['-', '–', '—'])
+    PRESENT_MARKER_ADJACENT_RE.is_match(s)
+        || OPEN_ENDED_OPENER_RE.is_match(s)
+        || s.trim_end().ends_with(['-', '–', '—'])
 }
 
 /// True when `s` carries a year (1900–2099) or reads as an open-ended span —
@@ -514,37 +540,37 @@ const MONTH_TOKENS: &[&str] = &[
 /// "Today"/"currently"-family present-tense markers recognised **only** by
 /// [`is_date_only`] — deliberately never added to [`PRESENT_MARKERS`], which
 /// [`is_open_ended`] and `validate::content::factual::unsupported_date_issues`
-/// both also consult, and never merged with either by stem/prefix matching.
+/// both also consult (the latter through [`trailing_date_column`]), and never
+/// merged with either by stem/prefix matching.
 ///
-/// **Why a separate list at all — measured, not just cautious.** Those two
-/// consumers match a SINGLE WORD anywhere in arbitrary text via
-/// [`contains_word`]/`contains_phrase` — no year, no separator, no other date
-/// structure required, because `is_open_ended`'s first branch returns as soon
-/// as the word is found. Every spelling here is ordinary prose in its
-/// language, not just "today": "currently" ("we are currently migrating"),
-/// "derzeit", "actuellement", "presente" (also an ordinary Spanish/Portuguese/
-/// Italian adjective — "el problema presente"). Putting any of them in
-/// [`PRESENT_MARKERS`] would turn a matching bullet into a date context and,
-/// in `unsupported_date_issues` specifically, risk a false
-/// `factual.unsupported_date` Critical the moment that bullet also names a
-/// year the source résumé doesn't. (Confirmed the same failure mode is
-/// already live for `actual`, which IS in [`PRESENT_MARKERS`] for Spanish
-/// `actual` — `is_open_ended` returns true for "Reduced actual costs by 20%
-/// in 2023" on the word alone; see the handoff for the measurement.)
-/// [`is_date_only`] cannot make that mistake: it already requires EVERY token
-/// on the line to be a digit, a month or a marker, so a prose sentence
-/// carrying any other word is rejected before this list is ever consulted —
-/// exact-token equality against a whole date column is structurally safe in a
-/// way word-bounded matching against free text is not.
+/// **Why a separate list at all — measured, not just cautious.** Both
+/// consumers now require date STRUCTURE — a year adjacent to the marker, or a
+/// parsed `JobEntry`/comma-tail date column — not just the word's presence.
+/// That structural requirement is what this list has never needed: every
+/// spelling here is ordinary prose in its language, not just "today":
+/// "currently" ("we are currently migrating"), "derzeit", "actuellement",
+/// "presente" (also an ordinary Spanish/Portuguese/Italian adjective — "el
+/// problema presente"). Putting any of them in [`PRESENT_MARKERS`] would let
+/// `is_open_ended` treat a bare occurrence next to an unrelated year as an
+/// open span. [`is_date_only`] cannot make that mistake even without the
+/// adjacency requirement: it already requires EVERY token on the line to be a
+/// digit, a month or a marker, so a prose sentence carrying any other word is
+/// rejected before this list is ever consulted — exact-token equality against
+/// a whole date column is structurally safe in a way word-bounded matching
+/// against free text was not. (`is_open_ended`'s marker branch used to match
+/// a bare word anywhere in arbitrary text — no year, no separator required —
+/// which read "Reduced actual costs by 20% in 2023" as an open-ended span on
+/// the word `actual` alone; fixed by requiring [`PRESENT_MARKER_ADJACENT_RE`]
+/// instead of a bare [`contains_word`] search.)
 ///
 /// **Why literal spellings, never a shared stem.** `actual`/`actuel`/
 /// `actualidad`/`atualmente`/`attualmente` all share a Latin root and a
 /// prefix rule would collapse them into one entry, but this const is already
 /// read by a whole-line gate today and nothing stops a future caller reading
-/// it against free text the way [`PRESENT_MARKERS`] is — the exact hazard the
-/// paragraph above documents. A literal list stays safe under a change of
-/// consumer; a prefix rule would not, so every spelling is listed in full
-/// even where it costs a near-duplicate entry.
+/// it against free text the way [`PRESENT_MARKERS`] used to be — the exact
+/// hazard the paragraph above documents. A literal list stays safe under a
+/// change of consumer; a prefix rule would not, so every spelling is listed
+/// in full even where it costs a near-duplicate entry.
 ///
 /// **`aujourd'hui`** is split by [`word_tokens`] into `aujourd` and `hui` —
 /// the apostrophe is not alphanumeric — so both halves are listed;

--- a/apps/desktop/src-tauri/src/documents/evidence/entry.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/entry.rs
@@ -653,6 +653,21 @@ pub(super) const DATE_ONLY_MARKERS: &[&str] = &[
 /// year ("Acme Corp, 2022") no longer opens a role, so its bullets continue the
 /// entry above it. That is the pre-existing behaviour for every unrecognised
 /// line, and it invents nothing.
+///
+/// The open end is read from the marker TOKEN, not from [`is_open_ended`],
+/// and [`PRESENT_MARKERS`] is checked here exactly the way [`DATE_ONLY_MARKERS`]
+/// beside it always was. [`is_open_ended`] requires an explicit span separator
+/// (`-`, `to`, `bis`, …) because it also runs against prose; this function
+/// never sees prose, because the `date_words` gate above has already rejected
+/// any line carrying a word that is not a digit, a month or a marker. Routing
+/// the separator-free column (`2015 Present`, `2015 Heute` — a shape
+/// `export::parser::DATE_RE` accepts) through `is_open_ended` therefore
+/// borrowed a restriction that protects a different caller: the column stopped
+/// opening a role, its bullets rejoined the entry above, employer salvage
+/// never ran, and `factual::unsupported_date_issues` — which reads date
+/// context through [`trailing_date_column`] — went silent on those lines.
+/// The two lists stay disjoint (asserted in the test suite); this reads both,
+/// it does not merge them.
 pub(super) fn is_date_only(s: &str) -> bool {
     let tokens = word_tokens(s);
     let date_words = tokens.iter().all(|t| {
@@ -667,9 +682,9 @@ pub(super) fn is_date_only(s: &str) -> bool {
     !date_spans(s).is_empty()
         || is_open_ended(s)
         || tokens.iter().any(|t| MONTH_TOKENS.contains(&t.as_str()))
-        || tokens
-            .iter()
-            .any(|t| DATE_ONLY_MARKERS.contains(&t.as_str()))
+        || tokens.iter().any(|t| {
+            DATE_ONLY_MARKERS.contains(&t.as_str()) || PRESENT_MARKERS.contains(&t.as_str())
+        })
 }
 
 /// True when one pipe/middot SEGMENT is the entry's date column: it carries a

--- a/apps/desktop/src-tauri/src/documents/evidence/test.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/test.rs
@@ -387,6 +387,40 @@ fn open_ended_spans_are_recognised_in_every_spelling() {
     }
 }
 
+/// Every [`PRESENT_MARKERS`] spelling — driven off the list itself, so a
+/// future addition to the list is covered automatically without anyone
+/// remembering to extend this test by hand. This is the complement to
+/// [`open_ended_spans_are_recognised_in_every_spelling`]'s hardcoded literals
+/// above: a list-driven loop alone would not catch a marker silently dropped
+/// FROM the regex construction while staying in the list (both would drift
+/// together), so the hardcoded spellings stay as the independent check for
+/// that.
+#[test]
+fn every_present_marker_opens_a_span_adjacent_to_a_year() {
+    let broken: Vec<&str> = PRESENT_MARKERS
+        .iter()
+        .filter(|m| !is_open_ended(&format!("2021 - {m}")))
+        .copied()
+        .collect();
+    assert!(
+        broken.is_empty(),
+        "not recognised adjacent to a year: {broken:?}"
+    );
+
+    // And the mirror: none of them alone, with no year anywhere, is a span —
+    // the accepted-loss case this fix trades for correctness (see
+    // `is_open_ended`'s doc comment).
+    let bare_still_open: Vec<&str> = PRESENT_MARKERS
+        .iter()
+        .filter(|m| is_open_ended(m))
+        .copied()
+        .collect();
+    assert!(
+        bare_still_open.is_empty(),
+        "bare marker with no year must not be open-ended: {bare_still_open:?}"
+    );
+}
+
 #[test]
 fn contains_word_respects_boundaries() {
     assert!(contains_word("this is vital work", "vital"));

--- a/apps/desktop/src-tauri/src/documents/evidence/test.rs
+++ b/apps/desktop/src-tauri/src/documents/evidence/test.rs
@@ -421,6 +421,73 @@ fn every_present_marker_opens_a_span_adjacent_to_a_year() {
     );
 }
 
+/// A separator-free date column still opens a role — and the three prose
+/// controls the whole `is_open_ended` tightening exists for stay closed.
+///
+/// `trailing_date_column` is the "does this line open a role?" predicate five
+/// callers share (`documents::evidence`, `validate::content::{ats, factual,
+/// split_sections}` and `credentials::education`). It answers through
+/// [`is_date_only`], which used to reach a separator-free column
+/// (`…, 2015 Present`) only via [`is_open_ended`]. When that function started
+/// requiring an explicit span separator, the column stopped being a column:
+/// the bullets under it silently joined the entry above, employer salvage
+/// never ran, and `unsupported_date_issues` went quiet on those lines.
+///
+/// [`is_date_only`] can read a bare marker safely where [`is_open_ended`]
+/// cannot, and the difference is structural rather than a judgement call:
+/// every token on the line must already be a digit, a month or a marker, so
+/// prose is rejected before any marker list is consulted. The three prose
+/// controls at the bottom assert exactly that — they are the defect this PR
+/// was opened for, and they must stay false however loose the column reading
+/// gets.
+#[test]
+fn a_separator_free_date_column_opens_a_role_without_reopening_the_prose_leak() {
+    for column in [
+        "2015 Present",     // no separator at all — the regression
+        "2015 Heute",       // …in German
+        "2015 - Present",   // dash
+        "2015 – Present",   // en dash
+        "(2015 - Present)", // parenthesised
+        "2015 - 2018",      // closed span
+        "Jan 2022",         // month + year
+    ] {
+        let line = format!("Acme Payments, Berlin, {column}");
+        assert_eq!(
+            trailing_date_column(&line),
+            Some(("Acme Payments, Berlin", column)),
+            "{column:?} must read as a date column"
+        );
+    }
+
+    // Negative controls — a line that merely MENTIONS a year is not a column,
+    // and a lone year is the documented, deliberate non-answer. Without these
+    // the loop above passes for a `trailing_date_column` that accepts any
+    // comma tail carrying a digit.
+    assert_eq!(
+        trailing_date_column("Owned the ledger rewrite, delivered in 2019"),
+        None,
+        "prose ending in a year is not a date column"
+    );
+    assert_eq!(
+        trailing_date_column("Acme Payments, Berlin, 2022"),
+        None,
+        "a lone year is a date the line MENTIONS, not one it is structured by"
+    );
+
+    // The prose leak this PR fixed, re-asserted at its own function: none of
+    // these is an open-ended span, however many markers or years they carry.
+    for prose in [
+        "Reduced actual costs by 20% in 2023",
+        "Led the current platform migration",
+        "Shipped the ongoing rewrite",
+    ] {
+        assert!(
+            !is_open_ended(prose),
+            "{prose:?} is ordinary prose, not a date span"
+        );
+    }
+}
+
 #[test]
 fn contains_word_respects_boundaries() {
     assert!(contains_word("this is vital work", "vital"));

--- a/apps/desktop/src-tauri/src/documents/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/mod.rs
@@ -993,7 +993,7 @@ impl DocumentStore {
 
     pub fn embedding_config(&self) -> EmbeddingConfig {
         let conn = self.conn.lock();
-        conn.query_row(
+        let result = conn.query_row(
             "SELECT provider, model, base_url FROM embedding_config WHERE id = 1",
             [],
             |row| {
@@ -1003,11 +1003,25 @@ impl DocumentStore {
                     base_url: row.get::<_, Option<String>>(2)?,
                 })
             },
-        )
-        .unwrap_or_else(|_| EmbeddingConfig {
-            provider: "ollama".to_string(),
-            model: "nomic-embed-text".to_string(),
-            base_url: None,
+        );
+        result.unwrap_or_else(|e| {
+            // A missing row is the ordinary unseeded default; anything else is
+            // a real fault silently substituting a different embedding model
+            // — this used to swallow both cases identically, with no log line.
+            if matches!(e, rusqlite::Error::QueryReturnedNoRows) {
+                tracing::debug!(
+                    "embedding_config: unseeded, defaulting to ollama/nomic-embed-text"
+                );
+            } else {
+                tracing::warn!(
+                    "embedding_config: read failed ({e}), defaulting to ollama/nomic-embed-text"
+                );
+            }
+            EmbeddingConfig {
+                provider: "ollama".to_string(),
+                model: "nomic-embed-text".to_string(),
+                base_url: None,
+            }
         })
     }
 
@@ -1042,12 +1056,21 @@ pub async fn embed(app: &AppHandle, text: &str) -> AppResult<EmbeddingVector> {
         );
         e
     })?;
-    crate::commands::ai_provider::embed_text(app, provider, &cfg.model, cfg.base_url.clone(), text)
-        .await
-        .map_err(|e| {
-            tracing::warn!("embed failed ({}): {e}", cfg.provider);
-            e
-        })
+    let result = crate::commands::ai_provider::embed_text(
+        app,
+        provider,
+        &cfg.model,
+        cfg.base_url.clone(),
+        text,
+    )
+    .await;
+    // The model, not just the provider — answering "which embedding model
+    // actually ran?" used to require watching Ollama's API from outside.
+    match &result {
+        Ok(_) => tracing::debug!(provider = %cfg.provider, model = %cfg.model, "embed ok"),
+        Err(e) => tracing::warn!(provider = %cfg.provider, model = %cfg.model, "embed failed: {e}"),
+    }
+    result
 }
 
 /// Lowercase-hex SHA-256 of `text`. Deterministic and stable across process

--- a/apps/desktop/src-tauri/src/documents/mod.rs
+++ b/apps/desktop/src-tauri/src/documents/mod.rs
@@ -12,11 +12,8 @@ use std::sync::Arc;
 
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
 
-use crate::commands::ai_provider::{
-    EmbeddingSpace, EmbeddingVector, ProviderId, EMBEDDING_VECTOR_VERSION,
-};
+use crate::commands::ai_provider::{EmbeddingSpace, EmbeddingVector, EMBEDDING_VECTOR_VERSION};
 use crate::data_store::DataStore;
 use crate::db::{column_exists, now_ms, run_migrations, ts_from_db, ts_to_db, Migration};
 use crate::error::AppResult;
@@ -1013,8 +1010,13 @@ impl DocumentStore {
                     "embedding_config: unseeded, defaulting to ollama/nomic-embed-text"
                 );
             } else {
+                // `e` is `rusqlite::Error` — `InvalidPath` can carry the
+                // absolute DB path, so this must never interpolate it raw
+                // (the `check-log-error-leaks` guard only scans `log::`
+                // macros, not `tracing::`, so it can't catch this itself).
                 tracing::warn!(
-                    "embedding_config: read failed ({e}), defaulting to ollama/nomic-embed-text"
+                    "embedding_config: read failed ({}), defaulting to ollama/nomic-embed-text",
+                    sanitize_reason(&e.to_string())
                 );
             }
             EmbeddingConfig {
@@ -1040,208 +1042,21 @@ impl DocumentStore {
     }
 }
 
-// ── Embedding ───────────────────────────────────────────────────────────────
-//
-// Routes through the centralized provider layer using the persisted embedding
-// config, so embeddings are provider-aware (Ollama / OpenAI / Gemini) and every
-// vector is tagged with the space that produced it. No provider/endpoint strings
-// live here.
-
-pub async fn embed(app: &AppHandle, text: &str) -> AppResult<EmbeddingVector> {
-    let cfg = app.state::<DocumentStore>().embedding_config();
-    let provider = ProviderId::parse(&cfg.provider).map_err(|e| {
-        tracing::warn!(
-            "embed failed: unknown embedding provider '{}': {e}",
-            cfg.provider
-        );
-        e
-    })?;
-    let result = crate::commands::ai_provider::embed_text(
-        app,
-        provider,
-        &cfg.model,
-        cfg.base_url.clone(),
-        text,
-    )
-    .await;
-    // The model, not just the provider — answering "which embedding model
-    // actually ran?" used to require watching Ollama's API from outside.
-    match &result {
-        Ok(_) => tracing::debug!(provider = %cfg.provider, model = %cfg.model, "embed ok"),
-        Err(e) => tracing::warn!(provider = %cfg.provider, model = %cfg.model, "embed failed: {e}"),
-    }
-    result
-}
-
-/// Lowercase-hex SHA-256 of `text`. Deterministic and stable across process
-/// restarts (unlike `DefaultHasher`/`RandomState`), so it is safe as the
-/// cross-session cache guard for both `posting_vectors.text_hash` and
-/// `match_scores.job_text_hash`. Single source of the hash for both caches.
-pub(crate) fn sha256_hex(text: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let mut h = Sha256::new();
-    h.update(text.as_bytes());
-    h.finalize()
-        .iter()
-        .fold(String::with_capacity(64), |mut acc, b| {
-            use std::fmt::Write;
-            let _ = write!(acc, "{b:02x}");
-            acc
-        })
-}
-
-/// Whether `id` belongs to a synthetic, content-addressed SCORING identity
-/// (`adhoc:…` from the extension bridge, `autopilot:…` / `autopilot-resume:…`
-/// from the headless re-rank) rather than a real `documents` row.
-///
-/// The app-wide convention for such an id is a `<namespace>:` prefix; a real
-/// document id is `doc-<millis>-<uuid8>` (see [`make_doc_id`]) and never
-/// contains a colon. Used by [`upsert_vector_with_conn`] to keep the DOCUMENT
-/// index free of rows that have no document: nothing would ever delete them
-/// (document delete and re-embed both iterate real documents; `prune_caches`
-/// only touches `posting_vectors`/`match_scores`), and
-/// [`DocumentStore::count_vectors_in_space`] counts every row — so one orphan
-/// makes the Embeddings panel report "N/N indexed, stale 0" over an index that
-/// is genuinely stale.
-pub(crate) fn is_synthetic_scoring_id(id: &str) -> bool {
-    id.contains(':')
-}
-
-/// Cache-precedence predicate for the posting-vector cache: a cached row is a
-/// HIT iff its embedding space matches the `active` config AND it was stored for
-/// the exact text we're requesting (`requested_hash == cached.text_hash`). A
-/// `None` row (no cached vector) is always a miss. This is the single source of
-/// the resolver's cache-hit decision — [`posting_vector_or_embed`] calls it so a
-/// reverted/loosened check fails a unit test (see documents/test.rs).
-pub(crate) fn posting_vector_is_fresh(
-    active: &EmbeddingConfig,
-    requested_hash: &str,
-    cached: Option<&(EmbeddingVector, String)>,
-) -> bool {
-    match cached {
-        Some((v, stored_hash)) => active.matches(&v.space) && stored_hash == requested_hash,
-        None => false,
-    }
-}
-
-/// ONE embedding round-trip, behind a seam.
-///
-/// The scoring kernel's only reach into the provider layer. It is a trait (not
-/// a bare `AppHandle` call) because this crate has no `tauri::test` mock-app
-/// harness: with the round-trip behind a seam, "how many provider calls did
-/// this score make, on what bytes, and what did each one cost" is a plain unit
-/// test over a real [`DocumentStore`] instead of a hand-retyped mirror of the
-/// kernel's own cache logic — which is exactly the shape that let an
-/// untranslated-hash charge predicate pass review.
-/// `pub(crate)`, not `pub`: the choke point is only a guarantee while every
-/// implementor is in this crate and reachable from `embed_charged`.
-#[async_trait::async_trait]
-pub(crate) trait Embedder: Send + Sync {
-    /// `None` on any failure — the caller degrades to keyword-only scoring.
-    async fn embed_one(&self, text: &str) -> Option<EmbeddingVector>;
-}
-
-/// A budget consulted immediately before each ACTUAL embedding round-trip.
-///
-/// The charge belongs HERE, at the call, evaluated on the exact bytes the call
-/// consumes — never in a caller that predicts the call from earlier state. The
-/// two answers diverge in practice: a caller sees the pre-translation blob (so
-/// its hash never matches the cached row for a translated posting → it charges
-/// on every total cache hit), and it cannot see the résumé-side embed at all
-/// (an evicted résumé vector then makes a real, uncharged round-trip). Same
-/// rule as `extension_bridge::answer_assist`: charge immediately before the
-/// work that reaches the provider, once per round-trip, and not at all when a
-/// cached path short-circuits.
-///
-/// `Err` means the ceiling refused: the round-trip must NOT happen.
-/// `pub(crate)` for the same reason as [`Embedder`]: "charged exactly once" is
-/// only a guarantee while every implementor is in this crate.
-pub(crate) trait EmbedBudget: Send + Sync {
-    fn charge_one_embed(&self) -> AppResult<()>;
-}
-
-/// Charge (if a budget is present) and then make one embedding round-trip.
-///
-/// The single choke point for every provider call the scoring kernel makes, so
-/// "charged exactly once per actual embed" is a property of one function rather
-/// than a convention each call site has to remember. A refused charge returns
-/// `None` — the same degrade-to-keyword-only signal as a failed embed.
-pub(crate) async fn embed_charged<E: Embedder + ?Sized>(
-    embedder: &E,
-    budget: Option<&dyn EmbedBudget>,
-    text: &str,
-) -> Option<EmbeddingVector> {
-    if let Some(budget) = budget {
-        if let Err(e) = budget.charge_one_embed() {
-            log::info!("[embed] round-trip refused by the daily ceiling: {e}");
-            return None;
-        }
-    }
-    embedder.embed_one(text).await
-}
-
-/// Production [`Embedder`]: the app's configured embedding provider.
-///
-/// `embed` already logs its own failure (see its doc), so `.ok()` here only
-/// discards the error from this `Option`-returning seam.
-pub(crate) struct AppEmbedder<'a>(pub &'a AppHandle);
-
-#[async_trait::async_trait]
-impl Embedder for AppEmbedder<'_> {
-    async fn embed_one(&self, text: &str) -> Option<EmbeddingVector> {
-        embed(self.0, text).await.ok()
-    }
-}
-
-/// Resolve the embedding for a job posting's (possibly translated) `text`,
-/// using the persisted `posting_vectors` cache. A hit avoids the embed call
-/// entirely. The cache is guarded by BOTH the active embedding space and a
-/// `text_hash` of the exact `text` passed here, so a stale or wrong-language
-/// row is a natural miss. Does NOT touch `PostingsCache` (raw-text vectors).
-///
-/// `budget` is charged only on the miss path, immediately before the call —
-/// see [`EmbedBudget`]. `active` comes from the caller (which already resolved
-/// it for its own cache key) so the hit decision and the score are computed
-/// against one snapshot of the embedding space.
-pub(crate) async fn posting_vector_or_embed<E: Embedder + ?Sized>(
-    store: &DocumentStore,
-    active: &EmbeddingConfig,
-    embedder: &E,
-    budget: Option<&dyn EmbedBudget>,
-    job_id: &str,
-    text: &str,
-) -> Option<EmbeddingVector> {
-    // Snapshot everything from the store before any await — the store methods
-    // each take/release the lock internally and return owned values, so no DB
-    // lock is held across the embed call below.
-    let hash = sha256_hex(text);
-    let cached = store.get_posting_vector(job_id);
-    // Single cache-hit decision (space + text_hash), shared with its unit test.
-    if posting_vector_is_fresh(active, &hash, cached.as_ref()) {
-        return cached.map(|(v, _)| v); // cache hit — no embed, no charge
-    }
-    let v = embed_charged(embedder, budget, text).await?;
-    // Best-effort cache write: the embed already succeeded, so a failed upsert
-    // must not fail the score — it only means the NEXT call re-embeds (and
-    // re-charges) this posting. Logged rather than dropped, because a
-    // persistently failing write is invisible otherwise and reads downstream as
-    // "the cache never hits". Never the text — but `job_id` is NOT always the
-    // opaque `board:external-id` shape it looks like: `breezy`/`pinpoint`/
-    // `themuse` build their [`crate::scraping::JobPosting::id`] as
-    // `format!("{BOARD_ID}:{url}")`, embedding the posting's full URL. Redact
-    // it with the same shape-based classifier the error already goes through,
-    // rather than hashing — that would cost every OTHER board's (the
-    // majority) debuggable `greenhouse:12345`-style id to close a leak only
-    // these three have.
-    if let Err(e) = store.upsert_posting_vector(job_id, &hash, &v) {
-        log::warn!(
-            "[documents] posting vector not cached for {}: {}",
-            crate::observability::redact_token(job_id),
-            sanitize_reason(&e.to_string())
-        );
-    }
-    Some(v)
-}
+mod embedding;
+// Re-exported flat at `documents::` so this split is invisible to every
+// existing `crate::documents::X` call site (`embed` alone has ~5 external
+// callers, `sha256_hex`/`EmbedBudget` several more) — see embedding.rs's doc.
+pub use embedding::embed;
+pub(crate) use embedding::{
+    embed_charged, is_synthetic_scoring_id, posting_vector_or_embed, sha256_hex, AppEmbedder,
+    EmbedBudget, Embedder,
+};
+// `posting_vector_is_fresh` has no caller outside `embedding.rs` itself in a
+// non-test build — only `documents/test.rs`'s unit tests reach it through
+// this re-export, so it is unused (and clippy `-D warnings` fails on it)
+// outside `#[cfg(test)]`.
+#[cfg(test)]
+pub(crate) use embedding::posting_vector_is_fresh;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src-tauri/src/model/rich.rs
+++ b/apps/desktop/src-tauri/src/model/rich.rs
@@ -26,14 +26,21 @@ static FULL_URL_RE: LazyLock<Regex> =
 static BARE_DOMAIN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?i)\b(?:[a-z0-9-]+\.)+[a-z]{2,}/[^\s|·•,<>"']+"#).unwrap());
 
-/// TLDs a bare domain with NO path may end in to be linked. Mirrors the
-/// allowlist `validate/content/factual.rs`'s `URL_RE` already curates for the
-/// identical collision on its own bare-host arm (`com|org|net|io|dev|app|de|co|ai|sh|me`) —
-/// kept as a sibling literal rather than a cross-module import, since this
-/// module has no other dependency on `validate`. Deliberately NOT an
-/// open-ended `[a-z]{2,}` class: applied to a path-less bare domain that would
-/// link `node.js` (an invalid `https://` host) and the `e.g`/`i.e`/`vs.`
-/// family right along with it.
+/// TLDs a bare domain with NO path may end in to be linked. Mirrors
+/// `validate/content/factual.rs`'s `URL_RE` arm 5,
+/// `BARE_DOMAIN_NO_PATH_TLDS` (`com|org|net|io|dev|app|de|co|ai|sh|me`) —
+/// added there specifically so that guard can see the identical shape this
+/// arm renders as a real link; the two MUST stay in lockstep or a domain this
+/// arm links slips past that file's Critical-severity
+/// `factual.altered_project_link` check. This is NOT the same list as that
+/// file's OTHER bare-host arm (arm 3), which is gated by the narrower
+/// `CODE_HOSTS` name allowlist plus a different TLD set
+/// (`com|org|io|dev|net|rs`) rather than by TLD alone — kept as a sibling
+/// literal rather than a cross-module import, since this module has no other
+/// dependency on `validate`. Deliberately NOT an open-ended `[a-z]{2,}`
+/// class: applied to a path-less bare domain that would link `node.js` (an
+/// invalid `https://` host) and the `e.g`/`i.e`/`vs.` family right along with
+/// it.
 const BARE_DOMAIN_TLDS: &str = "com|org|net|io|dev|app|de|co|ai|sh|me";
 
 /// A bare domain with NO path (`aijobhunter.app`, `iamsaeed.dev`) — a real

--- a/apps/desktop/src-tauri/src/model/rich.rs
+++ b/apps/desktop/src-tauri/src/model/rich.rs
@@ -20,10 +20,37 @@ static FULL_URL_RE: LazyLock<Regex> =
 /// A scheme-less URL written out in body text: a domain WITH a path
 /// (`github.com/user/repo`). Linked verbatim — the full text stays visible and an
 /// `https://` scheme is added only for the hyperlink target — so résumé project
-/// links render the same in the export as in the WYSIWYG editor. A bare domain
-/// with no path, or a short-TLD token like `CI/CD`, is intentionally not matched.
+/// links render the same in the export as in the WYSIWYG editor. Case-insensitive
+/// (`GitHub.com/user/repo` still links) — unlike [`BARE_DOMAIN_NO_PATH_RE`] below,
+/// a path already disambiguates this from a capitalised library name.
 static BARE_DOMAIN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?i)\b(?:[a-z0-9-]+\.)+[a-z]{2,}/[^\s|·•,<>"']+"#).unwrap());
+
+/// TLDs a bare domain with NO path may end in to be linked. Mirrors the
+/// allowlist `validate/content/factual.rs`'s `URL_RE` already curates for the
+/// identical collision on its own bare-host arm (`com|org|net|io|dev|app|de|co|ai|sh|me`) —
+/// kept as a sibling literal rather than a cross-module import, since this
+/// module has no other dependency on `validate`. Deliberately NOT an
+/// open-ended `[a-z]{2,}` class: applied to a path-less bare domain that would
+/// link `node.js` (an invalid `https://` host) and the `e.g`/`i.e`/`vs.`
+/// family right along with it.
+const BARE_DOMAIN_TLDS: &str = "com|org|net|io|dev|app|de|co|ai|sh|me";
+
+/// A bare domain with NO path (`aijobhunter.app`, `iamsaeed.dev`) — a real
+/// portfolio/product domain written without `https://` or a trailing path.
+/// Case-SENSITIVE (the only arm in this file that is) and restricted to
+/// [`BARE_DOMAIN_TLDS`]: without both gates this would also link every
+/// capitalised library/product name that happens to be spelled with a dot —
+/// `Socket.IO`, `Bun.sh`, `Nuxt.dev` — the exact collision
+/// `validate/content/factual.rs` already documents for the identical
+/// path-less-bare-host shape. Every real collision on record is a capitalised
+/// proper noun; every real bare portfolio domain in the wild is lowercase, so
+/// the case gate alone confines this arm to the domains it should link — a
+/// capitalised real domain simply stays unlinked (no worse than before this
+/// arm existed), and a lowercase library name links to its genuine official
+/// homepage, which is the correct destination anyway.
+static BARE_DOMAIN_NO_PATH_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(&format!(r"\b(?:[a-z0-9-]+\.)+(?:{BARE_DOMAIN_TLDS})\b")).unwrap());
 
 static EMAIL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap());
@@ -218,6 +245,28 @@ pub fn split_urls(text: &str) -> Vec<Span> {
                 end: m.end(),
                 label: email.to_string(),
                 url: format!("mailto:{email}"),
+            });
+        }
+    }
+
+    // A bare domain with NO path (`aijobhunter.app`) — lowercase + allowlisted
+    // TLD only, see BARE_DOMAIN_NO_PATH_RE's doc. Runs LAST — after
+    // BARE_DOMAIN_RE so a domain that DOES have a path is never re-matched as
+    // just its host, and after EMAIL_RE so `jane@example.com`'s host half
+    // isn't sliced off as its own bare-domain link before the email arm ever
+    // sees the whole address (`example.com` alone is a lowercase,
+    // allowlisted-TLD match too).
+    for m in BARE_DOMAIN_NO_PATH_RE.find_iter(text) {
+        let url = m.as_str();
+        let overlaps = matches
+            .iter()
+            .any(|u| m.start() < u.end && m.end() > u.start);
+        if !overlaps {
+            matches.push(Match {
+                start: m.start(),
+                end: m.end(),
+                label: url.to_string(),
+                url: format!("https://{url}"),
             });
         }
     }
@@ -539,17 +588,111 @@ mod tests {
         }
     }
 
+    /// INTENTIONAL BEHAVIOUR CHANGE, stated explicitly per the author-contract
+    /// rule that editing a test to make a change pass must be justified in
+    /// writing, not silently done. This test used to assert `split_urls("github.com")`
+    /// stayed plain text — that was the reported bug: a bare portfolio domain
+    /// with no path (`aijobhunter.app`, `iamsaeed.dev`) rendered as plain text
+    /// while a GitHub URL one line below, which happened to carry a `/path`,
+    /// rendered as a clickable link. `github.com` alone is lowercase on an
+    /// allowlisted TLD ([`BARE_DOMAIN_NO_PATH_RE`]), so it is now linked too —
+    /// a bare `github.com` written in a résumé is a real site, not a stray
+    /// token. The other half of the original test — no-domain-dot tokens like
+    /// `CI/CD`/`Agile`/`TDD` never becoming links — is unaffected by this arm
+    /// and stays covered here for the same reason it always was.
     #[test]
-    fn split_urls_ignores_bare_domain_without_path_and_short_tld_tokens() {
-        // No path → not a project link; "CI/CD" has no domain dot → not a URL.
-        assert!(matches!(
-            split_urls("github.com").as_slice(),
-            [Span::Text(_)]
-        ));
+    fn split_urls_links_a_bare_domain_without_path_on_an_allowlisted_tld() {
+        match split_urls("github.com").as_slice() {
+            [Span::Link { label, url }] => {
+                assert_eq!(label, "github.com");
+                assert_eq!(url, "https://github.com");
+            }
+            other => panic!("expected a single link span, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn split_urls_ignores_short_tld_tokens_with_no_domain_dot() {
+        // "CI/CD" has no domain dot at all → never read as a URL, allowlist or not.
         assert!(matches!(
             split_urls("Agile, CI/CD, TDD").as_slice(),
             [Span::Text(_)]
         ));
+    }
+
+    /// The reported bug, verbatim: portfolio domains with no path must link
+    /// exactly like GitHub project URLs with a path already do.
+    #[test]
+    fn split_urls_links_lowercase_bare_domains_on_allowlisted_tlds() {
+        for (text, href) in [
+            ("aijobhunter.app", "https://aijobhunter.app"),
+            ("crosskit.iamsaeed.dev", "https://crosskit.iamsaeed.dev"),
+            ("iamsaeed.dev", "https://iamsaeed.dev"),
+        ] {
+            match split_urls(text).as_slice() {
+                [Span::Link { label, url }] => {
+                    assert_eq!(label, text, "label for {text}");
+                    assert_eq!(url, href, "href for {text}");
+                }
+                other => panic!("expected a single link span for {text}, got {other:?}"),
+            }
+        }
+    }
+
+    /// Every documented collision this arm has to avoid is a capitalised
+    /// proper noun spelled with a dot — a tech-stack line's library names,
+    /// never a portfolio domain. The case gate is what tells them apart.
+    #[test]
+    fn split_urls_leaves_capitalized_library_names_as_plain_text() {
+        for text in ["Socket.IO", "Bun.sh", "Nuxt.dev", "Node.js"] {
+            assert!(
+                matches!(split_urls(text).as_slice(), [Span::Text(_)]),
+                "{text} must stay plain text"
+            );
+        }
+    }
+
+    /// Isolates the TLD-allowlist gate from the case gate: these are already
+    /// all-lowercase (so they'd clear a case check), but `.js` is not on
+    /// [`BARE_DOMAIN_TLDS`]. Without an explicit allowlist, the old
+    /// open-ended `[a-z]{2,}` class would treat any two-letter-plus suffix as
+    /// a real TLD and link these to an invalid `https://node.js` host.
+    #[test]
+    fn split_urls_leaves_lowercase_names_with_unlisted_tlds_as_plain_text() {
+        for text in ["node.js", "vue.js", "next.js"] {
+            assert!(
+                matches!(split_urls(text).as_slice(), [Span::Text(_)]),
+                "{text} must stay plain text (unlisted TLD)"
+            );
+        }
+    }
+
+    /// The new no-path arm is case-SENSITIVE, but the pre-existing arms must
+    /// behave exactly as they did before this change — this only gates the
+    /// NEW arm. `BARE_DOMAIN_RE` (domain+path) is genuinely `(?i)`, so an
+    /// uppercase-prefixed scheme-less URL with a path must still link;
+    /// `FULL_URL_RE` (scheme-prefixed) was never case-insensitive on the
+    /// scheme itself even before this change (no `(?i)` flag on that regex),
+    /// so a lowercase `https://` URL is the fair regression check for it.
+    #[test]
+    fn split_urls_keeps_pre_existing_arms_unaffected() {
+        match split_urls("GitHub.com/me/repo").as_slice() {
+            [Span::Link { label, url }] => {
+                assert_eq!(label, "GitHub.com/me/repo");
+                assert_eq!(url, "https://GitHub.com/me/repo");
+            }
+            other => {
+                panic!("an uppercase path-carrying scheme-less URL must still link, got {other:?}")
+            }
+        }
+
+        let scheme = split_urls("see https://github.com/x today");
+        assert!(
+            scheme
+                .iter()
+                .any(|s| matches!(s, Span::Link { url, .. } if url == "https://github.com/x")),
+            "a scheme-prefixed URL must still be linked verbatim"
+        );
     }
 
     // ── Link helpers (moved here with their implementation from export::links) ──

--- a/apps/desktop/src-tauri/src/model/rich.rs
+++ b/apps/desktop/src-tauri/src/model/rich.rs
@@ -20,44 +20,10 @@ static FULL_URL_RE: LazyLock<Regex> =
 /// A scheme-less URL written out in body text: a domain WITH a path
 /// (`github.com/user/repo`). Linked verbatim — the full text stays visible and an
 /// `https://` scheme is added only for the hyperlink target — so résumé project
-/// links render the same in the export as in the WYSIWYG editor. Case-insensitive
-/// (`GitHub.com/user/repo` still links) — unlike [`BARE_DOMAIN_NO_PATH_RE`] below,
-/// a path already disambiguates this from a capitalised library name.
+/// links render the same in the export as in the WYSIWYG editor. A bare domain
+/// with no path, or a short-TLD token like `CI/CD`, is intentionally not matched.
 static BARE_DOMAIN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?i)\b(?:[a-z0-9-]+\.)+[a-z]{2,}/[^\s|·•,<>"']+"#).unwrap());
-
-/// TLDs a bare domain with NO path may end in to be linked. Mirrors
-/// `validate/content/factual.rs`'s `URL_RE` arm 5,
-/// `BARE_DOMAIN_NO_PATH_TLDS` (`com|org|net|io|dev|app|de|co|ai|sh|me`) —
-/// added there specifically so that guard can see the identical shape this
-/// arm renders as a real link; the two MUST stay in lockstep or a domain this
-/// arm links slips past that file's Critical-severity
-/// `factual.altered_project_link` check. This is NOT the same list as that
-/// file's OTHER bare-host arm (arm 3), which is gated by the narrower
-/// `CODE_HOSTS` name allowlist plus a different TLD set
-/// (`com|org|io|dev|net|rs`) rather than by TLD alone — kept as a sibling
-/// literal rather than a cross-module import, since this module has no other
-/// dependency on `validate`. Deliberately NOT an open-ended `[a-z]{2,}`
-/// class: applied to a path-less bare domain that would link `node.js` (an
-/// invalid `https://` host) and the `e.g`/`i.e`/`vs.` family right along with
-/// it.
-const BARE_DOMAIN_TLDS: &str = "com|org|net|io|dev|app|de|co|ai|sh|me";
-
-/// A bare domain with NO path (`aijobhunter.app`, `iamsaeed.dev`) — a real
-/// portfolio/product domain written without `https://` or a trailing path.
-/// Case-SENSITIVE (the only arm in this file that is) and restricted to
-/// [`BARE_DOMAIN_TLDS`]: without both gates this would also link every
-/// capitalised library/product name that happens to be spelled with a dot —
-/// `Socket.IO`, `Bun.sh`, `Nuxt.dev` — the exact collision
-/// `validate/content/factual.rs` already documents for the identical
-/// path-less-bare-host shape. Every real collision on record is a capitalised
-/// proper noun; every real bare portfolio domain in the wild is lowercase, so
-/// the case gate alone confines this arm to the domains it should link — a
-/// capitalised real domain simply stays unlinked (no worse than before this
-/// arm existed), and a lowercase library name links to its genuine official
-/// homepage, which is the correct destination anyway.
-static BARE_DOMAIN_NO_PATH_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(&format!(r"\b(?:[a-z0-9-]+\.)+(?:{BARE_DOMAIN_TLDS})\b")).unwrap());
 
 static EMAIL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap());
@@ -252,28 +218,6 @@ pub fn split_urls(text: &str) -> Vec<Span> {
                 end: m.end(),
                 label: email.to_string(),
                 url: format!("mailto:{email}"),
-            });
-        }
-    }
-
-    // A bare domain with NO path (`aijobhunter.app`) — lowercase + allowlisted
-    // TLD only, see BARE_DOMAIN_NO_PATH_RE's doc. Runs LAST — after
-    // BARE_DOMAIN_RE so a domain that DOES have a path is never re-matched as
-    // just its host, and after EMAIL_RE so `jane@example.com`'s host half
-    // isn't sliced off as its own bare-domain link before the email arm ever
-    // sees the whole address (`example.com` alone is a lowercase,
-    // allowlisted-TLD match too).
-    for m in BARE_DOMAIN_NO_PATH_RE.find_iter(text) {
-        let url = m.as_str();
-        let overlaps = matches
-            .iter()
-            .any(|u| m.start() < u.end && m.end() > u.start);
-        if !overlaps {
-            matches.push(Match {
-                start: m.start(),
-                end: m.end(),
-                label: url.to_string(),
-                url: format!("https://{url}"),
             });
         }
     }
@@ -595,111 +539,17 @@ mod tests {
         }
     }
 
-    /// INTENTIONAL BEHAVIOUR CHANGE, stated explicitly per the author-contract
-    /// rule that editing a test to make a change pass must be justified in
-    /// writing, not silently done. This test used to assert `split_urls("github.com")`
-    /// stayed plain text — that was the reported bug: a bare portfolio domain
-    /// with no path (`aijobhunter.app`, `iamsaeed.dev`) rendered as plain text
-    /// while a GitHub URL one line below, which happened to carry a `/path`,
-    /// rendered as a clickable link. `github.com` alone is lowercase on an
-    /// allowlisted TLD ([`BARE_DOMAIN_NO_PATH_RE`]), so it is now linked too —
-    /// a bare `github.com` written in a résumé is a real site, not a stray
-    /// token. The other half of the original test — no-domain-dot tokens like
-    /// `CI/CD`/`Agile`/`TDD` never becoming links — is unaffected by this arm
-    /// and stays covered here for the same reason it always was.
     #[test]
-    fn split_urls_links_a_bare_domain_without_path_on_an_allowlisted_tld() {
-        match split_urls("github.com").as_slice() {
-            [Span::Link { label, url }] => {
-                assert_eq!(label, "github.com");
-                assert_eq!(url, "https://github.com");
-            }
-            other => panic!("expected a single link span, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn split_urls_ignores_short_tld_tokens_with_no_domain_dot() {
-        // "CI/CD" has no domain dot at all → never read as a URL, allowlist or not.
+    fn split_urls_ignores_bare_domain_without_path_and_short_tld_tokens() {
+        // No path → not a project link; "CI/CD" has no domain dot → not a URL.
+        assert!(matches!(
+            split_urls("github.com").as_slice(),
+            [Span::Text(_)]
+        ));
         assert!(matches!(
             split_urls("Agile, CI/CD, TDD").as_slice(),
             [Span::Text(_)]
         ));
-    }
-
-    /// The reported bug, verbatim: portfolio domains with no path must link
-    /// exactly like GitHub project URLs with a path already do.
-    #[test]
-    fn split_urls_links_lowercase_bare_domains_on_allowlisted_tlds() {
-        for (text, href) in [
-            ("aijobhunter.app", "https://aijobhunter.app"),
-            ("crosskit.iamsaeed.dev", "https://crosskit.iamsaeed.dev"),
-            ("iamsaeed.dev", "https://iamsaeed.dev"),
-        ] {
-            match split_urls(text).as_slice() {
-                [Span::Link { label, url }] => {
-                    assert_eq!(label, text, "label for {text}");
-                    assert_eq!(url, href, "href for {text}");
-                }
-                other => panic!("expected a single link span for {text}, got {other:?}"),
-            }
-        }
-    }
-
-    /// Every documented collision this arm has to avoid is a capitalised
-    /// proper noun spelled with a dot — a tech-stack line's library names,
-    /// never a portfolio domain. The case gate is what tells them apart.
-    #[test]
-    fn split_urls_leaves_capitalized_library_names_as_plain_text() {
-        for text in ["Socket.IO", "Bun.sh", "Nuxt.dev", "Node.js"] {
-            assert!(
-                matches!(split_urls(text).as_slice(), [Span::Text(_)]),
-                "{text} must stay plain text"
-            );
-        }
-    }
-
-    /// Isolates the TLD-allowlist gate from the case gate: these are already
-    /// all-lowercase (so they'd clear a case check), but `.js` is not on
-    /// [`BARE_DOMAIN_TLDS`]. Without an explicit allowlist, the old
-    /// open-ended `[a-z]{2,}` class would treat any two-letter-plus suffix as
-    /// a real TLD and link these to an invalid `https://node.js` host.
-    #[test]
-    fn split_urls_leaves_lowercase_names_with_unlisted_tlds_as_plain_text() {
-        for text in ["node.js", "vue.js", "next.js"] {
-            assert!(
-                matches!(split_urls(text).as_slice(), [Span::Text(_)]),
-                "{text} must stay plain text (unlisted TLD)"
-            );
-        }
-    }
-
-    /// The new no-path arm is case-SENSITIVE, but the pre-existing arms must
-    /// behave exactly as they did before this change — this only gates the
-    /// NEW arm. `BARE_DOMAIN_RE` (domain+path) is genuinely `(?i)`, so an
-    /// uppercase-prefixed scheme-less URL with a path must still link;
-    /// `FULL_URL_RE` (scheme-prefixed) was never case-insensitive on the
-    /// scheme itself even before this change (no `(?i)` flag on that regex),
-    /// so a lowercase `https://` URL is the fair regression check for it.
-    #[test]
-    fn split_urls_keeps_pre_existing_arms_unaffected() {
-        match split_urls("GitHub.com/me/repo").as_slice() {
-            [Span::Link { label, url }] => {
-                assert_eq!(label, "GitHub.com/me/repo");
-                assert_eq!(url, "https://GitHub.com/me/repo");
-            }
-            other => {
-                panic!("an uppercase path-carrying scheme-less URL must still link, got {other:?}")
-            }
-        }
-
-        let scheme = split_urls("see https://github.com/x today");
-        assert!(
-            scheme
-                .iter()
-                .any(|s| matches!(s, Span::Link { url, .. } if url == "https://github.com/x")),
-            "a scheme-prefixed URL must still be linked verbatim"
-        );
     }
 
     // ── Link helpers (moved here with their implementation from export::links) ──

--- a/apps/desktop/src-tauri/src/pipeline/resume/source.rs
+++ b/apps/desktop/src-tauri/src/pipeline/resume/source.rs
@@ -309,7 +309,16 @@ pub(crate) fn seed_one_project(entry: &[&SourceLine]) -> Option<ProjectOut> {
                 .text
                 .split(PROJECT_SEPARATORS)
                 .map(|item| item.trim().to_string())
-                .filter(|item| !item.is_empty() && urls_in(item).is_empty())
+                .filter(|item| {
+                    // A stack item is dropped only when it IS a claimed link — the
+                    // same `names_a_resource` test its two siblings above (`:253`,
+                    // `:288`) apply. Without this guard, any technology token that
+                    // merely LOOKS host-shaped (a bare `urls_in` match with no
+                    // scheme/www/path — e.g. a stack line spelling a library by its
+                    // own domain name) is silently deleted from the candidate's own
+                    // stack line instead of kept as the technology it is.
+                    !item.is_empty() && !urls_in(item).iter().any(|u| names_a_resource(u))
+                })
                 .collect()
         })
         .unwrap_or_default();

--- a/apps/desktop/src-tauri/src/pipeline/resume/test.rs
+++ b/apps/desktop/src-tauri/src/pipeline/resume/test.rs
@@ -4990,3 +4990,37 @@ async fn humanize_one_runs_normalize_before_grading_so_an_accepted_candidate_is_
         "the accepted text is byte-identical to the source's own link line"
     );
 }
+
+/// `seed_one_project`'s stack-line filter used to drop an item whenever
+/// `urls_in` found ANY match, with no `names_a_resource` guard — unlike its
+/// two siblings in the same function (the labeled-span and bare-URL link
+/// capture), which both skip a stack-line match that doesn't name a
+/// resource. `crates.io` written bare in a stack line matches `URL_RE`'s
+/// code-host arm (it is a known registry host) but names no resource (no
+/// scheme, `www.`, or path), so it used to be silently deleted from the
+/// candidate's own stack line instead of kept as the technology it is.
+///
+/// Mutation check: reverting the filter to
+/// `!item.is_empty() && urls_in(item).is_empty()` drops `crates.io` from
+/// `stack` and this assertion goes red — verified — then restoring the
+/// `names_a_resource` guard makes it green again.
+#[test]
+fn a_bare_code_host_stack_token_survives_as_a_technology_not_a_link() {
+    let source = "PROJECTS\n\n\
+                  **Ledger CLI** · https://ledger.example.dev\n\
+                  Rust · crates.io · Tokio\n\
+                  A command-line ledger tool.\n";
+    let projects = crate::pipeline::resume::source::seed_projects(source);
+    assert_eq!(projects.len(), 1, "exactly one project must be seeded");
+    assert_eq!(
+        projects[0].stack,
+        vec![
+            "Rust".to_string(),
+            "crates.io".to_string(),
+            "Tokio".to_string()
+        ],
+        "a bare code-host token in the stack line is a technology, not a \
+         claimed link; got {:?}",
+        projects[0].stack
+    );
+}

--- a/apps/desktop/src-tauri/src/validate/content/credentials/tenure.rs
+++ b/apps/desktop/src-tauri/src/validate/content/credentials/tenure.rs
@@ -653,26 +653,37 @@ static SPAN_OPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b(since|seit|from|ab|depuis|desde|dal|dalla|vanaf|sinds)\b").unwrap()
 });
 
-/// A [`PRESENT_MARKERS`] word right after a year with NO separator at all —
-/// `2021 Present`, `2021 Heute`, `Jan 2021 Present`. `documents::evidence`'s
-/// own [`is_open_ended`] requires an explicit separator (`-`, `to`, `bis`, …)
-/// between the year and the marker, because that adjacency check also runs
-/// against whole prose sentences elsewhere and a bare "year, then a marker
-/// word a few words later" match is indistinguishable from an ordinary
-/// sentence there. This regex is narrower in one way (whitespace ONLY, no
-/// separator, no room for other words) and looser in another (no separator
-/// required) — a shape `export::parser::DATE_RE` itself already treats as a
-/// job entry's date range (it allows up to 30 arbitrary characters with no
-/// separator at all). Without this arm, a source written that way had its
-/// span closed at the role's own start year and a truthful long tenure read
-/// as inflated. Same vocabulary as [`is_open_ended`], deliberately, so the
-/// two never disagree about which words these are; only the adjacency rule
-/// differs, and only in the generous direction this whole function already
-/// documents.
-static SPAN_MARKER_NO_SEP_RE: LazyLock<Regex> = LazyLock::new(|| {
-    let markers = PRESENT_MARKERS.join("|");
-    Regex::new(&format!(r"(?i)\b(?:19|20)\d{{2}}\s+(?:{markers})\b")).unwrap()
-});
+/// A [`PRESENT_MARKERS`] word anywhere on a line that ALREADY CARRIES A YEAR —
+/// `2021 Present`, `2021 | Heute`, `2015 · Aktuell`, `2016 (ongoing)`.
+///
+/// `documents::evidence::is_open_ended` used to answer this and deliberately
+/// no longer does: it now demands an explicit span separator (`-`, `to`,
+/// `bis`, …) between the year and the marker, because that predicate also
+/// runs against whole prose sentences, where "a year, and a marker word a few
+/// words later" is indistinguishable from ordinary text ("Reduced actual
+/// costs by 20% in 2023"). Here it IS distinguishable, and that is why this
+/// arm is local to this file: [`source_is_ongoing`] has already established
+/// the line carries a year, and every direction of error it can make is the
+/// generous one.
+///
+/// **Why no separator list of its own.** The first attempt at this arm allowed
+/// only WHITESPACE between the year and the marker, which left a pipe, a
+/// middot, a comma and a parenthesis reading as CLOSED — the one dangerous
+/// answer [`source_is_ongoing`] documents. Measured: a truthful
+/// `… | 2015 | Present` history collapsed from an eleven-year span to a
+/// zero-year one and raised a false `factual.inflated_experience` Critical.
+/// Any enumeration of separators fails the same way one spelling further out,
+/// and `export::parser::DATE_RE` — this codebase's own definition of a job
+/// entry's date range — already allows 30 ARBITRARY characters there. So this
+/// asks only for the marker and lets the caller's year requirement carry the
+/// structure.
+///
+/// Same vocabulary as [`is_open_ended`], deliberately, so the two can never
+/// disagree about which words these are; only the adjacency rule differs.
+fn names_a_present_marker(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    PRESENT_MARKERS.iter().any(|m| contains_phrase(&lower, m))
+}
 
 /// True when the source shows a role that has NOT ended.
 ///
@@ -682,8 +693,8 @@ static SPAN_MARKER_NO_SEP_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Aujourd'hui` and `2020 - Today`, none of which `PRESENT_MARKERS` carries —
 /// and for the next spelling nobody has thought of either. The marker list is
 /// still consulted, because `seit 2021` is open with no separator at all, and
-/// so is [`SPAN_MARKER_NO_SEP_RE`], because a marker can follow a year with NO
-/// separator either.
+/// so is [`names_a_present_marker`], because a marker can sit next to a year
+/// behind any separator at all — or none.
 ///
 /// Every direction of error here is generous: an unrelated "in 2019 - a big
 /// year" reads as an open span and WIDENS the allowance. A false "closed" is
@@ -697,7 +708,7 @@ fn source_is_ongoing(source: &str) -> bool {
         }
         is_open_ended(line)
             || SPAN_OPENER_RE.is_match(line)
-            || SPAN_MARKER_NO_SEP_RE.is_match(line)
+            || names_a_present_marker(line)
             || SPAN_TAIL_RE.captures_iter(line).any(|c| {
                 c.get(1)
                     .is_none_or(|tail| years_in(tail.as_str()).is_empty())

--- a/apps/desktop/src-tauri/src/validate/content/credentials/tenure.rs
+++ b/apps/desktop/src-tauri/src/validate/content/credentials/tenure.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use chrono::Datelike;
 use regex::Regex;
 
-use crate::documents::evidence::{is_open_ended, years_in, SectionKind};
+use crate::documents::evidence::{is_open_ended, years_in, SectionKind, PRESENT_MARKERS};
 
 use super::super::{contains_phrase, Section};
 use super::{names_a_role, word_tokens};
@@ -653,6 +653,27 @@ static SPAN_OPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b(since|seit|from|ab|depuis|desde|dal|dalla|vanaf|sinds)\b").unwrap()
 });
 
+/// A [`PRESENT_MARKERS`] word right after a year with NO separator at all —
+/// `2021 Present`, `2021 Heute`, `Jan 2021 Present`. `documents::evidence`'s
+/// own [`is_open_ended`] requires an explicit separator (`-`, `to`, `bis`, …)
+/// between the year and the marker, because that adjacency check also runs
+/// against whole prose sentences elsewhere and a bare "year, then a marker
+/// word a few words later" match is indistinguishable from an ordinary
+/// sentence there. This regex is narrower in one way (whitespace ONLY, no
+/// separator, no room for other words) and looser in another (no separator
+/// required) — a shape `export::parser::DATE_RE` itself already treats as a
+/// job entry's date range (it allows up to 30 arbitrary characters with no
+/// separator at all). Without this arm, a source written that way had its
+/// span closed at the role's own start year and a truthful long tenure read
+/// as inflated. Same vocabulary as [`is_open_ended`], deliberately, so the
+/// two never disagree about which words these are; only the adjacency rule
+/// differs, and only in the generous direction this whole function already
+/// documents.
+static SPAN_MARKER_NO_SEP_RE: LazyLock<Regex> = LazyLock::new(|| {
+    let markers = PRESENT_MARKERS.join("|");
+    Regex::new(&format!(r"(?i)\b(?:19|20)\d{{2}}\s+(?:{markers})\b")).unwrap()
+});
+
 /// True when the source shows a role that has NOT ended.
 ///
 /// Asked of raw text, and asked STRUCTURALLY: a date column whose separator is
@@ -660,7 +681,9 @@ static SPAN_OPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// there. That is what makes it work for `2015 - Actualidad`, `2019 -
 /// Aujourd'hui` and `2020 - Today`, none of which `PRESENT_MARKERS` carries —
 /// and for the next spelling nobody has thought of either. The marker list is
-/// still consulted, because `seit 2021` is open with no separator at all.
+/// still consulted, because `seit 2021` is open with no separator at all, and
+/// so is [`SPAN_MARKER_NO_SEP_RE`], because a marker can follow a year with NO
+/// separator either.
 ///
 /// Every direction of error here is generous: an unrelated "in 2019 - a big
 /// year" reads as an open span and WIDENS the allowance. A false "closed" is
@@ -674,6 +697,7 @@ fn source_is_ongoing(source: &str) -> bool {
         }
         is_open_ended(line)
             || SPAN_OPENER_RE.is_match(line)
+            || SPAN_MARKER_NO_SEP_RE.is_match(line)
             || SPAN_TAIL_RE.captures_iter(line).any(|c| {
                 c.get(1)
                     .is_none_or(|tail| years_in(tail.as_str()).is_empty())

--- a/apps/desktop/src-tauri/src/validate/content/factual.rs
+++ b/apps/desktop/src-tauri/src/validate/content/factual.rs
@@ -896,14 +896,30 @@ fn unsupported_date_issues(ctx: &Analysis) -> Vec<ContentIssue> {
 /// library name. Everything else needs a scheme, a `www.`, or a `/path`.
 const CODE_HOSTS: &str = "github|gitlab|bitbucket|codeberg|sourcehut|sourceforge|npmjs|crates|pypi|huggingface|gitea|launchpad";
 
+/// TLDs a bare domain with NO path may end in to be linked, as arm 5 of
+/// [`URL_RE`] below. This is the exact allowlist `model::rich`'s
+/// `BARE_DOMAIN_NO_PATH_TLDS` applies before the renderer turns a bare domain
+/// into a real, clickable hyperlink in the exported PDF/DOCX — the two MUST
+/// stay in lockstep (cross-referenced in that module's doc comment too). If
+/// they drift, a domain the renderer links stops being visible to this
+/// file's Critical-severity `factual.altered_project_link` guard, and a
+/// hallucinated project domain renders as a seemingly-verified link.
+const BARE_DOMAIN_NO_PATH_TLDS: &str = "com|org|net|io|dev|app|de|co|ai|sh|me";
+
 /// A URL in résumé prose.
 ///
-/// Four arms, and the fourth one is the whole reason this regex is not simply
-/// "host dot TLD": a scheme-less bare host reads a stack line's library names as
-/// links. `Socket.IO` is `.io`, `Bun.sh` is `.sh`, `Nuxt.dev` is `.dev` — and a
+/// Five arms. Arms 3 and 5 are why this regex is not simply "host dot TLD": a
+/// scheme-less bare host reads a stack line's library names as links.
+/// `Socket.IO` is `.io`, `Bun.sh` is `.sh`, `Nuxt.dev` is `.dev` — and a
 /// stack line listing three of them produced three Critical
-/// `factual.altered_project_link` findings on a truthful résumé. So a bare host
-/// must either be a known code host or carry a `/path`.
+/// `factual.altered_project_link` findings on a truthful résumé. So a bare
+/// host must either be a known code host (arm 3, [`CODE_HOSTS`]), carry a
+/// `/path` (arm 4), or be lowercase on [`BARE_DOMAIN_NO_PATH_TLDS`] with NO
+/// path (arm 5 — scoped `(?-i:...)` against the rest of the pattern's
+/// `(?i)`, since a capitalised library name must stay unmatched). Arm 5
+/// mirrors, on purpose, the exact shape `model::rich`'s
+/// `BARE_DOMAIN_NO_PATH_RE` renders as a real link — this guard has to see
+/// what a reader can click.
 static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Assembled from parts, never a `\`-continued raw string: a raw string does
     // not process escapes, so a trailing backslash would leave a literal
@@ -912,7 +928,8 @@ static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
         r"(?i)(?:https?://[^\s)\]<>]+",
         r"|www\.[^\s)\]<>]+",
         &format!(r"|(?:{CODE_HOSTS})\.(?:com|org|io|dev|net|rs)(?:/[^\s)\]<>]*)?"),
-        r"|[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:com|org|net|io|dev|app|de|co|ai|sh|me)/[^\s)\]<>]*)",
+        r"|[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:com|org|net|io|dev|app|de|co|ai|sh|me)/[^\s)\]<>]*",
+        &format!(r"|(?-i:\b(?:[a-z0-9-]+\.)+(?:{BARE_DOMAIN_NO_PATH_TLDS})\b))"),
     ]
     .concat();
     Regex::new(&pattern).unwrap()

--- a/apps/desktop/src-tauri/src/validate/content/factual.rs
+++ b/apps/desktop/src-tauri/src/validate/content/factual.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use crate::documents::evidence::{
-    identity_tokens, split_entry, years_in, SectionKind, LEGAL_FORMS, PRESENT_MARKERS,
+    identity_tokens, split_entry, trailing_date_column, years_in, SectionKind, LEGAL_FORMS,
 };
 use crate::documents::keywords::{keywords_normalized, SHORT_TECH_TERMS, SYNONYMS};
 use crate::export::types::{LineKind, ParsedLine};
@@ -829,8 +829,7 @@ fn dropped_role_issues(ctx: &Analysis) -> Vec<ContentIssue> {
 ///
 /// ## Heuristic
 ///
-/// Only years found inside a date-shaped context (a `JobEntry` line, or a line
-/// carrying a present-tense marker at a WORD BOUNDARY) are considered, and only
+/// Only years found inside a date-shaped context are considered, and only
 /// years the source never states. Even then it fires only when the year is
 /// EARLIER than the latest year the source knows about: an invented earlier date
 /// can never be a legitimate resolution of anything.
@@ -844,10 +843,16 @@ fn dropped_role_issues(ctx: &Analysis) -> Vec<ContentIssue> {
 /// `documents::evidence::is_open_ended`'s job, and this check no longer needs to
 /// ask: a later year is never reported either way.
 ///
-/// The word-boundary rule on the markers matters just as much: `present` lives
-/// inside "presented" and `now` inside "knowledge", so a substring test turned
-/// ordinary bullets into date contexts and every year in them into a candidate
-/// Critical.
+/// **What counts as a date-shaped context.** A parsed `JobEntry` line, or a
+/// line whose text ends in a [`trailing_date_column`] — the same structural
+/// predicate `validate::content::labels_the_entry_below` uses, so the two
+/// surfaces cannot drift about what "opens an entry" means. This used to be a
+/// raw `PRESENT_MARKERS` word-boundary scan over the WHOLE line, which read
+/// any ordinary bullet carrying one of those words (`current`, `ongoing`,
+/// `now`, `actual`…) — anywhere in the sentence, regardless of a year's
+/// position — as a date context: "Reduced actual costs by 20% in 2023" turned
+/// its own truthful year into a false Critical. A present-tense word inside a
+/// bullet no longer decides this; only actual date structure does.
 ///
 /// Deterministic on purpose: the check never reads the system clock.
 fn unsupported_date_issues(ctx: &Analysis) -> Vec<ContentIssue> {
@@ -860,9 +865,8 @@ fn unsupported_date_issues(ctx: &Analysis) -> Vec<ContentIssue> {
     let mut issues = Vec::new();
     for section in &ctx.generated_sections {
         for line in &section.lines {
-            let lower = line.text.to_lowercase();
             let date_context = matches!(line.kind, LineKind::JobEntry)
-                || PRESENT_MARKERS.iter().any(|m| contains_phrase(&lower, m));
+                || trailing_date_column(&line.text).is_some();
             if !date_context {
                 continue;
             }

--- a/apps/desktop/src-tauri/src/validate/content/factual.rs
+++ b/apps/desktop/src-tauri/src/validate/content/factual.rs
@@ -896,30 +896,23 @@ fn unsupported_date_issues(ctx: &Analysis) -> Vec<ContentIssue> {
 /// library name. Everything else needs a scheme, a `www.`, or a `/path`.
 const CODE_HOSTS: &str = "github|gitlab|bitbucket|codeberg|sourcehut|sourceforge|npmjs|crates|pypi|huggingface|gitea|launchpad";
 
-/// TLDs a bare domain with NO path may end in to be linked, as arm 5 of
-/// [`URL_RE`] below. This is the exact allowlist `model::rich`'s
-/// `BARE_DOMAIN_NO_PATH_TLDS` applies before the renderer turns a bare domain
-/// into a real, clickable hyperlink in the exported PDF/DOCX — the two MUST
-/// stay in lockstep (cross-referenced in that module's doc comment too). If
-/// they drift, a domain the renderer links stops being visible to this
-/// file's Critical-severity `factual.altered_project_link` guard, and a
-/// hallucinated project domain renders as a seemingly-verified link.
-const BARE_DOMAIN_NO_PATH_TLDS: &str = "com|org|net|io|dev|app|de|co|ai|sh|me";
-
 /// A URL in résumé prose.
 ///
-/// Five arms. Arms 3 and 5 are why this regex is not simply "host dot TLD": a
-/// scheme-less bare host reads a stack line's library names as links.
-/// `Socket.IO` is `.io`, `Bun.sh` is `.sh`, `Nuxt.dev` is `.dev` — and a
+/// Four arms, and the fourth one is the whole reason this regex is not simply
+/// "host dot TLD": a scheme-less bare host reads a stack line's library names as
+/// links. `Socket.IO` is `.io`, `Bun.sh` is `.sh`, `Nuxt.dev` is `.dev` — and a
 /// stack line listing three of them produced three Critical
-/// `factual.altered_project_link` findings on a truthful résumé. So a bare
-/// host must either be a known code host (arm 3, [`CODE_HOSTS`]), carry a
-/// `/path` (arm 4), or be lowercase on [`BARE_DOMAIN_NO_PATH_TLDS`] with NO
-/// path (arm 5 — scoped `(?-i:...)` against the rest of the pattern's
-/// `(?i)`, since a capitalised library name must stay unmatched). Arm 5
-/// mirrors, on purpose, the exact shape `model::rich`'s
-/// `BARE_DOMAIN_NO_PATH_RE` renders as a real link — this guard has to see
-/// what a reader can click.
+/// `factual.altered_project_link` findings on a truthful résumé. So a bare host
+/// must either be a known code host or carry a `/path`.
+///
+/// **No fifth "bare domain, no path, lowercase" arm.** That was tried (to mirror
+/// `model::rich`'s bare-domain-without-path renderer arm) and reverted: with no
+/// email-aware arm and no lookaround in the `regex` crate, it matched the
+/// DOMAIN HALF of an email address as a bare "URL" (`urls_in("jane@gmail.com")`
+/// → `["gmail.com"]`), and on a title/description line — which carries no
+/// `names_a_resource` filter — a lowercase library mention in ordinary prose
+/// reopened the exact false-Critical shape this file exists to prevent. See
+/// `model::rich`'s doc for why the renderer's mirror arm was reverted too.
 static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Assembled from parts, never a `\`-continued raw string: a raw string does
     // not process escapes, so a trailing backslash would leave a literal
@@ -928,8 +921,7 @@ static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
         r"(?i)(?:https?://[^\s)\]<>]+",
         r"|www\.[^\s)\]<>]+",
         &format!(r"|(?:{CODE_HOSTS})\.(?:com|org|io|dev|net|rs)(?:/[^\s)\]<>]*)?"),
-        r"|[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:com|org|net|io|dev|app|de|co|ai|sh|me)/[^\s)\]<>]*",
-        &format!(r"|(?-i:\b(?:[a-z0-9-]+\.)+(?:{BARE_DOMAIN_NO_PATH_TLDS})\b))"),
+        r"|[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:com|org|net|io|dev|app|de|co|ai|sh|me)/[^\s)\]<>]*)",
     ]
     .concat();
     Regex::new(&pattern).unwrap()

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -8087,7 +8087,7 @@ EXPERIENCE
 /// `export::parser::DATE_RE` itself accepts this shape as a job entry's date
 /// range with no separator required between the year and the marker, so a
 /// résumé written this way is not a contrived fixture. Before
-/// `credentials::tenure::SPAN_MARKER_NO_SEP_RE` existed, `source_is_ongoing`
+/// `credentials::tenure::names_a_present_marker` existed, `source_is_ongoing`
 /// missed it entirely: the span closed at the role's own single stated year
 /// (2016-2016), and a truthful "8 years of experience" against a role that
 /// started in 2016 read as inflated. The control proves the widened
@@ -8111,6 +8111,63 @@ fn a_separator_free_ongoing_date_column_widens_the_allowance() {
         codes(&report_for(&implausible, source, EN_JOB_AD, &[]))
             .contains(&FACTUAL_INFLATED_EXPERIENCE),
         "control: an implausible claim must still fire even with the widened allowance"
+    );
+}
+
+/// A2a separator sweep — the shape of the SEPARATOR between a role's start
+/// year and its present-tense marker must not decide whether the role is
+/// still open.
+///
+/// `source_is_ongoing` is read here through the value it exists to produce,
+/// `career_span_years`: an open role's span runs to the reference year, a
+/// closed one stops at the last year the source names. Measured regression:
+/// when the marker branch required an explicit span separator
+/// (`-`, `to`, `bis`, …), every pipe/middot/comma/parenthesised spelling
+/// below collapsed from an eleven-year span to a zero-year one, and a
+/// truthful "11 years of experience" became a false
+/// `factual.inflated_experience` Critical.
+///
+/// Not a contrived set: `export::parser::DATE_RE`, this codebase's own
+/// definition of a job entry's date range, allows up to 30 ARBITRARY
+/// characters between the year and the marker, so every spelling here is one
+/// the parser itself already reads as a date range.
+///
+/// The closed-history control is what stops this passing for the wrong
+/// reason. Without it, an implementation that simply called every line
+/// ongoing would satisfy every other row.
+#[test]
+fn any_separator_between_a_year_and_a_present_marker_keeps_the_role_open() {
+    let source_with = |dates: &str| {
+        format!(
+            "Jane Doe\n\nEXPERIENCE\n\n\
+             Senior Engineer | Globex Logistics | {dates}\n\
+             - Built the billing API in Python and PostgreSQL\n"
+        )
+    };
+
+    for dates in [
+        "2015 - Present", // dash — never broke
+        "2015 | Present", // pipe
+        "2015 | Aktuell", // pipe, German marker
+        "2015 · Present", // middot
+        "2015, Present",  // comma
+        "2015 (ongoing)", // parenthesised, no separator at all
+        "2015 Present",   // whitespace only, no separator at all
+    ] {
+        assert_eq!(
+            credentials::career_span_years(&source_with(dates), Some(2026)),
+            Some(11),
+            "{dates:?}: an open role must run to the reference year"
+        );
+    }
+
+    // Negative control: a genuinely CLOSED history still closes at its own
+    // last year. A test without this row passes for an implementation that
+    // answers "ongoing" unconditionally.
+    assert_eq!(
+        credentials::career_span_years(&source_with("2005 - 2015"), Some(2026)),
+        Some(10),
+        "a closed history must stop at the last year the source names"
     );
 }
 

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -2873,7 +2873,14 @@ fn present_markers_only_match_whole_words() {
         );
     }
     assert!(looks_like_date_span("2021 - Present"));
-    assert!(looks_like_date_span("Heute"));
+    assert!(looks_like_date_span("2021 - Heute"));
+    // A bare marker with no year anywhere to anchor it is NOT a date span —
+    // the same non-answer DATE_ONLY_MARKERS already gives for a bare "Today"
+    // (see `documents::evidence::is_open_ended`'s doc comment). Requiring a
+    // year is exactly what stops an unrelated present-tense word from turning
+    // an ordinary sentence into a date context, so this is an intentional
+    // behavior change, not a silently accepted regression.
+    assert!(!looks_like_date_span("Heute"));
 
     // End to end: a truthful bullet with a year the source does not carry, in a
     // line whose only "date marker" is the word "Presented".
@@ -2883,6 +2890,52 @@ fn present_markers_only_match_whole_words() {
                      - Presented the 2019 roadmap review to the board\n";
     silent(
         &report_for(generated, source, EN_JOB_AD, &[]),
+        FACTUAL_UNSUPPORTED_DATE,
+    );
+}
+
+/// H5b — a present-tense word standing on its own, many words from an
+/// unrelated year, is not a date context either — reproduces the reported
+/// defect end to end. `unsupported_date_issues` used to decide a line was a
+/// "date context" the moment it carried a bare `PRESENT_MARKERS` word
+/// ANYWHERE, so an ordinary truthful bullet naming its own year (not one
+/// buried inside another word, unlike H5's "Presented") still tripped a false
+/// Critical. Each pair below is the SAME document, one word apart: the
+/// marker-word version and a control with just that word removed must both
+/// resolve silently, and both marker positions (before the year, after it)
+/// are covered because the old bug fired on either.
+#[test]
+fn present_tense_prose_far_from_a_year_is_not_a_date_context() {
+    let source = "EXPERIENCE\n\nAcme Payments | 2020 - 2024\n\
+                  - Ran the settlement platform on Kubernetes\n";
+
+    // Marker BEFORE the year — the task's own reproduction.
+    let with_marker = "EXPERIENCE\n\nAcme Payments | 2020 - 2024\n\
+                       - Reduced actual costs by 20% in 2023\n";
+    silent(
+        &report_for(with_marker, source, EN_JOB_AD, &[]),
+        FACTUAL_UNSUPPORTED_DATE,
+    );
+    let control = "EXPERIENCE\n\nAcme Payments | 2020 - 2024\n\
+                   - Reduced costs by 20% in 2023\n";
+    silent(
+        &report_for(control, source, EN_JOB_AD, &[]),
+        FACTUAL_UNSUPPORTED_DATE,
+    );
+
+    // Marker AFTER the year, several words away.
+    let ongoing = "EXPERIENCE\n\nAcme Payments | 2020 - 2024\n\
+                   - Cut spend 30% below the 2023 baseline while keeping the \
+                     ongoing migration on schedule\n";
+    silent(
+        &report_for(ongoing, source, EN_JOB_AD, &[]),
+        FACTUAL_UNSUPPORTED_DATE,
+    );
+    let ongoing_control = "EXPERIENCE\n\nAcme Payments | 2020 - 2024\n\
+                           - Cut spend 30% below the 2023 baseline while \
+                             keeping the migration on schedule\n";
+    silent(
+        &report_for(ongoing_control, source, EN_JOB_AD, &[]),
         FACTUAL_UNSUPPORTED_DATE,
     );
 }
@@ -7944,6 +7997,37 @@ EXPERIENCE
     silent(
         &report_for(&generated, &with_future_year, EN_JOB_AD, &[]),
         FACTUAL_INFLATED_EXPERIENCE,
+    );
+}
+
+/// A2a — the separator-free date column (`2016 Present`, no dash at all).
+/// `export::parser::DATE_RE` itself accepts this shape as a job entry's date
+/// range with no separator required between the year and the marker, so a
+/// résumé written this way is not a contrived fixture. Before
+/// `credentials::tenure::SPAN_MARKER_NO_SEP_RE` existed, `source_is_ongoing`
+/// missed it entirely: the span closed at the role's own single stated year
+/// (2016-2016), and a truthful "8 years of experience" against a role that
+/// started in 2016 read as inflated. The control proves the widened
+/// allowance is not just "nothing ever fires": an implausible claim still
+/// does.
+#[test]
+fn a_separator_free_ongoing_date_column_widens_the_allowance() {
+    let source = "Jane Doe\n\n\
+         EXPERIENCE\n\n\
+         Backend Developer | Globex Logistics | 2016 Present\n\
+         - Built the billing API in Python and PostgreSQL\n";
+
+    let truthful = summary_claiming("Backend engineer with 8 years of experience in payments.");
+    silent(
+        &report_for(&truthful, source, EN_JOB_AD, &[]),
+        FACTUAL_INFLATED_EXPERIENCE,
+    );
+
+    let implausible = summary_claiming("Backend engineer with 45 years of experience in payments.");
+    assert!(
+        codes(&report_for(&implausible, source, EN_JOB_AD, &[]))
+            .contains(&FACTUAL_INFLATED_EXPERIENCE),
+        "control: an implausible claim must still fire even with the widened allowance"
     );
 }
 

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1181,6 +1181,73 @@ fn stack_line_library_names_are_never_read_as_project_links() {
     );
 }
 
+/// The renderer (`model::rich`'s `BARE_DOMAIN_NO_PATH_RE`) turns a bare,
+/// path-less, lowercase, allowlisted-TLD domain into a real hyperlink. Before
+/// `URL_RE` grew its matching fifth arm, such a domain matched neither the
+/// code-host arm (not a known host) nor the domain+path arm (no path), so a
+/// hallucinated project domain like `innovatehub.app` contributed to neither
+/// `source_urls` nor `generated_urls` here and this guard never fired — even
+/// though the export rendered it as a real, clickable, seemingly-verified
+/// link. A title line carries no `names_a_resource` filter (only index 1
+/// does), so the fabricated domain on the title line must be caught.
+///
+/// Mutation check: dropping arm 5 from `URL_RE` (reverting to the four-arm
+/// pattern) makes this go red (`hits.len() == 0`, `assert_eq!` panics with
+/// "1", "0") — verified — then restoring arm 5 makes it green again.
+#[test]
+fn a_fabricated_bare_domain_in_a_project_title_is_an_altered_link() {
+    let source = "PROJECTS\n\n\
+                  **Ledger CLI** · https://ledger.example.dev/docs\n\
+                  Rust · PostgreSQL\n\
+                  A command-line ledger tool.\n";
+    let generated = "PROJECTS\n\n\
+                     **InnovateHub** · innovatehub.app\n\
+                     Rust · PostgreSQL\n\
+                     A fabricated project.\n";
+    let report = report_for(generated, source, EN_JOB_AD, &[]);
+    let hits = fired(&report, FACTUAL_ALTERED_PROJECT_LINK);
+    assert_eq!(
+        hits.len(),
+        1,
+        "the bare fabricated domain must be caught as invented; got {hits:#?}"
+    );
+    assert_eq!(
+        hits[0].evidence.as_deref(),
+        Some("innovatehub.app"),
+        "evidence should name the fabricated domain; got {:?}",
+        hits[0].evidence
+    );
+}
+
+/// The negative direction of the test above: `URL_RE`'s new fifth arm is
+/// scoped `(?-i:...)` against the rest of the pattern's `(?i)` specifically so
+/// it does NOT relink the exact stack-line collision arm 3 already guards
+/// against — a capitalised library name whose lowercase tail happens to sit on
+/// an allowlisted TLD (`Socket.IO`, `Bun.sh`, `Nuxt.dev`) must stay unmatched,
+/// on both the bare-string check and the full project-entry comparison.
+///
+/// Mutation check: removing the `(?-i:...)` scope (letting arm 5 inherit the
+/// pattern's case-insensitivity) makes `urls_in` return the three names and
+/// the `is_empty()` assertion go red — verified — then restoring the scoped
+/// negation makes it green again.
+#[test]
+fn bare_domain_arm_stays_silent_on_capitalised_stack_names() {
+    assert!(
+        factual::urls_in("Socket.IO · Bun.sh · Nuxt.dev").is_empty(),
+        "capitalised library names must not be read as links; got {:?}",
+        factual::urls_in("Socket.IO · Bun.sh · Nuxt.dev")
+    );
+
+    let source = "PROJECTS\n\n\
+                  **Chat Relay** · https://relay.example.dev/docs\n\
+                  Socket.IO · Bun.sh · Nuxt.dev\n\
+                  A tiny websocket relay.\n";
+    silent(
+        &report_for(source, source, EN_JOB_AD, &[]),
+        FACTUAL_ALTERED_PROJECT_LINK,
+    );
+}
+
 /// H1b — the same link written a different way is the same link. Compared on a
 /// canonical key (scheme dropped, host lowercased, trailing `/` removed,
 /// markdown href unwrapped); still REPORTED verbatim when it genuinely differs.

--- a/apps/desktop/src-tauri/src/validate/content/test.rs
+++ b/apps/desktop/src-tauri/src/validate/content/test.rs
@@ -1181,71 +1181,87 @@ fn stack_line_library_names_are_never_read_as_project_links() {
     );
 }
 
-/// The renderer (`model::rich`'s `BARE_DOMAIN_NO_PATH_RE`) turns a bare,
-/// path-less, lowercase, allowlisted-TLD domain into a real hyperlink. Before
-/// `URL_RE` grew its matching fifth arm, such a domain matched neither the
-/// code-host arm (not a known host) nor the domain+path arm (no path), so a
-/// hallucinated project domain like `innovatehub.app` contributed to neither
-/// `source_urls` nor `generated_urls` here and this guard never fired — even
-/// though the export rendered it as a real, clickable, seemingly-verified
-/// link. A title line carries no `names_a_resource` filter (only index 1
-/// does), so the fabricated domain on the title line must be caught.
-///
-/// Mutation check: dropping arm 5 from `URL_RE` (reverting to the four-arm
-/// pattern) makes this go red (`hits.len() == 0`, `assert_eq!` panics with
-/// "1", "0") — verified — then restoring arm 5 makes it green again.
+/// An `urls_in` widening tried once to add a fifth "bare domain, no path,
+/// lowercase" arm so the validator would see every domain the renderer's
+/// `model::rich::split_urls` turns into a real hyperlink. It was reverted
+/// (see `factual.rs`'s `URL_RE` doc) because, with no email-aware arm and no
+/// lookaround in the `regex` crate, it matched the DOMAIN HALF of an email
+/// address as a bare "URL" — `urls_in("jane.doe@gmail.com")` returned
+/// `["gmail.com"]` — even though the renderer correctly treats the whole
+/// address as one `mailto:` link and never exposes the domain separately.
+/// This pins BOTH surfaces so a future widening cannot reopen the gap on
+/// just one side: the validator must find no bare-URL match inside an email
+/// address, and the renderer's only match for that text is the one `mailto:`
+/// link — never an extra bare-domain link fragment.
 #[test]
-fn a_fabricated_bare_domain_in_a_project_title_is_an_altered_link() {
-    let source = "PROJECTS\n\n\
-                  **Ledger CLI** · https://ledger.example.dev/docs\n\
-                  Rust · PostgreSQL\n\
-                  A command-line ledger tool.\n";
-    let generated = "PROJECTS\n\n\
-                     **InnovateHub** · innovatehub.app\n\
-                     Rust · PostgreSQL\n\
-                     A fabricated project.\n";
-    let report = report_for(generated, source, EN_JOB_AD, &[]);
-    let hits = fired(&report, FACTUAL_ALTERED_PROJECT_LINK);
-    assert_eq!(
-        hits.len(),
-        1,
-        "the bare fabricated domain must be caught as invented; got {hits:#?}"
-    );
-    assert_eq!(
-        hits[0].evidence.as_deref(),
-        Some("innovatehub.app"),
-        "evidence should name the fabricated domain; got {:?}",
-        hits[0].evidence
-    );
+fn an_email_address_never_yields_a_phantom_domain_url() {
+    for email in [
+        "Jane Doe · jane.doe@gmail.com · Berlin, Germany",
+        "team@openai.com",
+        "jane@proton.me",
+    ] {
+        assert!(
+            factual::urls_in(email).is_empty(),
+            "an email address is not a project URL; got {:?} for {email:?}",
+            factual::urls_in(email)
+        );
+
+        let spans = crate::model::rich::split_urls(email);
+        let links: Vec<&crate::model::rich::Span> = spans
+            .iter()
+            .filter(|s| matches!(s, crate::model::rich::Span::Link { .. }))
+            .collect();
+        assert_eq!(
+            links.len(),
+            1,
+            "the renderer must produce exactly one link (the mailto:) for \
+             {email:?}, not a second bare-domain fragment; got {spans:?}"
+        );
+        assert!(
+            matches!(links[0], crate::model::rich::Span::Link { url, .. } if url.starts_with("mailto:")),
+            "the one link for {email:?} must be a mailto:, got {:?}",
+            links[0]
+        );
+    }
 }
 
-/// The negative direction of the test above: `URL_RE`'s new fifth arm is
-/// scoped `(?-i:...)` against the rest of the pattern's `(?i)` specifically so
-/// it does NOT relink the exact stack-line collision arm 3 already guards
-/// against — a capitalised library name whose lowercase tail happens to sit on
-/// an allowlisted TLD (`Socket.IO`, `Bun.sh`, `Nuxt.dev`) must stay unmatched,
-/// on both the bare-string check and the full project-entry comparison.
+/// Renderer/validator parity on a shared corpus. `model::rich::split_urls`
+/// (what actually becomes a clickable link in the exported PDF/DOCX) and
+/// `validate::content::factual::urls_in` (what the Critical-severity
+/// `factual.altered_project_link` guard treats as a claimed link) must agree
+/// on whether ordinary, non-email text is link-shaped — this is the
+/// invariant the reverted fifth `URL_RE` arm broke (see the test above).
 ///
-/// Mutation check: removing the `(?-i:...)` scope (letting arm 5 inherit the
-/// pattern's case-insensitivity) makes `urls_in` return the three names and
-/// the `is_empty()` assertion go red — verified — then restoring the scoped
-/// negation makes it green again.
+/// Email text is deliberately excluded from this table: the renderer legally
+/// links it (as `mailto:`), a link type `urls_in` was never meant to model at
+/// all (project links, not contact emails) — covered on its own above.
 #[test]
-fn bare_domain_arm_stays_silent_on_capitalised_stack_names() {
-    assert!(
-        factual::urls_in("Socket.IO · Bun.sh · Nuxt.dev").is_empty(),
-        "capitalised library names must not be read as links; got {:?}",
-        factual::urls_in("Socket.IO · Bun.sh · Nuxt.dev")
-    );
-
-    let source = "PROJECTS\n\n\
-                  **Chat Relay** · https://relay.example.dev/docs\n\
-                  Socket.IO · Bun.sh · Nuxt.dev\n\
-                  A tiny websocket relay.\n";
-    silent(
-        &report_for(source, source, EN_JOB_AD, &[]),
-        FACTUAL_ALTERED_PROJECT_LINK,
-    );
+fn renderer_and_validator_agree_on_a_shared_url_corpus() {
+    let corpus: &[(&str, bool)] = &[
+        ("https://github.com/janedoe/ledger", true),
+        ("www.example.com/path", true),
+        ("github.com/janedoe/ledger", true),
+        ("just plain prose with no links at all", false),
+        ("Bun.sh", false),
+        ("bun.sh", false),
+        ("Socket.IO", false),
+        ("socket.io", false),
+        ("Agile, CI/CD, TDD", false),
+    ];
+    for (text, expect_link) in corpus {
+        let rendered_has_link = crate::model::rich::split_urls(text)
+            .iter()
+            .any(|s| matches!(s, crate::model::rich::Span::Link { .. }));
+        let validator_has_url = !factual::urls_in(text).is_empty();
+        assert_eq!(
+            rendered_has_link, *expect_link,
+            "renderer disagreed with the expected shape for {text:?}"
+        );
+        assert_eq!(
+            validator_has_url, *expect_link,
+            "validator disagreed with the expected shape for {text:?}"
+        );
+    }
 }
 
 /// H1b — the same link written a different way is the same link. Compared on a

--- a/apps/desktop/src-tauri/tests/architecture.rs
+++ b/apps/desktop/src-tauri/tests/architecture.rs
@@ -339,6 +339,9 @@ const R2_ALLOW: &[&str] = &[
     "reminder_scheduler.rs",
     "cover_letter/research/mod.rs",
     "documents/mod.rs",
+    // Split out of documents/mod.rs (R8 LOC cap) — same AppHandle-for-the-
+    // provider-layer shape as the parent store, not a new exception.
+    "documents/embedding.rs",
     "pipeline/mod.rs",
     "platform/config.rs", // sole owner: resolves the data dir from the AppHandle at bootstrap
     "platform/accent_watcher.rs", // Windows live-accent watcher: holds the AppHandle + emits SYSTEM_ACCENT_CHANGED from the WinRT ColorValuesChanged callback (bootstrap shell-reach, like platform/config.rs). TODO(arch): inject an emitter port.

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/AISettingsTab/index.tsx
@@ -10,6 +10,7 @@ import { useDebugMode } from '@/store/preferences-store';
 import { ActiveProviderSwitcher } from '../ActiveProviderSwitcher';
 import { CompanyResearchSettings } from '../CompanyResearchSettings';
 import { EmbeddingsSettings } from '../EmbeddingsSettings';
+import { PromptQualitySettings } from '../PromptQualitySettings';
 import { ProviderDebugBadge } from '../ProviderDebugBadge';
 import { ProviderRow } from '../ProviderRow';
 import { SpendSettings } from '../SpendSettings';
@@ -132,6 +133,12 @@ export function AISettingsTab() {
           })}
         </div>
       </GlassCard>
+
+      {/* Prompt quality — global preference, canonical home (also settable from
+          the AI Generate wizard and Analyze, which read/write the same store field). */}
+      <div data-settings-anchor="ai-prompt-quality">
+        <PromptQualitySettings activeProvider={activeProvider} />
+      </div>
 
       {/* Per-stage models — which model runs each step of a staged run. Fed the
           SAME key/health status the provider rows above use, so "is this

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/PromptQualitySettings/PromptQualitySettings.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/PromptQualitySettings/PromptQualitySettings.test.tsx
@@ -55,7 +55,12 @@ describe('PromptQualitySettings — scope honesty (Ollama-only)', () => {
     mockUsePromptQuality.mockReturnValue('auto');
     render(<PromptQualitySettings activeProvider="openai" />);
 
-    expect(screen.getByText(/settings\.promptQuality\.ollamaOnlyNote/)).toBeInTheDocument();
+    // Exact text, not a prefix regex: `/…ollamaOnlyNote/` also matched a
+    // typo'd `ollamaOnlyNoteX` key AND a component that dropped the
+    // `{ provider }` interpolation, so it survived both mutants. The trailing
+    // ` OpenAI` comes from the `t` mock above appending the param values —
+    // asserting it pins BOTH the key and the interpolation.
+    expect(screen.getByText('settings.promptQuality.ollamaOnlyNote OpenAI')).toBeInTheDocument();
   });
 
   it('stays silent about scope when the active provider IS Ollama', () => {

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/PromptQualitySettings/PromptQualitySettings.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/PromptQualitySettings/PromptQualitySettings.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * PromptQualitySettings — the canonical Settings home for the global
+ * `promptQuality` preference (also settable from the AI Generate wizard and
+ * Analyze — all three read/write the SAME `usePreferencesStore` field, so this
+ * only needs to prove the store write-through, not re-verify the sibling UIs).
+ *
+ * Scope honesty: `resolveEffectiveTier` (`lib/generate/provider-context.ts`)
+ * returns `'large'` unconditionally for anything but `ollama`, ignoring this
+ * preference entirely — the second describe block pins that the control says
+ * so whenever the active provider isn't Ollama, and stays quiet when it is.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@ajh/translations', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key} ${Object.values(params).join(' ')}` : key,
+  }),
+}));
+
+const setPromptQuality = vi.fn();
+const mockUsePromptQuality = vi.fn();
+
+vi.mock('@/store/preferences-store', () => ({
+  usePromptQuality: () => mockUsePromptQuality(),
+  usePreferencesStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ setPromptQuality }),
+}));
+
+import { PromptQualitySettings } from './index';
+
+describe('PromptQualitySettings — reads/writes the shared store', () => {
+  it('reflects the current promptQuality from usePromptQuality', () => {
+    mockUsePromptQuality.mockReturnValue('compact');
+    render(<PromptQualitySettings activeProvider="ollama" />);
+
+    expect(screen.getByRole('radio', { name: /fast/i })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls the SAME store setter StepFineTune/AnalyzeLeftPanel use, on selection', async () => {
+    mockUsePromptQuality.mockReturnValue('auto');
+    const user = userEvent.setup();
+    render(<PromptQualitySettings activeProvider="ollama" />);
+
+    await user.click(screen.getByRole('radio', { name: /full/i }));
+
+    expect(setPromptQuality).toHaveBeenCalledWith('full');
+  });
+});
+
+describe('PromptQualitySettings — scope honesty (Ollama-only)', () => {
+  it('states the setting does not apply when the active provider is not Ollama', () => {
+    mockUsePromptQuality.mockReturnValue('auto');
+    render(<PromptQualitySettings activeProvider="openai" />);
+
+    expect(screen.getByText(/settings\.promptQuality\.ollamaOnlyNote/)).toBeInTheDocument();
+  });
+
+  it('stays silent about scope when the active provider IS Ollama', () => {
+    mockUsePromptQuality.mockReturnValue('auto');
+    render(<PromptQualitySettings activeProvider="ollama" />);
+
+    expect(screen.queryByText(/settings\.promptQuality\.ollamaOnlyNote/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/PromptQualitySettings/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/PromptQualitySettings/index.tsx
@@ -1,0 +1,61 @@
+import { AlertTriangle, Gauge, SlidersHorizontal, Zap } from 'lucide-react';
+
+import { useTranslation } from '@ajh/translations';
+import { SegmentedControl, SettingsSection } from '@ajh/ui';
+
+import { PROVIDERS } from '@/lib/ai-providers/provider-meta';
+import type { AiProvider, PromptQuality } from '@/store/preferences-schema';
+import { usePreferencesStore, usePromptQuality } from '@/store/preferences-store';
+
+interface Props {
+  /** Currently active provider. `resolveEffectiveTier`
+   *  (`lib/generate/provider-context.ts`) returns `'large'` unconditionally for
+   *  anything but `'ollama'`, ignoring the preference below entirely — passed
+   *  down so the copy can stay honest about when the choice actually changes
+   *  generation, instead of shipping an unqualified toggle. */
+  activeProvider: AiProvider;
+}
+
+const OPTIONS: { value: PromptQuality; labelKey: string; icon?: typeof Gauge }[] = [
+  { value: 'full', labelKey: 'aiGenerate.wizard.quality.full', icon: SlidersHorizontal },
+  { value: 'auto', labelKey: 'aiGenerate.wizard.quality.auto' },
+  { value: 'compact', labelKey: 'aiGenerate.wizard.quality.fast', icon: Zap },
+];
+
+/**
+ * Canonical home for the global `promptQuality` preference. Reads/writes the
+ * SAME `usePreferencesStore` field as the two other surfaces that can change
+ * it (`StepFineTune`, `AnalyzeLeftPanel`) — all three stay in sync
+ * automatically since there is only one store field.
+ */
+export function PromptQualitySettings({ activeProvider }: Props) {
+  const { t } = useTranslation();
+  const promptQuality = usePromptQuality();
+  const setPromptQuality = usePreferencesStore((s) => s.setPromptQuality);
+  const isOllama = activeProvider === 'ollama';
+
+  return (
+    <SettingsSection icon={Gauge} label={t('settings.promptQuality.title')}>
+      <p className="mb-3 text-xs leading-relaxed text-foreground/50">
+        {t('settings.promptQuality.description')}
+      </p>
+      <SegmentedControl<PromptQuality>
+        variant="grid"
+        ariaLabel={t('settings.promptQuality.title')}
+        value={promptQuality}
+        onChange={setPromptQuality}
+        options={OPTIONS.map((o) => ({ value: o.value, label: t(o.labelKey), icon: o.icon }))}
+      />
+      {!isOllama && (
+        <div className="mt-3 flex items-start gap-2 rounded-lg border border-[var(--border-clear)] bg-foreground/[0.03] px-3 py-2">
+          <AlertTriangle size={12} className="mt-0.5 shrink-0 text-foreground/40" />
+          <p className="text-[10px] leading-relaxed text-foreground/45">
+            {t('settings.promptQuality.ollamaOnlyNote', {
+              provider: PROVIDERS[activeProvider].label,
+            })}
+          </p>
+        </div>
+      )}
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/renderer/features/settings/lib/search-anchor.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/lib/search-anchor.test.tsx
@@ -17,7 +17,7 @@
  *      general   → GeneralSection (6 anchors inside the component)
  *      appearance → AppearanceCard (5 anchors inside the component)
  *      contact   → ContactProfileTab (2 anchors inside the component)
- *      ai        → SettingsContent wrapper (2) + AISettingsTab interior (4)
+ *      ai        → SettingsContent wrapper (2) + AISettingsTab interior (5)
  *      job       → SettingsContent wrappers (3)
  *      resume    → SettingsContent wrapper (1)
  *      accounts  → AccountsSettingsTab (3 anchors inside)
@@ -248,6 +248,9 @@ vi.mock('@/features/settings/components/ai-settings/SpendSettings', () => ({
 vi.mock('@/features/settings/components/ai-settings/StageOverridesSettings', () => ({
   StageOverridesSettings: () => null,
 }));
+vi.mock('@/features/settings/components/ai-settings/PromptQualitySettings', () => ({
+  PromptQualitySettings: () => null,
+}));
 
 // AccountsSettingsTab children
 vi.mock('@/features/settings/components/accounts/BoardSessionRow', () => ({
@@ -340,8 +343,8 @@ function assertAnchor(container: HTMLElement, anchor: string) {
 // ── manifest integrity ────────────────────────────────────────────────────────
 
 describe('SEARCH_INDEX — manifest integrity', () => {
-  it('has exactly 32 entries', () => {
-    expect(SEARCH_INDEX).toHaveLength(32);
+  it('has exactly 33 entries', () => {
+    expect(SEARCH_INDEX).toHaveLength(33);
   });
 
   // A bare count survives the wrong deletion (or a duplicate masking a real

--- a/apps/desktop/src/renderer/features/settings/lib/search-index.ts
+++ b/apps/desktop/src/renderer/features/settings/lib/search-index.ts
@@ -179,6 +179,13 @@ export const SEARCH_INDEX: SearchEntry[] = [
     anchor: 'ai-tone',
   },
   {
+    id: 'ai-prompt-quality',
+    section: 'ai',
+    titleKey: 'settings.promptQuality.title',
+    keywords: ['prompt', 'quality', 'full', 'auto', 'compact', 'fast', 'verbosity', 'detail'],
+    anchor: 'ai-prompt-quality',
+  },
+  {
     id: 'ai-stages',
     section: 'ai',
     titleKey: 'settings.ai.stages.title',

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -659,6 +659,11 @@
       "reasoningEffort": "Denkaufwand",
       "effortDefault": "Standard"
     },
+    "promptQuality": {
+      "title": "Prompt-Qualität",
+      "description": "Wie viel Detailtiefe die KI in Überarbeitungen und Vorschläge steckt. Gilt nur für lokale Ollama-Modelle — Cloud- und CLI-Anbieter nutzen immer die volle Qualität.",
+      "ollamaOnlyNote": "Ihr aktiver Anbieter ist {{provider}} — er nutzt unabhängig von dieser Einstellung immer die volle Qualität."
+    },
     "aiModel": {
       "title": "KI-Modell",
       "refresh": "Aktualisieren",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -659,6 +659,11 @@
       "reasoningEffort": "Reasoning Effort",
       "effortDefault": "Default"
     },
+    "promptQuality": {
+      "title": "Prompt Quality",
+      "description": "How much detail the AI puts into rewrites and suggestions. Applies to local Ollama models only — cloud and CLI providers always use full quality.",
+      "ollamaOnlyNote": "Your active provider is {{provider}} — it always uses full quality, regardless of this setting."
+    },
     "aiModel": {
       "title": "AI Model",
       "refresh": "Refresh",

--- a/scripts/check-log-error-leaks.mjs
+++ b/scripts/check-log-error-leaks.mjs
@@ -549,23 +549,49 @@ export function violations(inventory = ALLOWLIST, leaks) {
   // message (two distinct call sites, identical text) falls back to the
   // ordinary line-exact rules below, so each site still needs its own
   // declaration rather than one `sig` silently covering both.
+  //
+  // Unambiguous means unambiguous on BOTH sides, and only against a leak no
+  // other entry has already claimed:
+  //
+  //   - Entry side: two entries sharing one (file, sig) were each satisfied
+  //     by the SAME single leak, so the stale duplicate was never reported.
+  //   - Already-claimed leak: an entry's sig can match the leak a DIFFERENT
+  //     entry declares line-exactly; that entry then has no site of its own
+  //     and IS stale. A sig pairing therefore only counts for a leak no entry
+  //     declares by line — when the leak sits on the entry's own line,
+  //     line-exact matching already covers it and `sig` is not needed.
+  //
+  // Both holes could only ever suppress a STALE-entry error, never an
+  // undeclared-leak one: a second site with the same message makes the LEAK
+  // bucket length 2, which disables sig matching for that bucket outright.
   const fileOf = (key) => key.slice(0, key.lastIndexOf(':'));
-  const leaksBySig = new Map(); // `${file} ${sig}` -> leak[]
-  for (const l of leaks) {
-    const bucketKey = `${l.file} ${l.sig}`;
-    const bucket = leaksBySig.get(bucketKey);
-    if (bucket) bucket.push(l);
-    else leaksBySig.set(bucketKey, [l]);
-  }
+  /** Group `items` into a Map keyed by `keyOf(item)`. */
+  const bucketBy = (items, keyOf) => {
+    const buckets = new Map();
+    for (const item of items) {
+      const k = keyOf(item);
+      const bucket = buckets.get(k);
+      if (bucket) bucket.push(item);
+      else buckets.set(k, [item]);
+    }
+    return buckets;
+  };
+  // NUL separator: it occurs in neither a path nor a Rust string literal, so
+  // two different (file, sig) pairs can never collide on one bucket key.
+  const leaksBySig = bucketBy(leaks, (l) => `${l.file} ${l.sig}`);
+  const entriesBySig = bucketBy(
+    Object.entries(inventory).filter(([, entry]) => entry.sig),
+    ([entryKey, entry]) => `${fileOf(entryKey)} ${entry.sig}`
+  );
   const sigSatisfiedLeakKeys = new Set();
   const sigSatisfiedEntryKeys = new Set();
-  for (const [entryKey, entry] of Object.entries(inventory)) {
-    if (!entry.sig) continue;
-    const bucket = leaksBySig.get(`${fileOf(entryKey)} ${entry.sig}`);
-    if (bucket && bucket.length === 1) {
-      sigSatisfiedLeakKeys.add(bucket[0].key);
-      sigSatisfiedEntryKeys.add(entryKey);
-    }
+  for (const [bucketKey, entries] of entriesBySig) {
+    if (entries.length !== 1) continue;
+    const bucket = leaksBySig.get(bucketKey);
+    if (!bucket || bucket.length !== 1) continue;
+    if (declaredKeys.has(bucket[0].key)) continue;
+    sigSatisfiedLeakKeys.add(bucket[0].key);
+    sigSatisfiedEntryKeys.add(entries[0][0]);
   }
 
   const undeclared = leaks.filter(

--- a/scripts/check-log-error-leaks.mjs
+++ b/scripts/check-log-error-leaks.mjs
@@ -93,6 +93,20 @@
 // already the sanctioned `sanitize_reason(&e.to_string())` wrapper, which
 // still does not match — see the comment on `positionalErrorRe`), so this
 // arm is a tripwire, not a fix for a live leak.
+//
+// A pre-PR review (2026-08-19) found the ALLOWLIST's `"<path>:<line>"` key is
+// its only identity, so ANY unrelated edit that inserts a line above a
+// declared site breaks the guard both ways at once (undeclared at the new
+// line, stale at the old one) — it happened to `documents/mod.rs`'s
+// `charge_provider_daily` site the same day it was written. An entry can now
+// opt into content-anchored matching by adding `sig` (copied from the `sig`
+// `findLeaks` reports for that site — its own format-string literal,
+// whitespace-collapsed), which survives a line shift as long as it stays the
+// ONLY declared entry with that (file, sig) pair — see `violations`. Kept
+// opt-in rather than migrating all existing entries at once: `sig` is a
+// verbatim copy of live source text, so a mechanical mass-migration script
+// would need to run and be verified against every entry, a bigger and
+// separately-reviewable change from fixing the one break in hand.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -126,9 +140,18 @@ const ALLOWLIST = {
       'fixed, author-written template naming only the provider id and a static ' +
       'daily-ceiling number — see limits/mod.rs.',
   },
-  'documents/mod.rs:1153': {
+  'documents/embedding.rs:153': {
     status: 'safe',
     reason: 'Same charge_provider_daily fixed-template message as autopilot_helpers/mod.rs:395.',
+    // `sig` opts this entry into content-anchored matching (see `violations`)
+    // so the NEXT unrelated edit that shifts this line doesn't repeat the
+    // 2026-08-19 break (a 23-line insertion above it moved 1153 -> 1176 and
+    // failed both directions: undeclared-at-1176, stale-at-1153). Note `sig`
+    // only survives a LINE shift within the same file, not a file move — this
+    // entry's key itself moved to documents/embedding.rs the same day, when
+    // the site was extracted out of documents/mod.rs for R8's LOC cap.
+    // Copied verbatim from the call site's own format-string literal.
+    sig: '[embed] round-trip refused by the daily ceiling: {e}',
   },
   'validate/mod.rs:401': {
     status: 'safe',
@@ -448,16 +471,32 @@ function findPositionalErrorArg(argsText) {
 }
 
 /**
+ * A stable content signature for a log call's format-string literal —
+ * whitespace-collapsed so a `\`-continued literal (see the multi-line test
+ * case) reads the same regardless of exact line wrapping. This is what makes
+ * `sig`-based matching (see `violations`) survive a line-number shift: an
+ * unrelated edit above a declared site changes its LINE but never its own
+ * message text, so the signature is unchanged. Purely a display/matching
+ * convenience — not a security boundary, so a naive whitespace collapse
+ * (rather than actually decoding Rust escapes) is precise enough.
+ */
+function normalizeSig(literal) {
+  return literal.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Every `log::{warn,error,info,debug}!(...)` call site, under `srcDir`, that
  * interpolates a bound error identifier — captured in the format string
  * (`{e}`, `{err}`, `{error}`) or passed as a bare positional argument
  * (`"...{}...", e`). See `ERROR_BINDING_NAMES` for why detection is bounded
  * to those three names rather than every identifier.
  *
- * Returns `{ key, file, line }[]`, `key` being `"<path relative to src/>:<line>"`
- * — the ALLOWLIST's own key shape. `line` is the line the identifier itself
- * sits on (for a multi-line format string, or an argument list wrapped onto
- * its own line, that is not necessarily the `log::` call's own line).
+ * Returns `{ key, file, line, sig }[]`, `key` being
+ * `"<path relative to src/>:<line>"` — the ALLOWLIST's own key shape. `line`
+ * is the line the identifier itself sits on (for a multi-line format string,
+ * or an argument list wrapped onto its own line, that is not necessarily the
+ * `log::` call's own line). `sig` is the call's own format-string literal,
+ * normalized — see `normalizeSig` and, for how it's used, `violations`.
  */
 export function findLeaks(srcDir = join(REPO_ROOT, SRC_REL)) {
   const found = [];
@@ -468,10 +507,11 @@ export function findLeaks(srcDir = join(REPO_ROOT, SRC_REL)) {
     callRe.lastIndex = 0;
     let m;
     while ((m = callRe.exec(text))) {
+      const sig = normalizeSig(m[1]);
       const captured = capturedErrorRe.exec(m[0]);
       if (captured) {
         const line = lineOf(text, m.index + captured.index);
-        found.push({ key: `${rel}:${line}`, file: rel, line });
+        found.push({ key: `${rel}:${line}`, file: rel, line, sig });
         continue;
       }
 
@@ -480,7 +520,7 @@ export function findLeaks(srcDir = join(REPO_ROOT, SRC_REL)) {
       const argOffset = findPositionalErrorArg(rest);
       if (argOffset === null) continue;
       const line = lineOf(text, m.index + m[0].length + argOffset);
-      found.push({ key: `${rel}:${line}`, file: rel, line });
+      found.push({ key: `${rel}:${line}`, file: rel, line, sig });
     }
   }
   return found;
@@ -498,7 +538,39 @@ export function violations(inventory = ALLOWLIST, leaks) {
   const foundKeys = new Set(leaks.map((l) => l.key));
   const declaredKeys = new Set(Object.keys(inventory));
 
-  const undeclared = leaks.filter((l) => !declaredKeys.has(l.key));
+  // Content-anchored matching (opt-in — an ALLOWLIST entry declares its own
+  // `sig`, copied from the `sig` `findLeaks` reports for it): a line-keyed
+  // entry breaks the moment an unrelated edit inserts a line above it (its
+  // key no longer matches anything — the defect a 2026-08-19 review found).
+  // An entry's OWN message text almost never changes at the same time, so
+  // matching on (file, sig) survives that shift. Deliberately conservative:
+  // only an UNAMBIGUOUS pairing counts — exactly one declared entry and
+  // exactly one found leak sharing a (file, sig) pair. A genuinely repeated
+  // message (two distinct call sites, identical text) falls back to the
+  // ordinary line-exact rules below, so each site still needs its own
+  // declaration rather than one `sig` silently covering both.
+  const fileOf = (key) => key.slice(0, key.lastIndexOf(':'));
+  const leaksBySig = new Map(); // `${file} ${sig}` -> leak[]
+  for (const l of leaks) {
+    const bucketKey = `${l.file} ${l.sig}`;
+    const bucket = leaksBySig.get(bucketKey);
+    if (bucket) bucket.push(l);
+    else leaksBySig.set(bucketKey, [l]);
+  }
+  const sigSatisfiedLeakKeys = new Set();
+  const sigSatisfiedEntryKeys = new Set();
+  for (const [entryKey, entry] of Object.entries(inventory)) {
+    if (!entry.sig) continue;
+    const bucket = leaksBySig.get(`${fileOf(entryKey)} ${entry.sig}`);
+    if (bucket && bucket.length === 1) {
+      sigSatisfiedLeakKeys.add(bucket[0].key);
+      sigSatisfiedEntryKeys.add(entryKey);
+    }
+  }
+
+  const undeclared = leaks.filter(
+    (l) => !declaredKeys.has(l.key) && !sigSatisfiedLeakKeys.has(l.key)
+  );
   if (undeclared.length > 0) {
     problems.push(
       'These log call sites interpolate a caught error, captured or positional, which can ' +
@@ -515,7 +587,7 @@ export function violations(inventory = ALLOWLIST, leaks) {
     );
   }
 
-  const stale = [...declaredKeys].filter((k) => !foundKeys.has(k));
+  const stale = [...declaredKeys].filter((k) => !foundKeys.has(k) && !sigSatisfiedEntryKeys.has(k));
   if (stale.length > 0) {
     problems.push(
       'Declared in ALLOWLIST but no `{e}` site found there anymore (fixed, moved, or ' +

--- a/scripts/check-log-error-leaks.test.mjs
+++ b/scripts/check-log-error-leaks.test.mjs
@@ -39,7 +39,9 @@ function writeSrc(files) {
 describe('findLeaks', () => {
   it('flags a single-line captured `{e}` interpolation', () => {
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {e}");\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'foo.rs:1', file: 'foo.rs', line: 1, sig: '[foo] failed: {e}' },
+    ]);
   });
 
   it('finds the site on the LINE the literal `{e}` sits on, not the macro line', () => {
@@ -55,7 +57,16 @@ describe('findLeaks', () => {
         '',
       ].join('\n'),
     });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:2', file: 'foo.rs', line: 2 }]);
+    expect(findLeaks(root)).toEqual([
+      {
+        key: 'foo.rs:2',
+        file: 'foo.rs',
+        line: 2,
+        // The whitespace-collapsed literal, so a re-wrap of the same message
+        // onto different line lengths still reads as the same signature.
+        sig: '[foo] failed ({e}); degrading — \\ more text on a continuation line',
+      },
+    ]);
   });
 
   it('does not flag `.code()`', () => {
@@ -79,17 +90,23 @@ describe('findLeaks', () => {
     // The finding: the bare-identifier check missed `e.to_string()`, one
     // method call away from the exact same leak as a bare `e`.
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e.to_string());\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'foo.rs:1', file: 'foo.rs', line: 1, sig: '[foo] failed: {}' },
+    ]);
   });
 
   it('flags a positional `err.to_owned()`, `&`-prefixed, same shape as `.to_string()`', () => {
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", &err.to_owned());\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'foo.rs:1', file: 'foo.rs', line: 1, sig: '[foo] failed: {}' },
+    ]);
   });
 
   it('flags `error.to_string()` too, for the same reason as `e`/`err`', () => {
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", error.to_string());\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'foo.rs:1', file: 'foo.rs', line: 1, sig: '[foo] failed: {}' },
+    ]);
   });
 
   it('still does not flag sanitize_reason(&e.to_string()) once .to_string() is matched', () => {
@@ -111,7 +128,9 @@ describe('findLeaks', () => {
 
   it('flags a positional bare `e` argument — the vacuity hole review found live', () => {
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {}", e);\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'foo.rs:1', file: 'foo.rs', line: 1, sig: '[foo] failed: {}' },
+    ]);
   });
 
   it('flags a positional bare `err` argument, `&`-prefixed', () => {
@@ -119,7 +138,14 @@ describe('findLeaks', () => {
     const root = writeSrc({
       'foo.rs': "log::warn!(\"[foo] board '{}' failed (error='{}')\", board, &err);\n",
     });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      {
+        key: 'foo.rs:1',
+        file: 'foo.rs',
+        line: 1,
+        sig: "[foo] board '{}' failed (error='{}')",
+      },
+    ]);
   });
 
   it('does not flag a positional argument named something other than e/err/error', () => {
@@ -131,12 +157,16 @@ describe('findLeaks', () => {
     // Live (before this fix) at postings/mod.rs:382 and
     // platform/linux_appimage.rs:170.
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {err}");\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'foo.rs:1', file: 'foo.rs', line: 1, sig: '[foo] failed: {err}' },
+    ]);
   });
 
   it('flags `{error}` too, for the same reason as `{err}`', () => {
     const root = writeSrc({ 'foo.rs': 'log::warn!("[foo] failed: {error}");\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'foo.rs:1', file: 'foo.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'foo.rs:1', file: 'foo.rs', line: 1, sig: '[foo] failed: {error}' },
+    ]);
   });
 
   it('does not flag a captured identifier that is not an error-binding name', () => {
@@ -167,14 +197,16 @@ describe('findLeaks', () => {
 
   it('scans nested directories and produces POSIX-separated keys', () => {
     const root = writeSrc({ 'a/b/c.rs': 'log::warn!("nested: {e}");\n' });
-    expect(findLeaks(root)).toEqual([{ key: 'a/b/c.rs:1', file: 'a/b/c.rs', line: 1 }]);
+    expect(findLeaks(root)).toEqual([
+      { key: 'a/b/c.rs:1', file: 'a/b/c.rs', line: 1, sig: 'nested: {e}' },
+    ]);
   });
 });
 
 describe('violations', () => {
-  const leak = (key) => {
+  const leak = (key, sig) => {
     const [file, line] = [key.slice(0, key.lastIndexOf(':')), Number(key.split(':').pop())];
-    return { key, file, line };
+    return { key, file, line, sig };
   };
 
   it('passes when every finding is declared and every entry still has a finding', () => {
@@ -222,6 +254,51 @@ describe('violations', () => {
     const problems = violations(inv, leaks);
     expect(problems.join('\n')).toContain('foo.rs:56');
     expect(problems.join('\n')).not.toContain('detection looks');
+  });
+
+  // ── `sig`: content-anchored matching survives a line-number shift ───────
+  //
+  // The defect a 2026-08-19 review found: the ALLOWLIST's only identity is
+  // `"<path>:<line>"`, so an unrelated edit that inserts a line above a
+  // declared site breaks the guard BOTH ways at once (undeclared at the new
+  // line, stale at the old one).
+
+  it('an entry with a sig survives its site moving to a new line', () => {
+    const inv = { 'foo.rs:10': { status: 'safe', reason: 'a'.repeat(30), sig: 'boom: {e}' } };
+    // The site is now at line 33 (an unrelated insertion above it), same text.
+    expect(violations(inv, [leak('foo.rs:33', 'boom: {e}')])).toEqual([]);
+  });
+
+  it("without a sig, the same line shift still breaks both ways (today's bar)", () => {
+    const inv = { 'foo.rs:10': { status: 'safe', reason: 'a'.repeat(30) } };
+    const problems = violations(inv, [leak('foo.rs:33', 'boom: {e}')]);
+    expect(problems.join('\n')).toContain('foo.rs:33');
+    expect(problems.join('\n')).toContain('not declared in ALLOWLIST');
+    expect(problems.join('\n')).toContain('foo.rs:10');
+    expect(problems.join('\n')).toContain('Declared in ALLOWLIST but no `{e}` site found');
+  });
+
+  it('a sig match is scoped to the same file — a same-text site in another file is still undeclared', () => {
+    const inv = { 'foo.rs:10': { status: 'safe', reason: 'a'.repeat(30), sig: 'boom: {e}' } };
+    const problems = violations(inv, [leak('bar.rs:10', 'boom: {e}')]);
+    expect(problems.join('\n')).toContain('bar.rs:10');
+    expect(problems.join('\n')).toContain('not declared in ALLOWLIST');
+  });
+
+  it('an AMBIGUOUS sig (two real sites, one text) falls back to line-exact rules for both', () => {
+    // Deliberately conservative: a `sig` only covers an UNAMBIGUOUS pairing.
+    // Two genuinely distinct call sites sharing the same message text must
+    // not let one declaration silently cover both.
+    const inv = { 'foo.rs:10': { status: 'safe', reason: 'a'.repeat(30), sig: 'boom: {e}' } };
+    const problems = violations(inv, [
+      leak('foo.rs:20', 'boom: {e}'),
+      leak('foo.rs:40', 'boom: {e}'),
+    ]);
+    expect(problems.join('\n')).toContain('foo.rs:20');
+    expect(problems.join('\n')).toContain('foo.rs:40');
+    expect(problems.join('\n')).toContain('not declared in ALLOWLIST');
+    expect(problems.join('\n')).toContain('foo.rs:10');
+    expect(problems.join('\n')).toContain('Declared in ALLOWLIST but no `{e}` site found');
   });
 });
 

--- a/scripts/check-log-error-leaks.test.mjs
+++ b/scripts/check-log-error-leaks.test.mjs
@@ -300,6 +300,53 @@ describe('violations', () => {
     expect(problems.join('\n')).toContain('foo.rs:10');
     expect(problems.join('\n')).toContain('Declared in ALLOWLIST but no `{e}` site found');
   });
+
+  // The mirror-image hole the ambiguity check above missed: uniqueness was
+  // required on the LEAK side only, so N declared entries sharing one
+  // (file, sig) were each satisfied by the SAME single leak and none of the
+  // N-1 stale ones was ever reported. Latent while exactly one entry uses
+  // `sig`; live the moment the header's planned mass-`sig` migration lands,
+  // since a duplicated message text is exactly what produces duplicate sigs.
+
+  it('two entries sharing one (file, sig) are not both satisfied by a single leak', () => {
+    const inv = {
+      'foo.rs:10': { status: 'safe', reason: 'a'.repeat(30), sig: 'boom: {e}' },
+      'foo.rs:20': { status: 'safe', reason: 'a'.repeat(30), sig: 'boom: {e}' },
+    };
+    const problems = violations(inv, [leak('foo.rs:10', 'boom: {e}')]);
+    expect(problems.join('\n')).toContain('foo.rs:20');
+    expect(problems.join('\n')).toContain('Declared in ALLOWLIST but no `{e}` site found');
+    // …and the entry that DOES still have its site is untouched.
+    expect(problems.join('\n')).not.toContain('foo.rs:10');
+  });
+
+  it('five entries sharing one (file, sig) leave four stale, not zero', () => {
+    const inv = Object.fromEntries(
+      [10, 20, 30, 40, 50].map((line) => [
+        `foo.rs:${line}`,
+        { status: 'safe', reason: 'a'.repeat(30), sig: 'boom: {e}' },
+      ])
+    );
+    const problems = violations(inv, [leak('foo.rs:30', 'boom: {e}')]);
+    const text = problems.join('\n');
+    for (const line of [10, 20, 40, 50]) expect(text).toContain(`foo.rs:${line}`);
+    expect(text).toContain('Declared in ALLOWLIST but no `{e}` site found');
+    expect(text).not.toContain('foo.rs:30');
+  });
+
+  it('a stale sig entry is still reported when its sig matches a leak another entry declares', () => {
+    // Uniqueness on both sides is not enough on its own: one sig entry, one
+    // leak with that sig — but the leak is already claimed line-exactly by a
+    // DIFFERENT entry, so the sig entry has no site of its own and is stale.
+    const inv = {
+      'foo.rs:20': { status: 'safe', reason: 'a'.repeat(30) },
+      'foo.rs:99': { status: 'safe', reason: 'a'.repeat(30), sig: 'boom: {e}' },
+    };
+    const problems = violations(inv, [leak('foo.rs:20', 'boom: {e}')]);
+    expect(problems.join('\n')).toContain('foo.rs:99');
+    expect(problems.join('\n')).toContain('Declared in ALLOWLIST but no `{e}` site found');
+    expect(problems.join('\n')).not.toContain('foo.rs:20');
+  });
 });
 
 describe('MIN_SITES (the CLI-level absolute floor, not folded into violations())', () => {


### PR DESCRIPTION
Five threads folded into one PR, plus the pre-PR gate fixes they turned up.

**Read this first: the reported link bug is NOT fixed here.** A bare domain with no path (`aijobhunter.app`) still renders as plain text. The fix was built, reviewed, and reverted — see section 3. `model/rich.rs` has zero net diff against main.

## 1. A bare present-tense word no longer fakes a date context

`is_open_ended` returned true for ordinary prose containing `current`, `ongoing` or `actual` at a word boundary:

```
is_open_ended("Reduced actual costs by 20% in 2023")   = true
is_open_ended("Led the current platform migration")    = true
is_open_ended("Reduced costs by 20% in 2023")          = false   <- control
```

`factual::unsupported_date_issues` decides `date_context` by matching `PRESENT_MARKERS` the same way, so a truthful bullet — "cut spend 30% below the 2019 baseline while keeping the ongoing migration on schedule" — raised a false `factual.unsupported_date` Critical whenever 2019 was absent from the source.

Word boundaries were already the previous fix for this class (`present` inside *presented*), so the fix is deliberately not "add more boundaries".

## 2. Translation goes through the active provider

The root bug: `translate_if_needed` read `store.embedding_config()` and used the embedding provider as a proxy for the active one. It never asked which provider the user had actually selected.

Consequences measured from diagnostics logs:

- `first_chat_model()` returned whatever Ollama listed first. Nobody chose the 27B model; it just sorted first. **117 seconds for one job-ad translation**, which starved the 15s embed timeout and silently degraded semantic scoring to keyword-only.
- Every embed error mapped to `"Ollama unreachable"`, which misdiagnosed a timeout as a connectivity failure twice.

Now reads `ai_config::active_config()`. The `is_local()` cost gate is untouched — metered API keys still skip translation, because autopilot translates up to 20 postings per scheduled run indefinitely.

A fast Ollama-specific reachability gate was restored during review: dropping `reachable_chat_model` had removed the 3s skip, so an unreachable daemon would block each attempt for the full completion deadline — the same run-starving shape this PR exists to fix, reachable again by another route.

Also logs the embedding model on success and failure, and makes the silent `nomic-embed-text` fallback loud.

## 3. The bare-domain link widening was reverted

Linking bare lowercase domains was implemented, then reverted after review found `urls_in()` serves two opposite purposes:

- in the validator, a match means **this text is a link**
- at `pipeline/resume/source.rs:312`, a match means **delete this token from the user's résumé**

The widened rule silently deleted lowercase technology tokens from source résumés, over-linked lowercase library names in exports, reopened a documented false-Critical regression, and made `urls_in("jane.doe@gmail.com")` return `["gmail.com"]` — a phantom domain the renderer never produces, creating a fresh renderer/validator divergence in the opposite direction.

A context-aware version was investigated and rejected as not reachable in a small diff: `split_urls`/`tokenize_rich` are called generically from `model/adapter.rs`, `export/typst_engine/letter.rs`, `contact_profile/`, and `export/docx_renderer.rs` with no line-kind context threaded through.

Reverting restores the pre-branch 4-arm regex on both sides. The renderer no longer hyperlinks such text either, so nothing renders as a verified-looking link the validator cannot see.

**Still open:** the original report. Bare domains without a path remain plain text.

## 4. Data loss fix found by the gate

`source.rs:312` filtered stack-line tokens with `!item.is_empty() && urls_in(item).is_empty()` and no `names_a_resource` guard, unlike its two siblings at `:253` and `:288`. Any `urls_in` match deleted the token outright. Guard added; covered by a test that fails without it.

## 5. Prompt quality control in AI settings

`promptQuality` was only reachable from the résumé analyzer despite applying to the Ollama branch generally. Adds the control to the AI settings page with search-index entries and en/de translations.

## Gate fixes

- **Leak guard was line-number keyed**, so the routing commit shifted a declared site 1153 -> 1176 and made the branch unpushable. Entries can now opt into content-anchored matching via the log call's own format string; an entry survives its site moving within the same file. The other ~56 entries are a documented follow-up.
- **`try_state` restored** where it had been changed to `state`, which panics — the module contracts it must never error.
- **Two new `tracing::warn!` sites sanitized.** One wraps a `reqwest::Error`, and Gemini authenticates via a `?key=` query param.
- **`documents/mod.rs` was at exactly 1400 LOC**, the R8 hard cap, with comments trimmed to fit. Split into `documents/embedding.rs` (-244/+221) instead.
- **Dead disjunct removed** in `entry.rs`: `|| is_open_ended(s)` could never be true once `is_open_ended` required a year. Two doc comments describing the pre-fix behaviour as current were corrected.

## Verification

`cargo fmt --check`, `cargo clippy --all-features --locked --all-targets -D warnings`, and `cargo test --all-features --locked` (without `--lib`, which skips `tests/*.rs`) all clean: 4395 lib + 18 architecture + 20 egress + 3 eval + 3 kill-recovery.

Every new guard was mutation-checked in both directions — the mutation was applied, the test observed failing, then reverted. A green suite was treated as uninformative here, since all three defects on the parent branch were invisible to 4300+ passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI prompt-quality settings with Full, Automatic, and Compact options, searchable from Settings.
  * Added localized English and German text for the new setting.

* **Bug Fixes**
  * Improved translation provider and model selection, including clearer Ollama availability handling.
  * Improved Ollama timeout and connection-error reporting across AI operations.
  * Fixed date recognition for ongoing roles and reduced false date detections.
  * Preserved technology names that resemble domains, such as `crates.io`, when importing resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->