### PR TITLE
fix: make the v0.139.0 score tab actually score, and stop embeds timing out under load

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/mod.rs
@@ -27,6 +27,9 @@ mod ollama_cloud;
 mod openai;
 mod research; // shared company-research prompt spec + helpers used by every `research()`
 mod retry; // bounded exponential backoff for the non-streaming complete/embed paths
+/// Re-exported for `autopilot::rerank`'s compile-time budget assertion — the
+/// re-rank breaker's arithmetic depends on how many attempts one embed spends.
+pub(crate) use retry::EMBED_BUDGET_ATTEMPTS;
 pub mod search; // web-search backends (the retrieval half of research) — NOT AI providers
 mod stream; // shared streaming loop (cancel-check + chunk read + emit + complete) for cloud adapters
 mod structured; // `complete_structured`'s prompt-discipline default + the per-provider JSON wire shapes

--- a/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
@@ -75,8 +75,9 @@ const MAX_STREAM_DELAY_MS: u64 = 30_000;
 /// 2 s is a deliberate small value: a cloud 429 rejection round-trips in a few
 /// hundred milliseconds, so this is roughly 4× the observed floor plus
 /// handshake headroom, while staying far below the SMALLEST per-attempt bound
-/// that reaches this loop (`timeouts::OLLAMA_EMBED`, 15 s) — so it can only ever
-/// refuse an attempt that was already doomed, never one that had a real chance.
+/// that reaches this loop (`timeouts::EMBED`, 30 s — it took that title from
+/// `OLLAMA_EMBED` when the latter widened to 60 s) — so it can only ever refuse
+/// an attempt that was already doomed, never one that had a real chance.
 const MIN_RETRY_ATTEMPT_FLOOR: Duration = Duration::from_secs(2);
 
 /// How many per-attempt timeouts one EMBED call may spend in total (see
@@ -170,7 +171,7 @@ where
 /// to a second attempt. That is the intended trade for a 120 s/300 s completion
 /// — an attempt that spent five minutes is not worth repeating, and the outer
 /// `quality_run_deadline` counts exactly one of them per call. It is the WRONG
-/// trade here: `OLLAMA_EMBED` is 15 s, and the case that needs a second attempt
+/// trade here: `OLLAMA_EMBED` is 60 s, and the case that needs a second attempt
 /// is the first embed of an indexing run, where Ollama is COLD-LOADING the
 /// embedding model and the first request times out while the load completes. A
 /// fresh attempt then succeeds immediately; without one, the first document of
@@ -509,12 +510,12 @@ mod retry_loop_tests {
     ///
     /// Collapsing the per-attempt timeout into the sequence budget made
     /// retry-after-timeout structurally unreachable at every call site — correct
-    /// for a 300 s completion, wrong for a 15 s embed, where the first request of
+    /// for a 300 s completion, wrong for a 60 s embed, where the first request of
     /// an indexing run times out while Ollama cold-loads the embedding model and
     /// a fresh attempt then succeeds at once. `send_embed_with_retry` separates
     /// the two values so that recovery exists again.
     ///
-    /// The 2 s per-attempt bound is scaled down from `OLLAMA_EMBED`'s 15 s but the
+    /// The 2 s per-attempt bound is scaled down from `OLLAMA_EMBED`'s 60 s but the
     /// arithmetic is the real one: attempt 1 burns the full per-attempt timeout,
     /// the 500 ms backoff follows, and the 3× sequence budget still leaves 3.5 s —
     /// comfortably over the 2 s floor, so a slow host cannot flip it. Mutation

--- a/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
@@ -177,8 +177,13 @@ where
 /// fresh attempt then succeeds immediately; without one, the first document of
 /// an indexing run fails for a reason that has already gone away.
 ///
-/// The worst case is unchanged from before that collapse (`MAX_ATTEMPTS` × the
-/// per-attempt timeout + backoff) and it is bounded. Indexing has no run-level
+/// The worst case is unchanged from before that collapse and it is bounded — and
+/// the bound is the WHOLE sequence, not just its request time: `budget` below is
+/// wall clock measured from the first attempt, and `send_with_retry_capped` pays
+/// each backoff OUT of it (projecting `spent` past the sleep before deciding
+/// whether another attempt still fits). So one call costs at most
+/// `per_attempt` × [`EMBED_BUDGET_ATTEMPTS`] in total, backoff included — never
+/// that plus backoff. Indexing has no run-level
 /// deadline that counts it — but the autopilot re-rank phase DOES: this budget
 /// (`per_attempt` × [`EMBED_BUDGET_ATTEMPTS`]) is what one degraded job costs
 /// there, and `RERANK_DEGRADE_BREAKER` of them has to fit inside

--- a/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/retry.rs
@@ -75,14 +75,14 @@ const MAX_STREAM_DELAY_MS: u64 = 30_000;
 /// 2 s is a deliberate small value: a cloud 429 rejection round-trips in a few
 /// hundred milliseconds, so this is roughly 4× the observed floor plus
 /// handshake headroom, while staying far below the SMALLEST per-attempt bound
-/// that reaches this loop (`timeouts::EMBED`, 30 s — it took that title from
-/// `OLLAMA_EMBED` when the latter widened to 60 s) — so it can only ever refuse
-/// an attempt that was already doomed, never one that had a real chance.
+/// that reaches this loop (`timeouts::EMBED` and `timeouts::OLLAMA_EMBED`, both
+/// 30 s) — so it can only ever refuse an attempt that was already doomed, never
+/// one that had a real chance.
 const MIN_RETRY_ATTEMPT_FLOOR: Duration = Duration::from_secs(2);
 
 /// How many per-attempt timeouts one EMBED call may spend in total (see
 /// [`send_embed_with_retry`]).
-const EMBED_BUDGET_ATTEMPTS: u32 = 3;
+pub(crate) const EMBED_BUDGET_ATTEMPTS: u32 = 3;
 
 /// Whether a response status is worth retrying. 429 (rate limit / quota) and 5xx
 /// (service errors) are transient; everything else (success, 4xx client errors)
@@ -171,16 +171,20 @@ where
 /// to a second attempt. That is the intended trade for a 120 s/300 s completion
 /// — an attempt that spent five minutes is not worth repeating, and the outer
 /// `quality_run_deadline` counts exactly one of them per call. It is the WRONG
-/// trade here: `OLLAMA_EMBED` is 60 s, and the case that needs a second attempt
+/// trade here: `OLLAMA_EMBED` is 30 s, and the case that needs a second attempt
 /// is the first embed of an indexing run, where Ollama is COLD-LOADING the
 /// embedding model and the first request times out while the load completes. A
 /// fresh attempt then succeeds immediately; without one, the first document of
 /// an indexing run fails for a reason that has already gone away.
 ///
 /// The worst case is unchanged from before that collapse (`MAX_ATTEMPTS` × the
-/// per-attempt timeout + backoff), it is bounded, and no outer deadline is
-/// derived from the embed constants — indexing has no run-level deadline that
-/// counts them.
+/// per-attempt timeout + backoff) and it is bounded. Indexing has no run-level
+/// deadline that counts it — but the autopilot re-rank phase DOES: this budget
+/// (`per_attempt` × [`EMBED_BUDGET_ATTEMPTS`]) is what one degraded job costs
+/// there, and `RERANK_DEGRADE_BREAKER` of them has to fit inside
+/// `RERANK_STEP_TIMEOUT` or the breaker never fires. `rerank.rs` asserts that
+/// at compile time; do not widen `OLLAMA_EMBED` or this constant without
+/// reading it.
 pub async fn send_embed_with_retry<F>(build: F, per_attempt: Duration) -> reqwest::Result<Response>
 where
     F: FnMut() -> RequestBuilder,
@@ -510,12 +514,12 @@ mod retry_loop_tests {
     ///
     /// Collapsing the per-attempt timeout into the sequence budget made
     /// retry-after-timeout structurally unreachable at every call site — correct
-    /// for a 300 s completion, wrong for a 60 s embed, where the first request of
+    /// for a 300 s completion, wrong for a 30 s embed, where the first request of
     /// an indexing run times out while Ollama cold-loads the embedding model and
     /// a fresh attempt then succeeds at once. `send_embed_with_retry` separates
     /// the two values so that recovery exists again.
     ///
-    /// The 2 s per-attempt bound is scaled down from `OLLAMA_EMBED`'s 60 s but the
+    /// The 2 s per-attempt bound is scaled down from `OLLAMA_EMBED`'s 30 s but the
     /// arithmetic is the real one: attempt 1 burns the full per-attempt timeout,
     /// the 500 ms backoff follows, and the 3× sequence budget still leaves 3.5 s —
     /// comfortably over the 2 s floor, so a slow host cannot flip it. Mutation

--- a/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
@@ -159,22 +159,29 @@ pub fn ollama_completion_deadline(effort: Option<&str>) -> Duration {
 /// Gemini.
 pub const EMBED: Duration = Duration::from_secs(30);
 
-/// Local Ollama embeddings (`/api/embeddings`): the local daemon's embeddings
-/// endpoint, bounded LOOSER than cloud embeddings — the opposite of the usual
-/// local-is-faster assumption, and deliberately so.
+/// Local Ollama embeddings (`/api/embeddings`): the same bound as cloud
+/// [`EMBED`], not a tighter one — local is not reliably faster here.
 ///
 /// A local daemon shares one GPU with whatever chat model is loaded, and Ollama
-/// serialises by default: an embed request queues behind an in-flight generation
-/// rather than running beside it. Measured in the field at the previous 15s
-/// bound — embed cycles failing in exactly 45s (3 x 15s) while a 27B chat
-/// completion held the GPU for 213s. That is a queue wait, not an unreachable
-/// daemon, and failing it produced a silent keyword-only degrade.
+/// serialises by default: an embed request queues behind an in-flight
+/// generation rather than running beside it. Measured in the field at the
+/// previous 15s bound — embed cycles failing in exactly 45s (3 x 15s) while a
+/// 27B chat completion held the GPU for 213s. That is a queue wait, not an
+/// unreachable daemon, and failing it produced a silent keyword-only degrade.
+/// A cold load of a large embedding model (e.g. a 4B / 2560-dim one) can exceed
+/// 15s unaided too.
 ///
-/// A cold load of a large embedding model (e.g. a 4B / 2560-dim one) can also
-/// exceed 15s unaided. The cost of the wider bound is that a genuinely dead
-/// daemon now takes 3 x 60s to give up instead of 3 x 15s; a refused connection
-/// still fails fast, because that is a transport error rather than a timeout.
-pub const OLLAMA_EMBED: Duration = Duration::from_secs(60);
+/// 30s is a CEILING, not a preference: this constant is coupled to the
+/// autopilot re-rank phase, where
+/// `OLLAMA_EMBED * EMBED_BUDGET_ATTEMPTS * RERANK_DEGRADE_BREAKER` must stay
+/// under `RERANK_STEP_TIMEOUT` or the breaker can never fire and the phase
+/// burns its full wall clock hourly instead of giving up. That invariant is
+/// asserted at compile time in `commands/autopilot/rerank.rs` — raising this
+/// past ~33s fails the build rather than silently re-opening that defect.
+///
+/// A refused connection still fails fast either way: that is a transport
+/// error, not a timeout.
+pub const OLLAMA_EMBED: Duration = Duration::from_secs(30);
 
 // ── Company research (provider-native web search) ───────────────────────────────
 

--- a/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
@@ -459,6 +459,24 @@ mod tests {
     // a reported reasoning-model session timed out, and each cover letter was
     // written with no company knowledge and no visible failure.
 
+    /// The rerank const assertion bounds `OLLAMA_EMBED` from ABOVE only, so a
+    /// revert to the old 15s would satisfy it and silently restore the budget the
+    /// field measurement showed was too small. Pin the value here, and pin the
+    /// doc's own claim ("the same bound as cloud EMBED, not a tighter one") next
+    /// to it so the two cannot drift apart silently.
+    #[test]
+    fn ollama_embed_is_pinned_at_thirty_seconds_and_matches_the_cloud_bound() {
+        assert_eq!(
+            OLLAMA_EMBED,
+            Duration::from_secs(30),
+            "15s could not survive a local chat model holding the GPU; 30s is also the              ceiling that keeps RERANK_DEGRADE_BREAKER able to fire"
+        );
+        assert_eq!(
+            OLLAMA_EMBED, EMBED,
+            "OLLAMA_EMBED's doc claims local is not bounded tighter than cloud — keep              these equal or reword it"
+        );
+    }
+
     #[test]
     fn research_deadline_exceeds_the_inner_search_bounds_it_wraps() {
         // It wraps a web search AND a synthesis completion. If the outer bound

--- a/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
+++ b/apps/desktop/src-tauri/src/commands/ai_provider/timeouts.rs
@@ -160,8 +160,21 @@ pub fn ollama_completion_deadline(effort: Option<&str>) -> Duration {
 pub const EMBED: Duration = Duration::from_secs(30);
 
 /// Local Ollama embeddings (`/api/embeddings`): the local daemon's embeddings
-/// endpoint, bounded tighter than cloud embeddings.
-pub const OLLAMA_EMBED: Duration = Duration::from_secs(15);
+/// endpoint, bounded LOOSER than cloud embeddings — the opposite of the usual
+/// local-is-faster assumption, and deliberately so.
+///
+/// A local daemon shares one GPU with whatever chat model is loaded, and Ollama
+/// serialises by default: an embed request queues behind an in-flight generation
+/// rather than running beside it. Measured in the field at the previous 15s
+/// bound — embed cycles failing in exactly 45s (3 x 15s) while a 27B chat
+/// completion held the GPU for 213s. That is a queue wait, not an unreachable
+/// daemon, and failing it produced a silent keyword-only degrade.
+///
+/// A cold load of a large embedding model (e.g. a 4B / 2560-dim one) can also
+/// exceed 15s unaided. The cost of the wider bound is that a genuinely dead
+/// daemon now takes 3 x 60s to give up instead of 3 x 15s; a refused connection
+/// still fails fast, because that is a transport error rather than a timeout.
+pub const OLLAMA_EMBED: Duration = Duration::from_secs(60);
 
 // ── Company research (provider-native web search) ───────────────────────────────
 

--- a/apps/desktop/src-tauri/src/commands/autopilot/rerank.rs
+++ b/apps/desktop/src-tauri/src/commands/autopilot/rerank.rs
@@ -316,6 +316,27 @@ impl RerankEnv for LiveRerankEnv<'_> {
 pub(super) const RERANK_STEP_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(SEMANTIC_RERANK_MAX as u64 * 15);
 
+/// The per-job allowance above (the bare `15`) started life as
+/// `timeouts::OLLAMA_EMBED`, and the two have to stay compatible even though the
+/// literal no longer says so: [`RERANK_DEGRADE_BREAKER`] consecutive degraded
+/// jobs must FIT inside [`RERANK_STEP_TIMEOUT`], or the wall clock kills the
+/// phase mid-job first and the breaker can never reach its threshold — which is
+/// precisely the "full phase burned hourly to produce nothing" that breaker
+/// exists to prevent.
+///
+/// One degraded job costs a whole embed budget: `OLLAMA_EMBED` ×
+/// `EMBED_BUDGET_ATTEMPTS` (see `send_embed_with_retry`). Asserted here rather
+/// than commented, because the coupling is invisible from `timeouts.rs` — a
+/// well-meaning widening of `OLLAMA_EMBED` now fails the BUILD instead of
+/// silently disabling the breaker.
+const _: () = assert!(
+    (crate::commands::ai_provider::timeouts::OLLAMA_EMBED.as_secs()
+        * (crate::commands::ai_provider::EMBED_BUDGET_ATTEMPTS as u64)
+        * (RERANK_DEGRADE_BREAKER as u64))
+        < RERANK_STEP_TIMEOUT.as_secs(),
+    "RERANK_DEGRADE_BREAKER embed budgets must fit inside RERANK_STEP_TIMEOUT —      lower OLLAMA_EMBED, lower RERANK_DEGRADE_BREAKER, or raise RERANK_STEP_TIMEOUT"
+);
+
 /// Phase 2 of the two-phase rank, exactly as the command runs it: the GATE,
 /// then the wall-clock-bounded re-rank.
 ///

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
@@ -94,6 +94,8 @@ const mockSessionState: {
     applyAtsMode: boolean;
     applyForId: string | null;
     applyRun: { forId: string; runId: string; jobId: string } | null;
+    /** The autopilot one-shot seed — text only, never a saved-doc id. */
+    applySeedResume: string | null;
   };
   setApplicationApply: typeof mockSetApplicationApply;
   // Only `lastAppliedId` is read by the component (the resetScroll gate); kept
@@ -107,6 +109,7 @@ const mockSessionState: {
     applyAtsMode: false,
     applyForId: null,
     applyRun: null,
+    applySeedResume: null,
   },
   setApplicationApply: mockSetApplicationApply,
   autopilot: { lastAppliedId: null },
@@ -139,10 +142,12 @@ vi.mock('@/features/documents/components/TailorFlow', () => ({
     seedGeneration,
     onJobDescChange,
     persistence,
+    resumeDocId,
   }: {
     seedGeneration?: { id: string };
     onJobDescChange?: (text: string) => void;
     persistence?: { runId: string | null; runJobId: string | null };
+    resumeDocId?: string;
   }) => {
     capturedOnJobDescChange = onJobDescChange;
     return (
@@ -151,6 +156,7 @@ vi.mock('@/features/documents/components/TailorFlow', () => ({
         data-seedgenid={seedGeneration?.id ?? ''}
         data-runid={persistence?.runId ?? ''}
         data-runjobid={persistence?.runJobId ?? ''}
+        data-resumedocid={resumeDocId ?? ''}
       />
     );
   },
@@ -184,6 +190,11 @@ let mockImportJobUrlIsError = false;
 // JD-resolve (useResolveJobUrl) — controllable so BriefTab loading-state tests
 // can simulate the in-flight window before the auto-resolve settles.
 let mockResolveJobUrlIsFetching = false;
+// Saved-documents list + the default résumé's text — controllable so the
+// seedResumeDocId tests below can drive the "matched" vs. "no saved doc"
+// shapes `useDefaultResumeId`/`useDocumentText` resolve to.
+let mockDocsData: { _id: string; name?: string; isDefault?: boolean }[] = [];
+let mockDocumentTextData: string | undefined = undefined;
 /** `acceptStatusEvent.mutate`/`rejectStatusEvent.mutate` — resolve successfully
  *  (an empty, error-free result) by default. `onSuccess` takes the real
  *  `{ error? }` payload — the production handler branches on `data.error`,
@@ -227,8 +238,8 @@ vi.mock('@/services', () => ({
   }),
   useAcceptStatusEvent: () => ({ mutate: mockAcceptStatusEventMutate }),
   useRejectStatusEvent: () => ({ mutate: mockRejectStatusEventMutate }),
-  useDocuments: () => ({ data: [], isLoading: false }),
-  useDocumentText: () => ({ data: undefined, isLoading: false }),
+  useDocuments: () => ({ data: mockDocsData, isLoading: false }),
+  useDocumentText: () => ({ data: mockDocumentTextData, isLoading: false }),
   useImportJobUrl: () => ({
     mutate: mockImportJobUrlMutate,
     isPending: false,
@@ -349,6 +360,9 @@ beforeEach(() => {
   mockImportJobUrlMutate.mockReset();
   mockImportJobUrlIsError = false;
   mockResolveJobUrlIsFetching = false;
+  mockDocsData = [];
+  mockDocumentTextData = undefined;
+  mockSessionState.applicationApply.applySeedResume = null;
   capturedOnJobDescChange = undefined;
   mockAcceptStatusEventMutate.mockClear();
   mockAcceptStatusEventMutate.mockImplementation(
@@ -1272,6 +1286,83 @@ describe('ApplicationDetailPage — Documents tab toolbar', () => {
     ).not.toBeInTheDocument();
     // Referral button always present.
     expect(screen.getByRole('button', { name: /autopilot\.referral\.open/i })).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ApplicationDetailPage — seedResumeDocId (Score tab résumé identity)
+//
+// `seedResumeText` has THREE fallbacks (autopilot one-shot → default résumé
+// text → previous generation's output); only the middle one has a saved-
+// document backing. The id must be seeded ONLY when the visible text IS that
+// document's text — an id that doesn't match the seeded text is the exact
+// drift `useResumeInput`'s `selectDoc` contract exists to prevent (see
+// index.tsx's `seedResumeDocId` comment).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ApplicationDetailPage — seedResumeDocId (Score tab résumé identity)', () => {
+  it("seeds the default résumé id when the seeded text IS that résumé's text (matched branch)", () => {
+    mockTab = 'documents';
+    mockDocsData = [{ _id: 'doc-1', name: 'Resume.pdf', isDefault: true }];
+    mockDocumentTextData = 'Default resume text';
+    mockSessionState.applicationApply.applySeedResume = null; // no autopilot one-shot
+    mockUseAiGenerations.mockReturnValue({ data: [] }); // no generation fallback needed
+
+    renderLoaded({ id: 'app-1' });
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute(
+      'data-resumedocid',
+      'doc-1'
+    );
+  });
+
+  it('does NOT seed a résumé id when the text came from the autopilot one-shot seed', () => {
+    mockTab = 'documents';
+    mockDocsData = [{ _id: 'doc-1', name: 'Resume.pdf', isDefault: true }];
+    // Even though a default résumé (with its OWN text) exists, the one-shot
+    // seed wins priority — an id backing DIFFERENT text must never be seeded.
+    mockDocumentTextData = 'Default resume text';
+    mockSessionState.applicationApply.applySeedResume = 'Autopilot one-shot resume text';
+    mockUseAiGenerations.mockReturnValue({ data: [] });
+
+    renderLoaded({ id: 'app-1' });
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute(
+      'data-resumedocid',
+      ''
+    );
+  });
+
+  it("does NOT seed a résumé id when the text came from a previous generation's output", () => {
+    mockTab = 'documents';
+    mockDocsData = []; // no saved résumé at all — defaultResumeId is null
+    mockDocumentTextData = undefined;
+    mockSessionState.applicationApply.applySeedResume = null;
+    // `renderLoaded` always overwrites the generations mock to `{ data: [] }`
+    // (it's the "no matching generation" default for every OTHER test in this
+    // file) — call the two mocks + render directly instead, mirroring the
+    // "generation matching" describe block above.
+    const app = makeApp({ id: 'app-1', jobUrl: 'https://acme.com/job/1' });
+    mockUseApplication.mockReturnValue({
+      data: { application: app, events: [] },
+      isLoading: false,
+      isError: false,
+    });
+    mockUseAiGenerations.mockReturnValue({
+      data: [
+        {
+          ...makeGen({ id: 'gen-1', jobUrl: 'https://acme.com/job/1', applicationId: 'app-1' }),
+          resumeText: 'Previous generation resume text',
+        },
+      ],
+    });
+
+    render(<ApplicationDetailPage />);
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute(
+      'data-resumedocid',
+      ''
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/ApplicationDetailPage.test.tsx
@@ -146,7 +146,11 @@ vi.mock('@/features/documents/components/TailorFlow', () => ({
   }: {
     seedGeneration?: { id: string };
     onJobDescChange?: (text: string) => void;
-    persistence?: { runId: string | null; runJobId: string | null };
+    persistence?: {
+      runId: string | null;
+      runJobId: string | null;
+      wizardForm?: { resumeDocId?: string } | null;
+    };
     resumeDocId?: string;
   }) => {
     capturedOnJobDescChange = onJobDescChange;
@@ -157,6 +161,9 @@ vi.mock('@/features/documents/components/TailorFlow', () => ({
         data-runid={persistence?.runId ?? ''}
         data-runjobid={persistence?.runJobId ?? ''}
         data-resumedocid={resumeDocId ?? ''}
+        // The PERSISTED form's id, distinct from the freshly-seeded prop above —
+        // this is the one a deleted résumé can leave dangling.
+        data-formdocid={persistence?.wizardForm?.resumeDocId ?? ''}
       />
     );
   },
@@ -1333,10 +1340,56 @@ describe('ApplicationDetailPage — seedResumeDocId (Score tab résumé identity
     );
   });
 
+  it('strips a persisted résumé id whose document no longer exists', () => {
+    // `resume_source` is ID-WINS with NO fallback: a stale id fails the whole
+    // run with "resume not found" while the résumé text sits visible on screen.
+    mockTab = 'documents';
+    mockDocsData = [{ _id: 'doc-alive', name: 'Resume.pdf', isDefault: true }];
+    mockDocumentTextData = 'Default resume text';
+    mockSessionState.applicationApply.applySeedResume = null;
+    mockSessionState.applicationApply.applyWizardForm = {
+      resume: 'Some resume text',
+      outputType: 'both',
+      researchCompany: false,
+      resumeDocId: 'doc-deleted',
+    };
+    mockUseAiGenerations.mockReturnValue({ data: [] });
+
+    renderLoaded({ id: 'app-1' });
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute('data-formdocid', '');
+  });
+
+  it('keeps a persisted résumé id whose document still exists', () => {
+    mockTab = 'documents';
+    mockDocsData = [{ _id: 'doc-alive', name: 'Resume.pdf', isDefault: true }];
+    mockDocumentTextData = 'Default resume text';
+    mockSessionState.applicationApply.applySeedResume = null;
+    mockSessionState.applicationApply.applyWizardForm = {
+      resume: 'Some resume text',
+      outputType: 'both',
+      researchCompany: false,
+      resumeDocId: 'doc-alive',
+    };
+    mockUseAiGenerations.mockReturnValue({ data: [] });
+
+    renderLoaded({ id: 'app-1' });
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorFlow)).toHaveAttribute(
+      'data-formdocid',
+      'doc-alive'
+    );
+  });
+
   it("does NOT seed a résumé id when the text came from a previous generation's output", () => {
     mockTab = 'documents';
-    mockDocsData = []; // no saved résumé at all — defaultResumeId is null
-    mockDocumentTextData = undefined;
+    // A default résumé DOES exist, so `defaultResumeId` is a real id and the
+    // `?? undefined` fallback cannot carry this test on its own — the equality
+    // guard is the only thing preventing the seed. Its text is EMPTY, which is
+    // what lets the `||` chain fall through to the generation's text: a
+    // non-empty default text would win the chain and legitimately seed the id.
+    mockDocsData = [{ _id: 'doc-1', name: 'Resume.pdf', isDefault: true }];
+    mockDocumentTextData = '';
     mockSessionState.applicationApply.applySeedResume = null;
     // `renderLoaded` always overwrites the generations mock to `{ data: [] }`
     // (it's the "no matching generation" default for every OTHER test in this

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
@@ -62,6 +62,7 @@ import {
 } from '@/features/documents/components/TailorFlow';
 import { useFormatRelativeTime } from '@/hooks/use-format-relative-time';
 import { useDefaultResumeId } from '@/hooks/useDefaultResumeId';
+import type { RawDoc } from '@/lib/doc-record';
 import { DETAIL_TABS, type DetailTab, Route } from '@/routes/applications.$id';
 import {
   useAcceptStatusEvent,
@@ -1389,9 +1390,32 @@ function DocumentsTab({ application, matchingGenerations }: DocumentsTabProps) {
   const applyRun =
     applicationApply.applyRun?.forId === application.id ? applicationApply.applyRun : null;
 
+  // A persisted `resumeDocId` can outlive the document it points at: advance a
+  // wizard step (which snapshots the form into the memory-only
+  // `applyWizardForm`), delete that résumé on the Documents page, come back.
+  // `resume_source` is ID-WINS with NO fallback — `resolve_resume` answers
+  // `resume not found: <id>` and never consults `resumeText`, which
+  // `useTailorPipeline` has already blanked precisely BECAUSE an id was set. So
+  // a stale id fails the whole run with an opaque id echo while the résumé text
+  // sits visible on screen. Drop the id and let the run use that text; this is
+  // the one place that holds both the persisted form and the live document
+  // list, so it is the only place that can tell.
+  const persistedWizardForm = applicationApply.applyWizardForm;
+  // `useDocuments` is TYPED as `DocumentRecord[]` (`id`) but the backend really
+  // returns `_id` — `useDefaultResume` casts through `RawDoc` for exactly this
+  // reason, and `defaultResumeId` (what we compare against) is a `_id`. Reading
+  // `.id` here would typecheck and be `undefined` at runtime, quietly stripping
+  // EVERY persisted id instead of only stale ones.
+  const rawDocs = (docsQuery.data ?? []) as unknown as RawDoc[];
+  const knownDocIds = new Set(rawDocs.map((d) => d._id));
+  const wizardForm =
+    persistedWizardForm?.resumeDocId && !knownDocIds.has(persistedWizardForm.resumeDocId)
+      ? { ...persistedWizardForm, resumeDocId: undefined }
+      : persistedWizardForm;
+
   const persistence: TailorFlowPersistence = {
     wizardStep: applicationApply.applyWizardStep,
-    wizardForm: applicationApply.applyWizardForm,
+    wizardForm,
     templateId: applicationApply.applyTemplateId,
     atsMode: applicationApply.applyAtsMode,
     accent: applicationApply.applyAccent,

--- a/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
+++ b/apps/desktop/src/renderer/features/applications/components/ApplicationDetailPage/index.tsx
@@ -1352,6 +1352,15 @@ function DocumentsTab({ application, matchingGenerations }: DocumentsTabProps) {
     (resumeQuery.data ?? '') ||
     (matchingGenerations[0]?.resumeText ?? '');
 
+  // Seed the id ONLY when the seeded text IS the default résumé's text — the
+  // autopilot one-shot and a previous generation's output have no saved-document
+  // backing, and an id that doesn't match the visible text is the exact drift
+  // `useResumeInput`'s `selectDoc` contract exists to prevent.
+  const seedResumeDocId =
+    seedResumeText && seedResumeText === resumeQuery.data
+      ? (defaultResumeId ?? undefined)
+      : undefined;
+
   // Generation-store session key. Empty job URLs (`z.string().default('')`) would
   // collide for every URL-less application, bleeding one application's live
   // tailoring session into another — so key those by the stable application id.
@@ -1447,6 +1456,7 @@ function DocumentsTab({ application, matchingGenerations }: DocumentsTabProps) {
         <TailorFlow
           job={job}
           resumeText={seedResumeText}
+          resumeDocId={seedResumeDocId}
           board={application.board ?? ''}
           contextId={contextId}
           jobUrl={application.jobUrl}

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.i18n.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.i18n.test.tsx
@@ -466,4 +466,126 @@ describe('JobAdView — Score tab: CLI-agent egress disclosure', () => {
     });
     expect(screen.queryByText(egress)).not.toBeInTheDocument();
   });
+
+  // Regression: the disclosure used to render unconditionally above the
+  // five-way body branch, so it warned about egress on states that will
+  // NEVER send anything (nothing is scored yet). It must render ONLY where a
+  // score is actually loading or shown.
+  it('does NOT disclose egress on the no-résumé reason — nothing will ever be sent from that state', async () => {
+    mockActiveProvider = 'claude-code';
+    render(<JobAdView {...makeProps({ resumeId: undefined })} />);
+    await openScoreTab();
+
+    expect(screen.getByText(i18n.t('jobs.scoreNoResume'))).toBeInTheDocument();
+    const egress = i18n.t('autopilot.apply.jobAdView.score.cliAgentEgress', {
+      provider: 'Claude Code',
+    });
+    expect(screen.queryByText(egress)).not.toBeInTheDocument();
+  });
+
+  it('does NOT disclose egress on the no-posting reason — nothing will ever be sent from that state', async () => {
+    mockActiveProvider = 'claude-code';
+    render(<JobAdView {...makeProps({ jobDesc: '' })} />);
+    await openScoreTab();
+
+    expect(
+      screen.getByText(i18n.t('autopilot.apply.jobAdView.score.noPosting'))
+    ).toBeInTheDocument();
+    const egress = i18n.t('autopilot.apply.jobAdView.score.cliAgentEgress', {
+      provider: 'Claude Code',
+    });
+    expect(screen.queryByText(egress)).not.toBeInTheDocument();
+  });
+
+  it('DOES disclose egress while the score is loading — a call is genuinely in flight', async () => {
+    mockActiveProvider = 'claude-code';
+    stubbedScore = { data: undefined, isLoading: true, isError: false, refetch: vi.fn() };
+    render(<JobAdView {...makeProps()} />);
+    await openScoreTab();
+
+    expect(screen.getByText(i18n.t('autopilot.apply.jobAdView.score.loading'))).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        i18n.t('autopilot.apply.jobAdView.score.cliAgentEgress', { provider: 'Claude Code' })
+      )
+    ).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Recommendations — `MatchScore.recommendations` (backend-authored prose,
+// like `explanationText`) surfaced below the gaps chips. Gated on
+// `hasCoverage`: the "no extractable keywords" placeholder result still runs
+// the same `recommendations(&gaps)` fn over its empty `gaps`, which would
+// otherwise print a false "Strong keyword coverage" for a posting that was
+// never actually scored.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('JobAdView — Score tab: recommendations', () => {
+  it('renders the backend-authored recommendation prose under the Recommendations heading', async () => {
+    stubbedScore = {
+      data: baseScore({
+        ats: 40,
+        combined: 40,
+        scoreSource: 'keyword',
+        gaps: ['docker'],
+        recommendations: ['Consider adding evidence of: docker.'],
+      }),
+      isLoading: false,
+    };
+    render(<JobAdView {...makeProps()} />);
+    await openScoreTab();
+
+    expect(screen.getByText(i18n.t('analyze.recommendations'))).toBeInTheDocument();
+    expect(screen.getByText('Consider adding evidence of: docker.')).toBeInTheDocument();
+  });
+
+  it('renders a positive recommendation for a strong-coverage score with no gaps', async () => {
+    stubbedScore = {
+      data: baseScore({
+        ats: 95,
+        combined: 95,
+        scoreSource: 'keyword',
+        gaps: [],
+        recommendations: ['Strong keyword coverage — no obvious gaps.'],
+      }),
+      isLoading: false,
+    };
+    render(<JobAdView {...makeProps()} />);
+    await openScoreTab();
+
+    expect(screen.getByText('Strong keyword coverage — no obvious gaps.')).toBeInTheDocument();
+  });
+
+  it('does NOT render recommendations for the "no extractable keywords" placeholder, even if the field is non-empty', async () => {
+    // `ats: 0, gaps: []` is the placeholder shape (see `hasCoverage`'s doc) —
+    // the Rust `recommendations()` fn still runs over the empty `gaps` and
+    // would produce "Strong keyword coverage — no obvious gaps.", which
+    // would be a lie about a posting that was never actually scored.
+    stubbedScore = {
+      data: baseScore({
+        ats: 0,
+        combined: 0,
+        gaps: [],
+        scoreSource: 'keyword',
+        recommendations: ['Strong keyword coverage — no obvious gaps.'],
+      }),
+      isLoading: false,
+    };
+    render(<JobAdView {...makeProps()} />);
+    await openScoreTab();
+
+    expect(screen.queryByText(i18n.t('analyze.recommendations'))).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Strong keyword coverage — no obvious gaps.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing under the heading when recommendations is empty', async () => {
+    stubbedScore = { data: baseScore({ recommendations: [] }), isLoading: false };
+    render(<JobAdView {...makeProps()} />);
+    await openScoreTab();
+
+    expect(screen.queryByText(i18n.t('analyze.recommendations'))).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.i18n.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.i18n.test.tsx
@@ -510,6 +510,26 @@ describe('JobAdView — Score tab: CLI-agent egress disclosure', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('DOES disclose egress on the error state — a resolved-but-unusable response already egressed', async () => {
+    // The error branch is `scoreError || (score && !isMeasured(score))`. Reaching
+    // it at all means the request went out; the second disjunct means it came
+    // BACK. Either way the posting text was already sent, so this is the one
+    // failure state that still owes the user a disclosure.
+    mockActiveProvider = 'claude-code';
+    stubbedScore = { data: undefined, isLoading: false, isError: true, refetch: vi.fn() };
+    render(<JobAdView {...makeProps()} />);
+    await openScoreTab();
+
+    expect(
+      screen.getByText(i18n.t('autopilot.apply.jobAdView.score.errorTitle'))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        i18n.t('autopilot.apply.jobAdView.score.cliAgentEgress', { provider: 'Claude Code' })
+      )
+    ).toBeInTheDocument();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
@@ -224,9 +224,13 @@ export function JobAdView({
   // A CLI-agent provider (Claude Code, Codex, Gemini CLI) egresses despite
   // reading as "local" elsewhere in this app — scoring a foreign-language
   // posting routes through translation, which sends the job ad text to it.
-  // Rendered ONLY where a score is actually loading or shown below (never on
-  // the no-résumé/no-posting/error branches, which never send anything) —
-  // computed once here so both call sites stay in sync.
+  // Rendered on every branch that can only be reached AFTER a request went out
+  // — loading, measured, and error. The error branch counts: its second
+  // disjunct (`score && !isMeasured(score)`) requires the query to have
+  // RESOLVED, so the round trip provably completed and the posting text was
+  // already sent. Only the no-résumé/no-posting branches are silent, because
+  // those short-circuit before `scoreEnabled` ever turns on. Computed once here
+  // so all three call sites stay in sync.
   const egressNotice = isCliAgentProvider ? (
     <p className="shrink-0 text-[10px] leading-relaxed text-foreground/70">
       {t('autopilot.apply.jobAdView.score.cliAgentEgress', {
@@ -365,14 +369,17 @@ export function JobAdView({
               // `isMeasured`'s doc). Neither is "not scored" — that copy would
               // tell a user who waited up to two minutes for a failure exactly
               // what they'd be told about a posting with nothing in it.
-              <ErrorState
-                title={t('autopilot.apply.jobAdView.score.errorTitle')}
-                description={t('autopilot.apply.jobAdView.score.errorDescription')}
-                onRetry={() => {
-                  void refetchScore();
-                }}
-                className="rounded-lg border border-red-400/20 bg-red-400/5 py-6"
-              />
+              <>
+                {egressNotice}
+                <ErrorState
+                  title={t('autopilot.apply.jobAdView.score.errorTitle')}
+                  description={t('autopilot.apply.jobAdView.score.errorDescription')}
+                  onRetry={() => {
+                    void refetchScore();
+                  }}
+                  className="rounded-lg border border-red-400/20 bg-red-400/5 py-6"
+                />
+              </>
             ) : score ? (
               <>
                 {egressNotice}

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/JobAdView.tsx
@@ -1,4 +1,10 @@
-import { ExternalLink as ExternalLinkIcon, Loader2, Sparkles } from 'lucide-react';
+import {
+  ExternalLink as ExternalLinkIcon,
+  FileSearch,
+  FileText,
+  Loader2,
+  Sparkles,
+} from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { MatchScore } from '@ajh/shared';
@@ -8,6 +14,7 @@ import {
   Alert,
   Button,
   Dropdown,
+  EmptyState,
   ErrorState,
   MarkdownMessage,
   SegmentedControl,
@@ -214,6 +221,20 @@ export function JobAdView({
   // language shown in its own script.
   const languageOptions = OUTPUT_LANGUAGES.map((l) => ({ value: l.code, label: l.endonym }));
 
+  // A CLI-agent provider (Claude Code, Codex, Gemini CLI) egresses despite
+  // reading as "local" elsewhere in this app — scoring a foreign-language
+  // posting routes through translation, which sends the job ad text to it.
+  // Rendered ONLY where a score is actually loading or shown below (never on
+  // the no-résumé/no-posting/error branches, which never send anything) —
+  // computed once here so both call sites stay in sync.
+  const egressNotice = isCliAgentProvider ? (
+    <p className="shrink-0 text-[10px] leading-relaxed text-foreground/70">
+      {t('autopilot.apply.jobAdView.score.cliAgentEgress', {
+        provider: activeProviderMeta?.label ?? activeProvider,
+      })}
+    </p>
+  ) : null;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
       <div className="shrink-0 flex items-center justify-between gap-2">
@@ -313,37 +334,30 @@ export function JobAdView({
                 {t('autopilot.apply.jobAdView.score.resumeNote')}
               </p>
             )}
-            {/* A CLI-agent provider (Claude Code, Codex, Gemini CLI) egresses
-                despite reading as "local" elsewhere in this app — scoring a
-                foreign-language posting routes through translation, which
-                sends the job ad text to it. Disclosed here rather than
-                silently. */}
-            {isCliAgentProvider && (
-              <p className="shrink-0 text-[10px] leading-relaxed text-foreground/70">
-                {t('autopilot.apply.jobAdView.score.cliAgentEgress', {
-                  provider: activeProviderMeta?.label ?? activeProvider,
-                })}
-              </p>
-            )}
             {!resumeId ? (
-              <p className="text-[11px] text-foreground/50">{t('jobs.scoreNoResume')}</p>
+              <EmptyState icon={FileText} title={t('jobs.scoreNoResume')} className="flex-1 py-6" />
             ) : !scoreText ? (
-              <p className="text-[11px] text-foreground/50">
-                {t('autopilot.apply.jobAdView.score.noPosting')}
-              </p>
+              <EmptyState
+                icon={FileSearch}
+                title={t('autopilot.apply.jobAdView.score.noPosting')}
+                className="flex-1 py-6"
+              />
             ) : scoreLoading ? (
               // A translating scoring call can take up to ~117s (see
               // `handleTabChange`'s doc) — the one state on this tab most in
               // need of a live-region announcement, unlike the Summary tab's
               // `generating` block five lines up which it mirrors.
-              <div
-                role="status"
-                aria-live="polite"
-                className="flex items-center gap-2 text-[11px] text-foreground/40"
-              >
-                <Loader2 size={12} className="animate-spin" />
-                {t('autopilot.apply.jobAdView.score.loading')}
-              </div>
+              <>
+                {egressNotice}
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="flex items-center gap-2 text-[11px] text-foreground/40"
+                >
+                  <Loader2 size={12} className="animate-spin" />
+                  {t('autopilot.apply.jobAdView.score.loading')}
+                </div>
+              </>
             ) : scoreError || (score && !isMeasured(score)) ? (
               // Two distinct failure shapes routed to the SAME honest state: a
               // rejected query (offline, provider outage, the 200_000-byte zod
@@ -360,81 +374,102 @@ export function JobAdView({
                 className="rounded-lg border border-red-400/20 bg-red-400/5 py-6"
               />
             ) : score ? (
-              <div className="flex flex-col gap-1.5">
-                {/* `semantic_enabled` is hardcoded off for this endpoint (see
+              <>
+                {egressNotice}
+                <div className="flex flex-col gap-1.5">
+                  {/* `semantic_enabled` is hardcoded off for this endpoint (see
                     `hasSemantic`'s doc), so `combined === ats` always — Match and
                     Coverage would print the identical number under DIFFERENT
                     badge cut points (combined 75/50 vs coverage 55/30),
                     contradicting each other on every render. Drop Match; it
                     carries no information Coverage doesn't, and "Keyword
                     coverage" is the honest label for a keyword-only number. */}
-                {hasSemantic && (
+                  {hasSemantic && (
+                    <ScoreMetric
+                      label={t('autopilot.scoreAbbr.combined')}
+                      value={hasCoverage ? score.combined : null}
+                      variant="combined"
+                      notScoredLabel={t('autopilot.apply.jobAdView.score.noKeywords')}
+                      testId={TEST_IDS.documents.jobAdViewScoreMatch}
+                    />
+                  )}
                   <ScoreMetric
-                    label={t('autopilot.scoreAbbr.combined')}
-                    value={hasCoverage ? score.combined : null}
-                    variant="combined"
+                    // Reuses the Autopilot list's own field labels (`autopilot.scoreAbbr.*`)
+                    // rather than forking a second translation for the identical
+                    // `MatchScore.combined`/`.ats` values — the naming rule this
+                    // surface already follows for "never ATS score", applied to
+                    // German too.
+                    label={t('autopilot.scoreAbbr.coverage')}
+                    value={hasCoverage ? score.ats : null}
+                    variant="coverage"
                     notScoredLabel={t('autopilot.apply.jobAdView.score.noKeywords')}
-                    testId={TEST_IDS.documents.jobAdViewScoreMatch}
+                    testId={TEST_IDS.documents.jobAdViewScoreCoverage}
                   />
-                )}
-                <ScoreMetric
-                  // Reuses the Autopilot list's own field labels (`autopilot.scoreAbbr.*`)
-                  // rather than forking a second translation for the identical
-                  // `MatchScore.combined`/`.ats` values — the naming rule this
-                  // surface already follows for "never ATS score", applied to
-                  // German too.
-                  label={t('autopilot.scoreAbbr.coverage')}
-                  value={hasCoverage ? score.ats : null}
-                  variant="coverage"
-                  notScoredLabel={t('autopilot.apply.jobAdView.score.noKeywords')}
-                  testId={TEST_IDS.documents.jobAdViewScoreCoverage}
-                />
-                {hasSemantic ? (
-                  <ScoreMetric
-                    label={t('autopilot.apply.jobAdView.score.semanticLabel')}
-                    value={score.semantic}
-                    notScoredLabel={t('analyze.notScored')}
-                    testId={TEST_IDS.documents.jobAdViewScoreSemantic}
-                  />
-                ) : (
-                  // Never true through this endpoint today (see `hasSemantic`'s
-                  // doc) — a disclosure footnote, not a metric row: reserving a
-                  // full row with badge chrome for a value that can never have
-                  // content is its own small dishonesty.
-                  <p
-                    data-testid={TEST_IDS.documents.jobAdViewScoreSemantic}
-                    className="text-[10px] text-foreground/50"
-                  >
-                    {t('autopilot.apply.jobAdView.score.semanticLabel')}: {t('analyze.notScored')}
-                  </p>
-                )}
-                {/* The kernel's own detail sentence — the keyword COUNT the
+                  {hasSemantic ? (
+                    <ScoreMetric
+                      label={t('autopilot.apply.jobAdView.score.semanticLabel')}
+                      value={score.semantic}
+                      notScoredLabel={t('analyze.notScored')}
+                      testId={TEST_IDS.documents.jobAdViewScoreSemantic}
+                    />
+                  ) : (
+                    // Never true through this endpoint today (see `hasSemantic`'s
+                    // doc) — a disclosure footnote, not a metric row: reserving a
+                    // full row with badge chrome for a value that can never have
+                    // content is its own small dishonesty.
+                    <p
+                      data-testid={TEST_IDS.documents.jobAdViewScoreSemantic}
+                      className="text-[10px] text-foreground/50"
+                    >
+                      {t('autopilot.apply.jobAdView.score.semanticLabel')}: {t('analyze.notScored')}
+                    </p>
+                  )}
+                  {/* The kernel's own detail sentence — the keyword COUNT the
                     coverage fraction is out of, the one signal that lets a user
                     notice a boilerplate-inflated denominator. Backend-authored
                     prose (like `error` above), deliberately not run through
                     `t()` — there is nothing to translate a runtime-interpolated
                     English sentence INTO. */}
-                {explanationText && (
-                  <p className="text-[10px] leading-relaxed text-foreground/50">
-                    {explanationText}
-                  </p>
-                )}
-                {hasCoverage && score.gaps.length > 0 && (
-                  <div className="flex flex-col gap-1">
-                    <span className="text-[10px] text-foreground/50">{t('analyze.gaps')}</span>
-                    <div className="flex flex-wrap gap-1">
-                      {score.gaps.slice(0, 3).map((gap) => (
-                        <span
-                          key={gap}
-                          className="rounded-full border border-amber-400/20 bg-amber-400/5 px-2 py-0.5 text-[10px] text-amber-300/90"
-                        >
-                          {gap}
-                        </span>
+                  {explanationText && (
+                    <p className="text-[10px] leading-relaxed text-foreground/50">
+                      {explanationText}
+                    </p>
+                  )}
+                  {hasCoverage && score.gaps.length > 0 && (
+                    <div className="flex flex-col gap-1">
+                      <span className="text-[10px] text-foreground/50">{t('analyze.gaps')}</span>
+                      <div className="flex flex-wrap gap-1">
+                        {score.gaps.slice(0, 3).map((gap) => (
+                          <span
+                            key={gap}
+                            className="rounded-full border border-amber-400/20 bg-amber-400/5 px-2 py-0.5 text-[10px] text-amber-300/90"
+                          >
+                            {gap}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {/* Backend-authored English prose (like `explanationText`
+                    above), deliberately not run through `t()`. Gated on
+                    `hasCoverage` — the placeholder "no extractable keywords"
+                    result (`ats: 0, gaps: []`) still produces a "Strong
+                    keyword coverage" recommendation from the same `gaps`
+                    input, which would be a false positive here. */}
+                  {hasCoverage && score.recommendations.length > 0 && (
+                    <div className="flex flex-col gap-1">
+                      <span className="text-[10px] text-foreground/50">
+                        {t('analyze.recommendations')}
+                      </span>
+                      {score.recommendations.map((rec) => (
+                        <p key={rec} className="text-[10px] leading-relaxed text-foreground/50">
+                          {rec}
+                        </p>
                       ))}
                     </div>
-                  </div>
-                )}
-              </div>
+                  )}
+                </div>
+              </>
             ) : (
               <p className="text-[11px] text-foreground/50">{t('analyze.notScored')}</p>
             )}

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
@@ -110,6 +110,10 @@ export interface TailorFlowPersistence {
 export interface TailorFlowProps {
   job: AutopilotFoundJob;
   resumeText?: string;
+  /** The saved résumé backing `resumeText`, unedited — see `tailor-state.ts`'s
+   *  doc on `resumeDocId`. Undefined when the caller can't vouch that
+   *  `resumeText` IS that document's text (a generated/one-shot seed). */
+  resumeDocId?: string;
   board: string;
   /** Session key for the host's own bookkeeping (e.g. `autopilot:<jobUrl>`) —
    *  TailorFlow itself no longer keys any session state on it (the staged
@@ -156,6 +160,7 @@ export interface TailorFlowProps {
 export function TailorFlow({
   job,
   resumeText,
+  resumeDocId,
   board,
   jobUrl,
   seedGeneration,
@@ -191,7 +196,7 @@ export function TailorFlow({
   // `buildTailorDefaults` runs once, not on every render.
   const startedFresh = useRef(persistence.wizardForm == null);
   const [initialForm] = useState<TailorWizardState>(
-    () => persistence.wizardForm ?? buildTailorDefaults(resumeText, supportsWebSearch)
+    () => persistence.wizardForm ?? buildTailorDefaults(resumeText, supportsWebSearch, resumeDocId)
   );
   const methods = useForm<TailorWizardState>({
     defaultValues: initialForm,

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.test.ts
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.test.ts
@@ -34,4 +34,10 @@ describe('buildTailorDefaults', () => {
   it('seeds resume as empty string when resumeText is empty string', () => {
     expect(buildTailorDefaults('').resume).toBe('');
   });
+
+  it('seeds resumeDocId when the caller vouches for it, undefined otherwise', () => {
+    expect(buildTailorDefaults('text', false, 'doc-1').resumeDocId).toBe('doc-1');
+    expect(buildTailorDefaults('text', false).resumeDocId).toBeUndefined();
+    expect(buildTailorDefaults().resumeDocId).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.ts
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/lib/tailor-state.ts
@@ -19,10 +19,15 @@ export interface TailorWizardState {
  * `supportsWebSearch` so the "search company" toggle defaults ON for a model
  * that can web-search and OFF otherwise. Defaults to `false` (the safe fallback
  * used while the capability is still resolving, or when it can't).
+ *
+ * `resumeDocId` seeds `resumeDocId` (see `TailorWizardState`'s doc) — the
+ * caller's job to pass only when `resumeText` genuinely IS that document's
+ * text, never a guess.
  */
 export function buildTailorDefaults(
   resumeText?: string,
-  researchCompany = false
+  researchCompany = false,
+  resumeDocId?: string
 ): TailorWizardState {
-  return { resume: resumeText ?? '', outputType: 'both', researchCompany };
+  return { resume: resumeText ?? '', outputType: 'both', researchCompany, resumeDocId };
 }

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/EmbeddingsSettings.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/EmbeddingsSettings.test.tsx
@@ -165,6 +165,29 @@ describe('EmbeddingsSettings — cloud provider selected', () => {
     await switchProvider(user, 'OpenAI', 'Ollama (Local)');
     expect(screen.queryByText(ADVISORY_FRAGMENT)).not.toBeInTheDocument();
   });
+
+  // Ollama Cloud: users on it previously had no non-local embeddings option
+  // and kept hitting a local Ollama that wasn't running.
+  it('offers Ollama Cloud as a selectable provider and shows the cost advisory for it', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await switchProvider(user, 'Ollama (Local)', 'Ollama Cloud');
+    expect(screen.getByText(ADVISORY_FRAGMENT)).toBeInTheDocument();
+  });
+
+  it('does NOT presume a model for Ollama Cloud — the model field falls back to the generic placeholder', async () => {
+    // `default_embedding_model()` returns `None` for this client — inventing a
+    // model name here would silently disagree with what ollama.com actually
+    // serves. Mirrors the existing openai-compatible behaviour (empty
+    // `defaultModel`), asserted the same way `onProviderChange` verifies it:
+    // via the Input's placeholder, since the field itself stays empty.
+    const user = userEvent.setup();
+    renderPanel();
+
+    await switchProvider(user, 'Ollama (Local)', 'Ollama Cloud');
+    expect(screen.getByPlaceholderText('settings.embeddings.modelPlaceholder')).toBeInTheDocument();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/ai-settings/EmbeddingsSettings/index.tsx
@@ -18,13 +18,19 @@ import {
   useSemanticScoring,
 } from '@/store/preferences-store';
 
-// Providers that expose an embeddings API. Anthropic is intentionally excluded —
-// it has no embeddings endpoint.
+// Providers that expose an embeddings API — NOT exhaustive of every AI
+// provider in the app (e.g. Anthropic and the CLI-agent providers have no
+// embeddings endpoint and are intentionally excluded).
 const EMBED_PROVIDERS = [
   { value: 'ollama', label: 'Ollama (Local)', defaultModel: 'nomic-embed-text' },
   { value: 'openai', label: 'OpenAI', defaultModel: 'text-embedding-3-small' },
   { value: 'gemini', label: 'Gemini', defaultModel: 'gemini-embedding-2' },
   { value: 'openai-compatible', label: 'OpenAI-compatible', defaultModel: '' },
+  // No default model — `default_embedding_model()` returns `None` for this
+  // client (openai.rs), a deliberate consequence of not presuming an
+  // embedding model ollama.com serves; the user types it, exactly as for
+  // openai-compatible above.
+  { value: 'ollama-cloud', label: 'Ollama Cloud', defaultModel: '' },
 ] as const;
 
 export function EmbeddingsSettings() {

--- a/apps/desktop/src/renderer/routes/__root.error-boundary.test.tsx
+++ b/apps/desktop/src/renderer/routes/__root.error-boundary.test.tsx
@@ -7,15 +7,27 @@
  * (real i18n copy renders, retry wires to the router's `reset`) — there is no
  * repro for the underlying hook-order bug, so that is out of scope here.
  *
- * Renders `RootErrorBoundary` standalone (not the full root route tree) —
- * it only depends on `useTranslation` + `ErrorState`, neither of which needs
- * a router/store/IPC context.
+ * Renders `RootErrorBoundary` standalone (not the full root route tree). It
+ * depends on `useTranslation`, `ErrorState` and `useNavigate` — the router hook
+ * is MOCKED here rather than wrapped in a real router, so the assertion is
+ * "the button asks to go to `/`", not "the router moved".
+ *
+ * Standalone rendering is why this file cannot prove the shell unmounts on a
+ * catch (it does — the root match's component IS `RootLayout`). That is why the
+ * copy must not mention a sidebar and why the dashboard action exists at all.
  */
 import { describe, expect, it, vi } from 'vitest';
+import type * as RouterModule from '@tanstack/react-router';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import i18n from '@ajh/translations';
+
+const navigate = vi.fn();
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof RouterModule>()),
+  useNavigate: () => navigate,
+}));
 
 import { RootErrorBoundary } from './__root';
 
@@ -37,6 +49,19 @@ describe('RootErrorBoundary', () => {
     await user.click(screen.getByRole('button', { name: 'Try again' }));
 
     expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a dashboard escape hatch, because reset alone loops on a render bug', async () => {
+    // The whole shell (Sidebar included) is replaced on a catch, so navigation
+    // is the only real way out — and `reset` re-renders the route that threw,
+    // which returns straight to this screen for a deterministic crash.
+    navigate.mockClear();
+    const user = userEvent.setup();
+    render(<RootErrorBoundary error={new Error('boom')} reset={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: i18n.t('errorBoundary.goHome') }));
+
+    expect(navigate).toHaveBeenCalledWith({ to: '/' });
   });
 
   it('renders role="alert" so a screen reader announces the crash', () => {

--- a/apps/desktop/src/renderer/routes/__root.error-boundary.test.tsx
+++ b/apps/desktop/src/renderer/routes/__root.error-boundary.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * RootErrorBoundary — the root route's `errorComponent`.
+ *
+ * Regression: `AutopilotPage` threw a Rules-of-Hooks error (2026-08-18) and
+ * the app white-screened — TanStack Router had no `errorComponent` anywhere
+ * in the tree to catch it. This only covers the boundary component itself
+ * (real i18n copy renders, retry wires to the router's `reset`) — there is no
+ * repro for the underlying hook-order bug, so that is out of scope here.
+ *
+ * Renders `RootErrorBoundary` standalone (not the full root route tree) —
+ * it only depends on `useTranslation` + `ErrorState`, neither of which needs
+ * a router/store/IPC context.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import i18n from '@ajh/translations';
+
+import { RootErrorBoundary } from './__root';
+
+describe('RootErrorBoundary', () => {
+  it('renders the real translated title + description (never a raw i18n key)', () => {
+    render(<RootErrorBoundary error={new Error('boom')} reset={vi.fn()} />);
+
+    expect(screen.getByText(i18n.t('errorBoundary.title'))).toBeInTheDocument();
+    expect(screen.getByText(i18n.t('errorBoundary.description'))).toBeInTheDocument();
+  });
+
+  it('the retry action calls the router-supplied reset, not a page reload', async () => {
+    const reset = vi.fn();
+    const user = userEvent.setup();
+    render(<RootErrorBoundary error={new Error('boom')} reset={reset} />);
+
+    // `ErrorState`'s retry button label ("Try again") is a fixed string in
+    // the shared primitive itself, not a translation key of this component's.
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders role="alert" so a screen reader announces the crash', () => {
+    render(<RootErrorBoundary error={new Error('boom')} reset={vi.fn()} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/routes/__root.tsx
+++ b/apps/desktop/src/renderer/routes/__root.tsx
@@ -141,23 +141,44 @@ function NotificationToastBridge() {
  * Root-level error boundary — TanStack Router walks up to this when a route
  * component throws and neither it nor any ancestor route defines its own
  * `errorComponent` (e.g. the Rules-of-Hooks crash logged 2026-08-18, which
- * white-screened the whole app because no boundary existed at all). Rendered
- * in place of the failed route's `<Outlet />` content — the shell (Sidebar/
- * Titlebar) stays mounted, so "pick another page" is a real escape hatch, not
- * just decoration. `reset` is the router's own recovery: it re-attempts
- * rendering the route that threw (a per-render bug, not a data bug, so this
- * does not fix the root cause — the underlying crash is tracked separately).
+ * white-screened the whole app because no boundary existed at all).
+ *
+ * This replaces the WHOLE shell, not just the failed route's content: the
+ * router wraps a match's own component in the catch boundary, and the root
+ * match's component IS `RootLayout` — Titlebar, Sidebar, StatusBar and every
+ * always-mounted bridge go with it. So there is no sidebar left to send the
+ * user to, and the copy must not promise one.
+ *
+ * That is also why `reset` alone is not an escape hatch. It re-attempts
+ * rendering the route that threw, which recovers a transient failure but loops
+ * straight back for a deterministic render bug — exactly the case this was
+ * built for. The dashboard button is the real way out: `useNavigate` resolves
+ * fine inside the boundary, and landing on `/` remounts the shell.
+ *
+ * Neither action fixes the root cause; the underlying crash is tracked
+ * separately.
  *
  * Exported (not just used inline) so it can be unit-tested standalone,
  * without mounting the rest of the root layout's provider tree.
  */
 export function RootErrorBoundary({ reset }: ErrorComponentProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   return (
     <ErrorState
       title={t('errorBoundary.title')}
       description={t('errorBoundary.description')}
       onRetry={reset}
+      action={
+        <Button
+          variant="default"
+          onClick={() => {
+            void navigate({ to: '/' });
+          }}
+        >
+          {t('errorBoundary.goHome')}
+        </Button>
+      }
       className="h-full"
     />
   );

--- a/apps/desktop/src/renderer/routes/__root.tsx
+++ b/apps/desktop/src/renderer/routes/__root.tsx
@@ -2,6 +2,7 @@ import { AnimatePresence, motion, MotionConfig } from 'motion/react';
 import { useEffect, useRef } from 'react';
 import {
   createRootRoute,
+  type ErrorComponentProps,
   type NavigateOptions,
   Outlet,
   useNavigate,
@@ -10,7 +11,7 @@ import {
 
 import type { NotificationToast } from '@ajh/shared';
 import { useTranslation } from '@ajh/translations';
-import { Button, NotificationProvider, transition, useNotification } from '@ajh/ui';
+import { Button, ErrorState, NotificationProvider, transition, useNotification } from '@ajh/ui';
 
 import { CinematicBackground } from '@/components/background/CinematicBackground';
 import { ProtocolVersionGate } from '@/components/layout/ProtocolVersionGate';
@@ -134,6 +135,32 @@ function NotificationToastBridge() {
   }, [api]);
 
   return null;
+}
+
+/**
+ * Root-level error boundary — TanStack Router walks up to this when a route
+ * component throws and neither it nor any ancestor route defines its own
+ * `errorComponent` (e.g. the Rules-of-Hooks crash logged 2026-08-18, which
+ * white-screened the whole app because no boundary existed at all). Rendered
+ * in place of the failed route's `<Outlet />` content — the shell (Sidebar/
+ * Titlebar) stays mounted, so "pick another page" is a real escape hatch, not
+ * just decoration. `reset` is the router's own recovery: it re-attempts
+ * rendering the route that threw (a per-render bug, not a data bug, so this
+ * does not fix the root cause — the underlying crash is tracked separately).
+ *
+ * Exported (not just used inline) so it can be unit-tested standalone,
+ * without mounting the rest of the root layout's provider tree.
+ */
+export function RootErrorBoundary({ reset }: ErrorComponentProps) {
+  const { t } = useTranslation();
+  return (
+    <ErrorState
+      title={t('errorBoundary.title')}
+      description={t('errorBoundary.description')}
+      onRetry={reset}
+      className="h-full"
+    />
+  );
 }
 
 function RootLayout() {
@@ -279,6 +306,7 @@ function RootLayout() {
 
 export const Route = createRootRoute({
   component: RootLayout,
+  errorComponent: RootErrorBoundary,
   notFoundComponent: () => (
     <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
       <p className="text-base font-semibold text-foreground/50">Page not found</p>

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -5,6 +5,10 @@
     "close": "Schließen",
     "exportFailed": "Export fehlgeschlagen. Bitte versuche es erneut."
   },
+  "errorBoundary": {
+    "title": "Etwas ist schiefgelaufen",
+    "description": "Auf dieser Seite ist ein unerwarteter Fehler aufgetreten. Versuche es erneut oder wähle eine andere Seite in der Seitenleiste."
+  },
   "app": {
     "title": "AI Job Hunter",
     "tagline": "Ruhig. Lokal. KI-nativ."

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -7,7 +7,8 @@
   },
   "errorBoundary": {
     "title": "Etwas ist schiefgelaufen",
-    "description": "Auf dieser Seite ist ein unerwarteter Fehler aufgetreten. Versuche es erneut oder wähle eine andere Seite in der Seitenleiste."
+    "description": "Auf dieser Seite ist ein unerwarteter Fehler aufgetreten. Versuche es erneut oder kehre zum Dashboard zurück.",
+    "goHome": "Zum Dashboard"
   },
   "app": {
     "title": "AI Job Hunter",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -5,6 +5,10 @@
     "close": "Close",
     "exportFailed": "Export failed. Please try again."
   },
+  "errorBoundary": {
+    "title": "Something went wrong",
+    "description": "This page hit an unexpected error. Try again, or pick another page from the sidebar."
+  },
   "app": {
     "title": "AI Job Hunter",
     "tagline": "Calm. Local. AI-native."

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -7,7 +7,8 @@
   },
   "errorBoundary": {
     "title": "Something went wrong",
-    "description": "This page hit an unexpected error. Try again, or pick another page from the sidebar."
+    "description": "This page hit an unexpected error. Try again, or go back to the dashboard.",
+    "goHome": "Go to dashboard"
   },
   "app": {
     "title": "AI Job Hunter",

--- a/scripts/check-event-subscriptions.mjs
+++ b/scripts/check-event-subscriptions.mjs
@@ -211,7 +211,7 @@ const SUBSCRIBERS = {
   },
   'features/settings/components/ai-settings/EmbeddingsSettings/index.tsx': {
     mount: 'route-scoped',
-    hash: '0de0f20640fd',
+    hash: '71b93c0d2da4',
     note:
       'Completion is reported only by the panel that started the run: its `useJobEvents` ' +
       'handler unsubscribes on unmount, so the complete / partial-failure / failure toast is ' +


### PR DESCRIPTION
Four fixes found while reading a v0.139.0 diagnostics bundle. The headline: **the Score tab shipped in v0.139.0 has never rendered a score.**

## The Score tab could not score

`useJobAdTextMatchScore` is gated on `!!resumeId`, but the tailor wizard only ever carried résumé **text**. `buildTailorDefaults` never set `resumeDocId`, and `persistence.wizardForm` — the only other carrier — is session-store state reset to `null` on launch. So on every cold start the panel took its `!resumeId` branch and rendered *"Save a résumé to score"*.

Walking to the Resume step did not fix it either: `ResumeInputCard`'s auto-select short-circuits on pre-seeded text (`if (value) return;`), so `selectDoc` never fired. The only way to get a score was to manually re-pick a résumé from the Saved menu — which nobody would do, because the text was already correct.

`ApplicationDetailPage` had the id the whole time. It fetches the default résumé's text *by id* and forwarded only the text. It now forwards the id too — but only for the branch that genuinely has a saved-document backing. The autopilot one-shot seed and a previous generation's `resumeText` have none, and an id that does not match the visible text is the exact drift `useResumeInput`'s `selectDoc` contract exists to prevent.

Deliberately **not** fixed inside `useResumeInput`: making its short-circuit call `selectDoc` would break that twice-fixed contract. Seeding a matched pair at the source satisfies it instead.

A persisted id can also outlive its document (advance a step, delete the résumé, come back). `resume_source` is ID-WINS with **no fallback** — `resolve_resume` answers `resume not found: <id>` and never consults `resumeText`, which the pipeline has already blanked *because* an id was set. A stale id is now dropped. That guard reads `_id`, not `id`: `useDocuments` is typed as `DocumentRecord[]` but the backend really returns `_id`, so reading `.id` typechecks and is `undefined` at runtime — it would have stripped *every* id rather than only stale ones.

## The score panel disclosed egress it never performed

The CLI-agent notice (*"If this posting needs translation, its text is sent to {{provider}}"*) rendered above the body branch, so it also appeared on the no-résumé and no-posting states — warning about a network send on a panel that will never send anything. It now renders on exactly the branches reachable only *after* a request went out, the error branch included: that branch's `score && !isMeasured(score)` disjunct requires the query to have resolved, so the text was provably already sent.

Those no-data branches also stretched one line of grey text over ~600px of empty box; they use `EmptyState` now. And the panel finally renders `MatchScore.recommendations`, which the Rust kernel has always built and no component read.

## A route error white-screened the app

The bundle caught `AutopilotPage` throwing a Rules-of-Hooks error, with the router logging *"The following error wasn't caught by any route!"*. The root route had no `errorComponent`.

Worth being precise about what the boundary can do: it replaces the **whole shell**, because the router wraps a match's component in its catch boundary and the root match's component *is* `RootLayout`. So there is no sidebar left to send anyone to, and `reset` re-renders the route that threw — recovery for a transient failure, a loop for a deterministic render bug. The boundary therefore ships with a dashboard button as the real way out, and copy that does not promise a sidebar that is not there.

## Local embeddings had a budget a loaded GPU could not meet

66 `embed failed … Ollama unreachable` lines. Reading the database rather than the log settled what it actually was: the config was `('ollama', 'qwen3-embedding:4b')`, the document was indexed, and the stored vector matched that model at dim 2560. **The configuration was correct.**

The failure cycles are exactly 45s — three attempts at the 15s bound — running concurrently with a local `/api/chat` on a 27B model that held the GPU for 213s before failing. Ollama was up; it serialises by default, so the embed queued behind that generation. Before v0.138.1 a timeout and a refused connection both printed "unreachable", which is why it read as a dead daemon.

`OLLAMA_EMBED` goes to **30s**, not further. `rerank.rs` derives `RERANK_STEP_TIMEOUT` as `SEMANTIC_RERANK_MAX * 15`, and that bare `15` *was* this constant. One degraded job costs a whole embed budget, so at 60s the breaker's three consecutive degrades need 540s — past the 300s wall clock wrapping the phase, meaning `RERANK_DEGRADE_BREAKER` could never fire and the phase would burn its full clock hourly. That is verbatim what the breaker exists to prevent. 30s is the largest value that keeps `3 × (30 × 3) = 270s < 300s`.

Because that coupling is invisible from `timeouts.rs`, it is now a **compile-time assertion** rather than a comment — widening the constant past ~33s fails the build. Mutation-checked: restoring 60s produces `evaluation panicked: RERANK_DEGRADE_BREAKER embed budgets must fit inside RERANK_STEP_TIMEOUT`.

Separately, `ollama-cloud` joins the embeddings provider list. `OllamaCloudClient` implements `embed` and reports `supports_embeddings`, but the panel never offered it, so an Ollama Cloud user had no non-local option at all. Its `defaultModel` is deliberately empty, matching `openai-compatible`: `default_embedding_model()` returns `None` for that client on purpose, and guessing a model name `ollama.com` serves is the exact mistake #950 removed.

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `pnpm -F @ajh/desktop typecheck` — clean
- `eslint --max-warnings 0` on all changed TS/TSX — clean
- Full renderer suite — **494 files / 7215 tests passed**

Every guard added here was mutation-checked: the two seeding tests, the stale-id guard (both removing it and swapping `_id` for `id`), and the Rust const assertion. One pre-existing test was de-vacuumed — it passed with the equality guard removed, because an empty docs mock let the `?? undefined` fallback carry it alone.

## Not included

- The Rules-of-Hooks bug itself. There is no repro; the boundary makes it recoverable rather than fatal.
- An honest "embed provider unreachable" message in Settings → Embeddings, which still says *"Matching indexes them the first time they're needed"*. No reachability signal exists to drive it — `ai_embedding_status` reports counts, not health — so it needs a backend probe, not a string change.
- `ai_set_embedding_config` answers *"ollama-cloud does not support embeddings"* when the model field is left blank, where `embed_text` has the correct *"choose one in Settings"* wording. Pre-existing; this change adds a second door to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ollama Cloud as an embeddings provider, with a cost advisory and manual model selection.
  - Added a localized error screen with retry and dashboard navigation options.
  - Preserved résumé document associations when starting tailoring workflows.
  - Display recommendations in scoring results when available.

- **Bug Fixes**
  - Improved résumé and job-posting empty states and disclosure visibility.
  - Increased local Ollama embedding timeout to better support queue and model-loading delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->