### PR TITLE
fix(landing): stop the a11y page minting phantom numeric urls

### DIFF
--- a/apps/landing/src/components/accessibility/sections/Conformance.tsx
+++ b/apps/landing/src/components/accessibility/sections/Conformance.tsx
@@ -140,10 +140,14 @@ export function Conformance() {
         <p>
           <b>This fix is scoped to the home view.</b> The renderer has roughly 1,100{' '}
           <code>text-foreground/NN</code> usages, around 460 of them at the low-alpha steps (
-          <code>/30</code>, <code>/35</code>, <code>/40</code>, <code>/45</code>, <code>/55</code>)
-          that measure below 4.5:1 for small text. Only the home view has ever been scanned; every
-          other view is unaudited and likely carries the same defect. This is the single most
-          important known barrier on this page.
+          {/* Steps are written WITHOUT a leading slash on purpose. A bare `/30` lands in this
+              page's RSC payload as the JSON string "/30", which Googlebot reads as a relative
+              URL and crawls — that is where four phantom /NN 404s in Search Console came from.
+              The `text-foreground/NN` form above already establishes the syntax. */}
+          <code>30</code>, <code>35</code>, <code>40</code>, <code>45</code>, <code>55</code>) that
+          measure below 4.5:1 for small text. Only the home view has ever been scanned; every other
+          view is unaudited and likely carries the same defect. This is the single most important
+          known barrier on this page.
         </p>
         <p>
           Two <code>best-practice</code> axe rules also remain here — <b>landmark-unique</b> (1


### PR DESCRIPTION
## What

Search Console reports four **Not found (404)** pages, first detected 15 Aug:

| URL | last crawled |
| --- | --- |
| `https://aijobhunter.app/40` | Aug 17 |
| `https://aijobhunter.app/30` | Aug 16 |
| `https://aijobhunter.app/35` | Aug 16 |
| `https://aijobhunter.app/55` | Aug 15 |

Nothing links to them. No `href`, `src`, `xlink:href` or `url()` in the built output emits a bare number — I checked all four before looking further.

## Where they come from

`/accessibility`. The page documents the low-alpha contrast ramp as bare code spans:

```tsx
<code>/30</code>, <code>/35</code>, <code>/40</code>, <code>/45</code>, <code>/55</code>
```

Those land in the route's RSC payload (`out/accessibility/__next.accessibility/__PAGE__.txt`) as JSON string values:

```
["$","code",null,{"children":"/30"}], ", ", ["$","code",null,{"children":"/35"}], …
```

Googlebot extracts URL-shaped strings from JS/JSON payloads, and a slash-leading string reads as a relative URL — so it resolves `"/30"` against the origin and crawls it. **The page disclosing our accessibility debt was manufacturing our indexing errors.**

`/45` is in the source too but hadn't been crawled yet, which is why only four of the five showed up.

## The change

Drop the leading slash from the step values. The `text-foreground/NN` form on the line directly above already establishes the class syntax, so the slashes conveyed nothing and cost four crawl errors. A comment records why, so nobody "tidies" them back.

## Not changed

- The four 404s themselves need no redirect or removal request — 404 is the correct response for a URL that never existed, and they'll drop out of the report once the payload stops naming them.
- `<code>/404</code>`, `<code>/_not-found</code>` and `<code>/mission-control</code>` elsewhere on the same page are left alone: those are real routes, and Google crawling them is correct.

## Context from the rest of the report

Reviewed all four reasons while I was in there; the other three need no code change:

- **Excluded by 'noindex' (3)** — `/mission-control`, `/_not-found`, `/404`. Exactly as designed.
- **Alternate page with proper canonical tag (5)** — `.html` twins from the static export plus two `?ref=` inbound links. Correctly canonicalised; Google working as intended.
- **Duplicate without user-selected canonical (1)** — `/storybook/?path=/story/components-accordion--default`. Storybook is live on the production domain and its query-string story URLs are an unbounded duplicate surface. Raised separately rather than fixed here, since whether it should be indexable at all is a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
