### PR TITLE
fix(documents): score the saved résumé the score tab promises

### DIFF
--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.generation-error.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.generation-error.test.tsx
@@ -73,6 +73,10 @@ vi.mock('@/components/ui/ModelSelector', () => ({
 }));
 
 vi.mock('@/services', () => ({
+  // `TailorFlow` resolves the DEFAULT résumé for the Score tab's fallback id
+  // (`useDefaultResumeId` reads this) — empty list = no default, which keeps
+  // these tests on the pre-existing 'no résumé' behaviour.
+  useDocuments: () => ({ data: [], isLoading: false }),
   useResolveJobUrl: () => ({ data: undefined, isLoading: false }),
   useExtractText: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useActiveModelCapabilities: () => ({ data: { supportsWebSearch: false }, isSuccess: true }),

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/TailorFlow.test.tsx
@@ -79,7 +79,14 @@ const modelCapsState = {
   isSuccess: true,
 };
 
+/** Saved documents `useDefaultResumeId` resolves the Score-tab fallback from. */
+let savedDocsState: { _id: string; name?: string; isDefault?: boolean }[] = [];
+
 vi.mock('@/services', () => ({
+  // `TailorFlow` resolves the DEFAULT résumé for the Score tab's fallback id
+  // (`useDefaultResumeId` reads this). Defaults to an empty list — no default
+  // résumé — which keeps every other test on the pre-existing behaviour.
+  useDocuments: () => ({ data: savedDocsState, isLoading: false }),
   useResolveJobUrl: (_url: string, shouldFetch: boolean) => {
     lastResolveJobUrlShouldFetch = shouldFetch;
     return { data: resolveJobUrlState.data, isLoading: resolveJobUrlState.isLoading };
@@ -203,6 +210,7 @@ vi.mock('./TailorWizard', () => ({
     jobDesc,
     onJobDescChange,
     methods,
+    resumeId,
   }: {
     step: number;
     setStep: (n: number) => void;
@@ -212,12 +220,15 @@ vi.mock('./TailorWizard', () => ({
     // The RHF form — the stub reads the research toggle so the capability-driven
     // default is observable via a data attribute.
     methods: { watch: (name: 'researchCompany') => boolean };
+    /** What the Score tab will actually score — see TailorFlow's `resumeId`. */
+    resumeId?: string;
   }) => (
     <div
       data-testid={TEST_IDS.documents.tailorWizard}
       data-step={step}
       data-jobdesc={jobDesc}
       data-research={String(methods.watch('researchCompany'))}
+      data-resumeid={resumeId ?? ''}
     >
       <div
         role="button"
@@ -400,6 +411,7 @@ function renderFlow(opts: {
 // ── Reset between tests ───────────────────────────────────────────────────────
 
 beforeEach(() => {
+  savedDocsState = [];
   genMock.state = 'idle';
   genMock.busy = false;
   genMock.hasOutput = false;
@@ -1094,5 +1106,57 @@ describe('TailorFlow — persistent live-region announcer (CR-7)', () => {
     rerender(rerenderFlow());
 
     expect(screen.getByTestId(TEST_IDS.documents.liveAnnouncer)).toBeEmptyDOMElement();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Score-tab résumé id — the SAVED résumé, which is not always the form's field
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TailorFlow — which résumé the Score tab scores', () => {
+  it('falls back to the default saved résumé when the form has no picked document', () => {
+    // The autopilot apply path seeds `ap.resumeText`, a snapshot that can differ
+    // from the document it came from, so `resumeDocId` stays deliberately unset —
+    // which used to leave the Score tab permanently on "Save a résumé to score".
+    savedDocsState = [{ _id: 'doc-default', name: 'Resume.pdf', isDefault: true }];
+
+    renderFlow({});
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-resumeid',
+      'doc-default'
+    );
+  });
+
+  it('prefers an explicitly picked document over the default', () => {
+    savedDocsState = [
+      { _id: 'doc-default', name: 'Resume.pdf', isDefault: true },
+      { _id: 'doc-picked', name: 'Other.pdf' },
+    ];
+    const persistence = makePersistence();
+    persistence.wizardForm = {
+      resume: 'My resume',
+      outputType: 'both',
+      researchCompany: false,
+      resumeDocId: 'doc-picked',
+    };
+
+    renderFlow({ persistence });
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-resumeid',
+      'doc-picked'
+    );
+  });
+
+  it('scores nothing when there is no saved résumé at all — never a fabricated id', () => {
+    savedDocsState = [];
+
+    renderFlow({});
+
+    expect(screen.getByTestId(TEST_IDS.documents.tailorWizard)).toHaveAttribute(
+      'data-resumeid',
+      ''
+    );
   });
 });

--- a/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
+++ b/apps/desktop/src/renderer/features/documents/components/TailorFlow/index.tsx
@@ -11,6 +11,7 @@ import { ErrorState, transition } from '@ajh/ui';
 
 import { useCanUseAI, useSelectedModel } from '@/components/ui/ModelSelector';
 import { useInterviewQuestions } from '@/hooks/use-interview-questions';
+import { useDefaultResumeId } from '@/hooks/useDefaultResumeId';
 import type { LetterLayoutId, TemplateId } from '@/lib/generate';
 import { shouldSeedResearchDefault } from '@/lib/research-company-default';
 import { useActiveModelCapabilities, useResolveJobUrl } from '@/services';
@@ -208,12 +209,26 @@ export function TailorFlow({
   // below need its live value (the staged run itself takes no such field —
   // see the shared schema's doc comment on `ResumePipelineRunRequest`).
   const researchCompany = useWatch({ control: methods.control, name: 'researchCompany' });
-  // The SAVED résumé backing this generation, unedited (see `tailor-state.ts`'s
-  // doc on `resumeDocId`) — distinct from `resumeText`/`methods.getValues('resume')`,
-  // which is the wizard's live, possibly-tailored text. Threaded to JobAdView's
-  // Score tab so it reads the same résumé the Jobs page would score. Undefined
-  // until the user picks a saved résumé on the Resume step (or none is seeded).
-  const resumeId = useWatch({ control: methods.control, name: 'resumeDocId' });
+  // The form field: which saved document backs the text about to be GENERATED.
+  // It must keep matching the visible text, because `useTailorPipeline` sends
+  // `resumeText: ''` whenever it is set — a mismatched id would silently generate
+  // from a different résumé than the one on screen.
+  const pickedResumeDocId = useWatch({ control: methods.control, name: 'resumeDocId' });
+
+  // The Score tab asks a DIFFERENT question, and the two answers are not always
+  // the same document. Its own copy says "Scored against your saved résumé, not
+  // the tailored version shown here", so it wants the saved document even when
+  // the editor holds something else — and the autopilot apply path seeds
+  // `ap.resumeText` (see `AutopilotPage`), a snapshot that can differ from the
+  // document it was taken from, which is exactly when the strict field above must
+  // stay unset. Reading that field alone left this tab permanently on "Save a
+  // résumé to score" for every autopilot-originated application.
+  //
+  // Prefer an explicitly-picked document, fall back to the default — which is what
+  // the Jobs page has always scored (`useDefaultResumeId`), and what this line's
+  // previous comment already claimed to do.
+  const defaultResumeId = useDefaultResumeId();
+  const resumeId = pickedResumeDocId ?? defaultResumeId ?? undefined;
 
   // Keep the "search company" default in sync with the active model's capability:
   // seed it when the capability resolves after a cold-cache seed, and RE-seed it


### PR DESCRIPTION
Reported from a running dev session: the Score tab added in #1056 still read **"Save a résumé to score"** after #1057 supposedly fixed it — on an application reached through Autopilot → Apply.

## Why #1057 didn't cover it

#1057 seeds `resumeDocId` from the default résumé, but only when the seeded text **is** that document's text. That guard is correct for the field's own consumer: `useTailorPipeline` sends `resumeText: ''` whenever an id is set, so a mismatched id would silently generate from a different résumé than the one on screen.

It is the wrong constraint for the Score tab, which asks a different question.

`AutopilotPage` seeds `applySeedResume: ap.resumeText` — a snapshot taken when the autopilot was created. Re-import your résumé (new document id) and that snapshot no longer equals the document's text, so the guard correctly declines to seed, and the tab has no id to score with. Permanently, for every autopilot-originated application.

Confirmed against the reporter's own data: one document, `is_default = 1`, indexed, 8665 chars — `defaultResumeId` resolved fine the whole time. The id simply never reached `JobAdView`.

## The fix

The tab's own copy already states what it scores:

> Scored against your saved résumé, not the tailored version shown here.

So it wants the saved document even when the editor holds something else. It now prefers an explicitly-picked document and falls back to the default — which is what the Jobs page has always scored via `useDefaultResumeId`, and what the comment on that very line already *claimed* to do while reading the form field instead:

```
// Threaded to JobAdView's Score tab so it reads the same résumé the Jobs page
// would score.                                    ← the intent, not the behaviour
```

The form field keeps its strict meaning for the pipeline. Only the id handed to `JobAdView` changes. With no saved résumé at all there is still no id — never a fabricated one.

## Verification

Three new tests on the fallback (default used, explicit pick wins, nothing fabricated when there are no documents). Mutation-checked: dropping the fallback fails the first one.

`pnpm typecheck` clean · `eslint --max-warnings 0` clean · full renderer suite **7219 passed**.

Two existing `@/services` mocks needed `useDocuments` added, since `TailorFlow` now resolves the default résumé.

## Follow-up, not in this PR

With the tab finally rendering, it immediately exposed that the score itself is not trustworthy for non-English postings: a German ad yields *"Keyword coverage 7% across 291 job keywords"* with `abgeschlossenes`, `abgestimmt`, `abseits` — and a postcode, `13385` — listed as missing keywords. `documents::keywords::STOPWORDS` is English-only and the token filter admits any token longer than three characters, so the denominator fills with German function words and numbers. The codebase already documents this (`evidence/mod.rs`), and `STOPWORDS` is formula-version-pinned, so it needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
