### PR TITLE
ci: stop the linux dependency step hanging for the whole job timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,11 +242,32 @@ jobs:
         # (same SHA as .github/actions/setup-rust — bump both together).
         uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
+      # Three independent ways this step can block forever on a hosted runner,
+      # each closed below. Without them it hung once for the full 60-minute job
+      # timeout and took the whole release with it (every downstream job -
+      # Create Release, update manifest, Homebrew cask, landing page - skipped).
+      #
+      # 1. needrestart is apt-hooked on ubuntu-22.04 and prompts "Which services
+      #    should be restarted?", which nothing answers in CI. DEBIAN_FRONTEND
+      #    alone does NOT suppress it - needrestart reads its own env var.
+      # 2. unattended-upgrades holds the dpkg lock, and apt waits for it with no
+      #    timeout by default. It is supposed to be disabled on hosted images and
+      #    currently is not: actions/runner-images#13271 (open, regressed in the
+      #    2025-10-23 images, affects 22.04 and 24.04). DPkg::Lock::Timeout makes
+      #    the wait bounded instead of infinite.
+      # 3. debconf can prompt on its own; DEBIAN_FRONTEND covers that one.
+      #
+      # timeout-minutes is the backstop that matters most: it turns "silently
+      # burn the hour and lose the release" into "fail in 15, re-run".
       - name: 🐧 Install Linux Dependencies
         if: runner.os == 'Linux'
+        timeout-minutes: 15
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get update -o DPkg::Lock::Timeout=300
+          sudo apt-get install -y -o DPkg::Lock::Timeout=300 \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \


### PR DESCRIPTION
## What

The release build's `🐧 Install Linux Dependencies` step had no interactive-prompt suppression, no dpkg lock timeout, and no step timeout — so it could block indefinitely, and did.

Run `32295059433`, `ubuntu-22.04` leg:

| attempt | in step | outcome |
| --- | --- | --- |
| 1 | 19:48:32Z → 20:48:57Z | killed by the job's `timeout-minutes: 60` |
| 2 | 21:36:29Z → 21:55Z+ | same step, still hanging ~19 min in |

macOS ×2 and Windows passed on both attempts, so it is Linux-specific. Attempt 1 took the release with it — `Create Release`, `Generate Update Manifest`, `Update Homebrew Cask` and `Update Landing Download Page` all skipped.

## Why it hangs

Three independent blocking paths, none of them previously closed:

1. **`needrestart`** is apt-hooked on ubuntu-22.04 and prompts *"Which services should be restarted?"*, which nothing answers in CI. `DEBIAN_FRONTEND` does **not** suppress this — needrestart reads its own `NEEDRESTART_MODE`. ([actions/runner-images#122](https://github.com/actions/runner-images/issues/122))
2. **`unattended-upgrades` holds the dpkg lock** and apt waits for it with no timeout by default. It is supposed to be disabled on hosted images and currently is not — [actions/runner-images#13271](https://github.com/actions/runner-images/issues/13271) is **open**, regressed in the 2025-10-23 images, and affects both 22.04 and 24.04.
3. **debconf** can prompt on its own, which `DEBIAN_FRONTEND` covers.

## The change

```yaml
timeout-minutes: 15
env:
  DEBIAN_FRONTEND: noninteractive
  NEEDRESTART_MODE: a
run: |
  sudo apt-get update -o DPkg::Lock::Timeout=300
  sudo apt-get install -y -o DPkg::Lock::Timeout=300 \
```

`timeout-minutes` is the backstop and is worth having on its own: it turns *silently burn the hour and lose the release* into *fail in 15 with a log naming the package it died on*.

## Deliberately not changed

The package list. Tauri's official v2 workflow installs a shorter set, and `libgtk-3-dev` / `libsoup-3.0-dev` / `libjavascriptcoregtk-4.1-dev` are transitive dependencies of `libwebkit2gtk-4.1-dev` while `build-essential` / `curl` / `wget` / `file` are preinstalled on the image. Trimming would shave seconds, not minutes — the hang is a lock/prompt problem, not a volume problem — and this is a release path, so it is not worth the regression risk in the same PR.

## Verification

`release.yml` parses and the step resolves with `timeout-minutes: 15` and both env vars set. The real proof is the next dispatch: the workflow file is read from the branch you dispatch on, while the job checks out the release tag — so once this is on `main`, re-dispatching reaches the same tag with the fixed workflow, without re-cutting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
