### PR TITLE
docs: replace three extrapolated git-history figures with a measured one

### DIFF
--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -90,11 +90,22 @@ jobs:
           # metrics.ts happens to touch today, because a field dropped here does
           # not fail: it renders a silent '—' in a stat card.
           #
-          # Why it matters: these files are committed to main nightly. Dumped
-          # raw they were 3.4 MB, which cost ~70 MB of git history per year on a
-          # 54 MB repo — undoing the 147 MB -> 54 MB history rewrite within a
-          # year. Allowlisted they are ~170 KB. closed-pulls.json alone was
-          # 1.2 MB nightly to produce one median and one ratio.
+          # Why it matters: these files are committed to main nightly, and raw
+          # they were 3.4 MB a night. The cost to git is NOT that times 365.
+          # Consecutive snapshots differ only slightly, so git delta-compresses
+          # them hard, and an earlier note here said ~70 MB/year by multiplying
+          # raw bytes — wrong by about 2.7x. Measured instead, on the real
+          # thing: the 34 nightly revisions from 2026-07-21 to 2026-08-21 cost
+          # 2.2 MB of PACK space, i.e. ~26 MB/year — a rate this repo cannot
+          # absorb for long at any plausible clone size. Still
+          # very much worth removing; just a number that came from
+          # `cat-file --batch-check='%(objectsize:disk)'` rather than from
+          # multiplication. Allowlisted they are ~170 KB a night.
+          #
+          # closed-pulls.json alone was 1.2 MB nightly to produce one median and
+          # one ratio. That half is a page-weight win regardless of what git
+          # does with it: /mission-control was downloading 3.4 MB to render
+          # fifteen numbers.
           #
           # It is also a page-weight fix: /mission-control was downloading
           # 3.4 MB to render fifteen numbers.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,9 +66,12 @@ jobs:
       # The growth charts the home page embeds are regenerated daily by
       # 📈 Repo Charts and live on the orphan `badges` branch. They are pulled in
       # HERE rather than committed, because they are ~77 KB combined and change
-      # every day (new date stamp, new data point) — committing them to main
-      # would add ~28 MB of git history per year, the exact cost the parentless
-      # `badges` branch exists to avoid.
+      # every day (new date stamp, new data point). Committing them would grow
+      # main's history for output nobody reads twice — the cost the parentless
+      # `badges` branch exists to avoid. Deliberately not quantified as
+      # 77 KB x 365: git deltas near-identical daily files hard, and most of
+      # each SVG is an embedded font that never changes at all, so that
+      # multiplication overstates it badly (it did, in this comment, before).
       #
       # Runs AFTER the Next.js cache step on purpose: that step's key hashes
       # apps/landing/public/**, so landing a file that changes daily before it

--- a/.gitignore
+++ b/.gitignore
@@ -264,9 +264,11 @@ apps/landing/public/world/vid/
 
 # Growth charts fetched from the orphan `badges` branch at deploy time
 # (.github/workflows/pages.yml). ~77 KB that changes every day, so committing
-# them would add ~28 MB of git history a year — the cost the parentless badges
-# branch exists to avoid. Same rule as the /world clips above: build-time
-# asset, never a commit.
+# them would grow main's history for regenerated output — the cost the
+# parentless badges branch exists to avoid. Not quantified as 77 KB x 365: git
+# deltas near-identical daily files hard and most of each SVG is an unchanging
+# embedded font, so that multiplication overstates it (see pages.yml). Same
+# rule as the /world clips above: build-time asset, never a commit.
 apps/landing/public/stars.svg
 apps/landing/public/downloads.svg
 


### PR DESCRIPTION
Three comments claimed a git-history cost, and all three were wrong the same way: they multiplied a file's raw size by 365 and called the product "history per year". Git does not store files that way. Consecutive nightly snapshots differ only slightly so they delta-compress hard, and in the growth charts' case most of each SVG is an embedded font that is byte-identical every single day.

| Site | Claimed | Measured |
| --- | --- | --- |
| `metrics-snapshot.yml` | ~70 MB/year | **~26 MB/year** |
| `pages.yml` | ~28 MB/year | unquantified — see below |
| `.gitignore` | ~28 MB/year | unquantified — see below |

The measurement is `git cat-file --batch-check='%(objectsize:disk)'` over the real objects: the **34 nightly metrics revisions between 2026-07-21 and 2026-08-21 cost 2.2 MB of pack space**. That is an overstatement of about **2.7×** in the figure I wrote into `metrics-snapshot.yml` in #1065.

**The conclusion does not change.** ~26 MB/year is still a rate this repo cannot absorb, so slimming those payloads was right. And the page-weight half of that win never depended on git at all: `/mission-control` was downloading 3.4 MB to render fifteen numbers.

**Why the two chart comments are now unquantified rather than re-estimated.** I can measure what the metrics files cost because they are committed and their objects exist. The charts never have been committed, so any figure for them would come from the same multiplication that produced the error in the first place. A made-up number that happens to be smaller is not an improvement over a made-up number that was larger, so both comments now say *why* committing them is wrong and explicitly decline to put a figure on it.

Found while measuring what a history rewrite would actually reclaim — the same pass turned up that the repo's real cost profile is nothing like the raw-bytes picture these comments described.
