### PR TITLE
build(desktop): stop the route generator treating route tests as routes

### DIFF
--- a/apps/desktop/vite.config.mts
+++ b/apps/desktop/vite.config.mts
@@ -38,6 +38,12 @@ export default defineConfig({
     TanStackRouterVite({
       routesDirectory: path.resolve(import.meta.dirname, 'src/renderer/routes'),
       generatedRouteTree: path.resolve(import.meta.dirname, 'src/renderer/routeTree.gen.ts'),
+      // A co-located test for a route module (e.g. `__root`'s error boundary) is
+      // not a route: without this the generator warns on every run that the file
+      // "does not export a Route". Matched against the BASENAME, and the
+      // alternative the warning suggests — a `-` filename prefix — would hide the
+      // test from the `*.test.tsx` convention every other suite follows.
+      routeFileIgnorePattern: '\\.(test|spec)\\.tsx?$',
     }),
     react(),
     tailwindcss(),


### PR DESCRIPTION
The route test added in #1057 lives beside the route module it covers, so the TanStack generator scans it and warns on every dev run:

```
Warning: Route file ".../routes/__root.error-boundary.test.tsx" does not export a Route.
This file will not be included in the route tree.
```

`routeFileIgnorePattern` covers every current and future route test in one line. The alternative the warning itself suggests — renaming to `-__root.error-boundary.test.tsx` — fixes one file and hides it from the `*.test.tsx` convention every other suite in the repo follows.

Two details worth recording, both checked against the generator source rather than assumed:

- It matches the **basename** via `String.match`, not the full path. (It compiles with the `g` flag, which would be a stateful-`lastIndex` trap with `.test()` — but `.match()` ignores `lastIndex`, so it is harmless here.)
- The double backslash is load-bearing. In a JS string `'\.'` collapses to `.`, which matches *any* character — `axtestx.tsx` would have been ignored too.

## Verification

Regenerated the route tree both ways:

- **without** the option → the warning prints
- **with** it → clean, and `routeTree.gen.ts` excludes only that file

All 15 real routes still resolve (`index`, `__root`, `applications.$id`, …); the ignore list is exactly `['__root.error-boundary.test.tsx']`. Full renderer suite green at 7216 tests — `vite.config.mts` is shared with vitest, so that was worth confirming rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
