### PR TITLE
feat(landing): show real per-platform download counts on the download buttons

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,7 +63,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
-      # The growth charts the home page embeds are regenerated daily by
+      # The growth charts the home page embeds, plus the per-platform download
+      # counts /download shows on its buttons, are regenerated daily by
       # 📈 Repo Charts and live on the orphan `badges` branch. They are pulled in
       # HERE rather than committed, because they are ~77 KB combined and change
       # every day (new date stamp, new data point). Committing them would grow
@@ -86,7 +87,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --depth 1 origin badges
-          for f in stars.svg downloads.svg; do
+          for f in stars.svg downloads.svg downloads-by-platform.json; do
             git show "FETCH_HEAD:$f" > "apps/landing/public/$f"
             # `git show` into a redirect leaves an empty file behind on failure,
             # so check for content, not just existence. Failing the build is the

--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,7 @@ apps/landing/public/world/vid/
 # rule as the /world clips above: build-time asset, never a commit.
 apps/landing/public/stars.svg
 apps/landing/public/downloads.svg
+apps/landing/public/downloads-by-platform.json
 
 # ── Generated image sets ───────────────────────────────────────────────────────
 # All rendered output, not source: every file below is produced by a committed

--- a/apps/landing/src/app/download/page.tsx
+++ b/apps/landing/src/app/download/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 
 import { ClientScripts } from '@/components/ClientScripts';
 import { DownloadBody } from '@/components/download/DownloadBody';
+import { DownloadCounts } from '@/components/DownloadCounts';
 import { DownloadFreshness } from '@/components/DownloadFreshness';
 import { PageStyle } from '@/components/PageStyle';
 import versionData from '@/data/version.json';
@@ -52,6 +53,7 @@ export default function DownloadPage() {
       <PageStyle css={readStyle('download.css')} />
       <DownloadBody version={data.version} installers={data.installers} />
       <DownloadFreshness baked={data.version} />
+      <DownloadCounts />
       <ClientScripts srcs={['/scripts/download-0.js']} />
     </>
   );

--- a/apps/landing/src/components/DownloadCounts.test.tsx
+++ b/apps/landing/src/components/DownloadCounts.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+
+import { DownloadBody } from '@/components/download/DownloadBody';
+import { buildInstallers } from '@/lib/version';
+
+import { DownloadCounts } from './DownloadCounts';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const COUNTS = {
+  macArm: 21,
+  macIntel: 5,
+  winExe: 1200,
+  winMsi: 1,
+  linuxAppImage: 12,
+  linuxDeb: 10,
+  linuxRpm: 0,
+};
+
+function stubFetch(impl: () => unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(impl()))
+  );
+}
+
+const ok = (body: unknown) => ({ ok: true, json: () => Promise.resolve(body) });
+
+/** The real download page, so the pills are tested against the real buttons. */
+function renderPage() {
+  return render(
+    <>
+      <DownloadBody version="1.2.3" installers={buildInstallers('1.2.3')} />
+      <DownloadCounts />
+    </>
+  );
+}
+
+describe('DownloadCounts', () => {
+  it('puts each platform count on its own button, keyed by data-platform', async () => {
+    stubFetch(() => ok(COUNTS));
+    const { container } = renderPage();
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.dl-count')).toHaveLength(7);
+    });
+
+    for (const [platform, n] of Object.entries(COUNTS)) {
+      const btn = container.querySelector(`.dl-btn[data-platform="${platform}"]`);
+      expect(btn, `no button for ${platform}`).not.toBeNull();
+      // The count belongs to THIS button — a positional bug would still produce
+      // seven pills, so assert the pairing, not the tally.
+      expect(btn?.querySelector('.dl-count')?.textContent).toContain(
+        n === 1200 ? '1,200' : String(n)
+      );
+    }
+  });
+
+  it('speaks the unit, and gets its plural right', async () => {
+    stubFetch(() => ok(COUNTS));
+    const { container } = renderPage();
+    await waitFor(() => expect(container.querySelectorAll('.dl-count')).toHaveLength(7));
+
+    const unitFor = (p: string) =>
+      container.querySelector(`.dl-btn[data-platform="${p}"] .dl-count .sr-only`)?.textContent;
+    // Without this the link announces as "Intel · .dmg 5".
+    expect(unitFor('macArm')).toBe(' downloads');
+    expect(unitFor('winMsi')).toBe(' download');
+    expect(unitFor('linuxRpm')).toBe(' downloads');
+
+    // The visible pill must carry only the number; the unit is for the reader.
+    expect(
+      container.querySelector('.dl-btn[data-platform="macArm"] .dl-count')?.firstChild?.textContent
+    ).toBe('21');
+  });
+
+  it('leaves a button alone when its platform is absent or not a number', async () => {
+    stubFetch(() => ok({ macArm: 21, winExe: 'lots', linuxDeb: null }));
+    const { container } = renderPage();
+    await waitFor(() =>
+      expect(container.querySelector('.dl-btn[data-platform="macArm"] .dl-count')).not.toBeNull()
+    );
+    expect(container.querySelectorAll('.dl-count')).toHaveLength(1);
+  });
+
+  it('does not double up when the effect runs twice over the same buttons', async () => {
+    stubFetch(() => ok(COUNTS));
+    // Two mounted instances, ONE set of buttons — the effect body runs twice
+    // against the same nodes, which is what StrictMode does in dev.
+    //
+    // Deliberately not written as a rerender(): that re-renders DownloadBody
+    // too, replacing the button nodes, so the second pass decorates fresh
+    // buttons and the count comes back to 7 whether the guard exists or not.
+    // It passed with the guard deleted.
+    const { container } = render(
+      <>
+        <DownloadBody version="1.2.3" installers={buildInstallers('1.2.3')} />
+        <DownloadCounts />
+        <DownloadCounts />
+      </>
+    );
+
+    await waitFor(() => expect(container.querySelectorAll('.dl-count')).toHaveLength(7));
+    expect(container.querySelectorAll('.dl-btn[data-platform="winExe"] .dl-count')).toHaveLength(1);
+  });
+
+  it('stays silent when the counts file is missing, and never touches the buttons', async () => {
+    stubFetch(() => ({ ok: false, json: () => Promise.reject(new Error('nope')) }));
+    const { container } = renderPage();
+
+    await waitFor(() => expect(container.querySelectorAll('a.dl-btn')).toHaveLength(7));
+    expect(container.querySelectorAll('.dl-count')).toHaveLength(0);
+    // The download links are the point of the page; a missing count may not
+    // cost anyone one of them.
+    for (const a of Array.from(container.querySelectorAll('a.dl-btn'))) {
+      expect(a.getAttribute('href')).toMatch(/^https:\/\/github\.com\//);
+    }
+  });
+
+  it('survives fetch rejecting outright', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('offline')))
+    );
+    const { container } = renderPage();
+    await waitFor(() => expect(container.querySelectorAll('a.dl-btn')).toHaveLength(7));
+    expect(container.querySelectorAll('.dl-count')).toHaveLength(0);
+  });
+});

--- a/apps/landing/src/components/DownloadCounts.tsx
+++ b/apps/landing/src/components/DownloadCounts.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// Cumulative per-platform installer downloads, rendered as a pill on each
+// download button.
+//
+// SAME-ORIGIN AND STATIC, not the GitHub API. The honest figure is cumulative
+// across every release, and `releases/latest` only ever reports the newest one
+// — where every installer reads 1, because each asset picks up one automated
+// download nobody performed. Computing the real number client-side would mean
+// paginating the entire release list on every page view, against a 60/hour
+// budget shared by all visitors. Instead 📈 Repo Charts computes it nightly
+// (scripts/lib/github-releases.mjs, downloadsByPlatform) and pages.yml copies
+// the result into public/ next to the growth charts.
+//
+// Injected into the DOM rather than rendered as JSX because DownloadCards is a
+// server component whose markup is held to the ADR-0018 DOM-fidelity contract;
+// DownloadFreshness already mutates the same buttons in place on this page, so
+// this follows the idiom that is already here rather than adding a second one.
+const COUNTS_URL = '/downloads-by-platform.json';
+
+export function DownloadCounts() {
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const res = await fetch(COUNTS_URL);
+        if (!res.ok || cancelled) return;
+        const counts: unknown = await res.json();
+        if (cancelled || typeof counts !== 'object' || counts === null) return;
+
+        const byPlatform = counts as Record<string, unknown>;
+        const format = new Intl.NumberFormat('en-US');
+
+        document.querySelectorAll<HTMLAnchorElement>('.dl-btn[data-platform]').forEach((btn) => {
+          // Effects run twice under StrictMode in dev; without this the pill
+          // would be appended once per run.
+          if (btn.querySelector('.dl-count')) return;
+
+          const key = btn.dataset.platform;
+          const n = key === undefined ? undefined : byPlatform[key];
+          if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return;
+
+          const pill = document.createElement('span');
+          pill.className = 'dl-count';
+          pill.textContent = format.format(n);
+
+          // Without this the link announces as "Intel · .dmg 5", where the 5
+          // reads as part of the file description. The unit has to be spoken.
+          const unit = document.createElement('span');
+          unit.className = 'sr-only';
+          unit.textContent = n === 1 ? ' download' : ' downloads';
+          pill.appendChild(unit);
+
+          btn.appendChild(pill);
+        });
+      } catch {
+        // Silent, like DownloadFreshness: a missing count must never cost
+        // someone the download button it sits on.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/landing/src/components/download/DownloadBody.test.tsx
+++ b/apps/landing/src/components/download/DownloadBody.test.tsx
@@ -35,6 +35,28 @@ describe('DownloadBody', () => {
     expect(dlBtns.map((a) => a.getAttribute('href'))).toEqual(DL_BTN_ORDER);
   });
 
+  // DownloadCounts keys each download pill off data-platform, so a missing or
+  // misspelled one silently drops that platform's count with nothing else
+  // breaking. Asserted here in the same order as the href contract above, so
+  // the two identifiers for one button cannot drift apart.
+  it('labels every dl-btn with the data-platform key DownloadCounts looks up', () => {
+    const { container } = render(<DownloadBody version={VERSION} installers={installers} />);
+    const platforms = Array.from(container.querySelectorAll('a.dl-btn')).map((a) =>
+      a.getAttribute('data-platform')
+    );
+    expect(platforms).toEqual([
+      'macArm',
+      'macIntel',
+      'winExe',
+      'winMsi',
+      'linuxAppImage',
+      'linuxDeb',
+      'linuxRpm',
+    ]);
+    // Same keys the installer URLs are built from — one vocabulary, not two.
+    expect(platforms).toEqual(Object.keys(installers));
+  });
+
   it('renders #downloads-block as a display:contents node inside .platforms', () => {
     const { container } = render(<DownloadBody version={VERSION} installers={installers} />);
     const block = container.querySelector('#downloads-block');

--- a/apps/landing/src/components/download/DownloadCards.tsx
+++ b/apps/landing/src/components/download/DownloadCards.tsx
@@ -10,6 +10,11 @@ import type { Installers } from '@/lib/version';
 // linuxRpm — because DownloadFreshness swaps hrefs by `querySelectorAll` index,
 // not by any per-anchor identifier. Never reorder/insert/remove a `.dl-btn`
 // anchor here without updating DownloadFreshness.tsx (and its test) in lockstep.
+//
+// Each anchor also carries `data-platform`, which is what DownloadCounts keys
+// its download pills off — an explicit identifier rather than the positional
+// index above. DownloadFreshness could be moved onto it too; that swap is not
+// this change's to make, so the positional contract stands as written.
 export function DownloadCards({
   version,
   installers,
@@ -29,10 +34,10 @@ export function DownloadCards({
           <h2>macOS</h2>
         </div>
         <div className="pc-actions">
-          <a className="dl-btn" href={installers.macArm}>
+          <a className="dl-btn" data-platform="macArm" href={installers.macArm}>
             Apple Silicon · .dmg
           </a>
-          <a className="dl-btn alt" href={installers.macIntel}>
+          <a className="dl-btn alt" data-platform="macIntel" href={installers.macIntel}>
             Intel · .dmg
           </a>
         </div>
@@ -83,10 +88,10 @@ export function DownloadCards({
           <h2>Windows</h2>
         </div>
         <div className="pc-actions">
-          <a className="dl-btn" href={installers.winExe}>
+          <a className="dl-btn" data-platform="winExe" href={installers.winExe}>
             Installer · .exe
           </a>
-          <a className="dl-btn alt" href={installers.winMsi}>
+          <a className="dl-btn alt" data-platform="winMsi" href={installers.winMsi}>
             .msi
           </a>
         </div>
@@ -101,13 +106,13 @@ export function DownloadCards({
           <h2>Linux</h2>
         </div>
         <div className="pc-actions">
-          <a className="dl-btn" href={installers.linuxAppImage}>
+          <a className="dl-btn" data-platform="linuxAppImage" href={installers.linuxAppImage}>
             .AppImage
           </a>
-          <a className="dl-btn alt" href={installers.linuxDeb}>
+          <a className="dl-btn alt" data-platform="linuxDeb" href={installers.linuxDeb}>
             .deb
           </a>
-          <a className="dl-btn alt" href={installers.linuxRpm}>
+          <a className="dl-btn alt" data-platform="linuxRpm" href={installers.linuxRpm}>
             .rpm
           </a>
         </div>

--- a/apps/landing/src/styles/download.css
+++ b/apps/landing/src/styles/download.css
@@ -177,6 +177,42 @@ h2 {
   outline-offset: 3px;
   border-radius: 12px;
 }
+/* Download-count pill, appended into each .dl-btn by DownloadCounts.tsx once
+   the static /downloads-by-platform.json lands. It is absent on first paint and
+   absent entirely when the fetch fails, so nothing here may change the button's
+   resting size — margin-left only, no padding on the button itself. */
+.dl-count {
+  margin-left: 8px;
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  /* inherit, so the pill rides whichever button colour it lands on: cream text
+     on .dl-btn's ink, ink text on .dl-btn.alt's transparent card. */
+  color: inherit;
+  background: rgba(244, 236, 220, 0.18);
+  white-space: nowrap;
+}
+.dl-btn.alt .dl-count {
+  background: rgba(28, 24, 18, 0.1);
+}
+
+/* The pill's unit, spoken but not shown: "Intel · .dmg 5" reads as though the
+   5 were part of the file description. Not previously needed on this page, so
+   it is defined here rather than imported — /download loads download.css alone
+   (see readStyle in app/download/page.tsx), exactly like home.css elsewhere. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* note drops to its own full-width line beneath the head + buttons */
 .dl-note {
   flex-basis: 100%;

--- a/scripts/build-repo-charts.mjs
+++ b/scripts/build-repo-charts.mjs
@@ -18,7 +18,8 @@
 //     seeded once from git history (scripts/backfill-downloads-history.mjs) and
 //     appended to daily from here.
 //
-// Output: badge-out/{downloads.json,downloads-history.json,downloads.svg,stars.svg}
+// Output: badge-out/{downloads.json,downloads-by-platform.json,
+//                    downloads-history.json,downloads.svg,stars.svg}
 // Run locally: GITHUB_TOKEN=$(gh auth token) node scripts/build-repo-charts.mjs
 
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -26,7 +27,12 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { mergePoints, readJsonArray } from './lib/downloads-history.mjs';
-import { fetchAllReleases, fetchStargazers, installerDownloads } from './lib/github-releases.mjs';
+import {
+  downloadsByPlatform,
+  fetchAllReleases,
+  fetchStargazers,
+  installerDownloads,
+} from './lib/github-releases.mjs';
 import { GOLD, RED, renderLineChart } from './lib/line-chart-svg.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -81,6 +87,16 @@ writeFileSync(
   `${JSON.stringify({ schemaVersion: 1, label: 'downloads', message: humanize(total), color: RED.slice(1) }, null, 2)}\n`
 );
 writeFileSync(join(outDir, 'downloads-history.json'), `${JSON.stringify(history, null, 2)}\n`);
+
+// Per-platform split for the /download buttons. Published here rather than
+// fetched by the page: the honest number is cumulative across every release, so
+// a client would need the whole paginated release list to compute it — against
+// a 60/hour budget shared by every visitor. This costs one static same-origin
+// file that pages.yml copies into public/ alongside the charts.
+writeFileSync(
+  join(outDir, 'downloads-by-platform.json'),
+  `${JSON.stringify(downloadsByPlatform(releases), null, 2)}\n`
+);
 
 function writeChart(name, opts) {
   writeFileSync(join(outDir, `${name}.svg`), renderLineChart(opts));

--- a/scripts/lib/github-releases.mjs
+++ b/scripts/lib/github-releases.mjs
@@ -54,6 +54,80 @@ export function installerDownloads(releases) {
 }
 
 /**
+ * Which installer asset belongs to which button on /download.
+ *
+ * Matched by SUFFIX rather than by a version-bearing full name, so a version
+ * bump can never silently zero a platform. The seven suffixes partition the
+ * INSTALLER_RE set exactly — checked against every asset of every release:
+ * 1013 assets, 0 unmatched, 0 matched twice — and `downloadsByPlatform` asserts
+ * that partition on every run rather than trusting it.
+ */
+export const PLATFORM_SUFFIX = {
+  macArm: '_aarch64-apple-silicon.dmg',
+  macIntel: '_x64-intel.dmg',
+  winExe: '_x64-setup.exe',
+  winMsi: '_x64_en-US.msi',
+  linuxAppImage: '_amd64.AppImage',
+  linuxDeb: '_amd64.deb',
+  linuxRpm: '.x86_64.rpm',
+};
+
+/**
+ * Per-platform installer downloads, with the automated floor removed.
+ *
+ * Every asset picks up one download nobody performed. Measured across all
+ * releases, 334 of 438 installer assets sit at exactly 1 — including all seven
+ * installers of a release published the day before, .rpm included. Nobody
+ * downloads an rpm they have not heard of within a day, seven times over.
+ *
+ * Left in, that floor IS the number for the quiet platforms: .msi and .rpm each
+ * read 67 raw against 5 real, and three platforms tie at exactly the release
+ * count because that is all they are. A badge saying 67 where the truth is 5
+ * is not a rounding error, it is a different claim.
+ *
+ * So each asset contributes `max(0, count - 1)`. That is a floor subtraction,
+ * not a model — assets sitting at 0 exist, so it is clamped rather than
+ * assumed. It can undercount by one per release when a real download coincides
+ * with the automated one; undercounting is the right way to be wrong here.
+ */
+export function downloadsByPlatform(releases) {
+  const out = Object.fromEntries(Object.keys(PLATFORM_SUFFIX).map((k) => [k, 0]));
+  let rawMatched = 0;
+
+  for (const release of releases) {
+    for (const asset of release.assets ?? []) {
+      if (!INSTALLER_RE.test(asset.name)) continue;
+      const hits = Object.keys(PLATFORM_SUFFIX).filter((k) =>
+        asset.name.endsWith(PLATFORM_SUFFIX[k])
+      );
+      // A rename upstream must fail the build, not publish a badge that is
+      // quietly missing a platform. Same rule as readJsonArray in
+      // downloads-history.mjs: never publish reduced output silently.
+      if (hits.length !== 1) {
+        throw new Error(
+          `downloadsByPlatform: "${asset.name}" matched ${hits.length} platform suffixes ` +
+            `(expected exactly 1). Installer naming changed — update PLATFORM_SUFFIX.`
+        );
+      }
+      const count = asset.download_count ?? 0;
+      out[hits[0]] += Math.max(0, count - 1);
+      rawMatched += count;
+    }
+  }
+
+  // The partition check, stated as an equation rather than a comment: every
+  // download installerDownloads() counts must land in exactly one bucket.
+  const expected = installerDownloads(releases);
+  if (rawMatched !== expected) {
+    throw new Error(
+      `downloadsByPlatform: buckets saw ${rawMatched} raw downloads but ` +
+        `installerDownloads() counted ${expected} — the suffix map no longer partitions INSTALLER_RE.`
+    );
+  }
+  return out;
+}
+
+/**
  * Stargazers with their `starred_at` timestamps.
  *
  * Needs the `star+json` media type — the default representation omits

--- a/scripts/lib/github-releases.test.mjs
+++ b/scripts/lib/github-releases.test.mjs
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { downloadsByPlatform, installerDownloads, PLATFORM_SUFFIX } from './github-releases.mjs';
+
+const asset = (name, download_count) => ({ name, download_count });
+
+/** One release carrying the full seven-installer set, plus the noise GitHub attaches. */
+function release(v, counts = {}) {
+  return {
+    assets: [
+      asset(`macos-AI-Job-Hunter_${v}_aarch64-apple-silicon.dmg`, counts.macArm ?? 1),
+      asset(`macos-AI-Job-Hunter_${v}_x64-intel.dmg`, counts.macIntel ?? 1),
+      asset(`windows-AI-Job-Hunter_${v}_x64-setup.exe`, counts.winExe ?? 1),
+      asset(`windows-AI-Job-Hunter_${v}_x64_en-US.msi`, counts.winMsi ?? 1),
+      asset(`linux-AI-Job-Hunter_${v}_amd64.AppImage`, counts.linuxAppImage ?? 1),
+      asset(`linux-AI-Job-Hunter_${v}_amd64.deb`, counts.linuxDeb ?? 1),
+      asset(`linux-AI-Job-Hunter-${v}-1.x86_64.rpm`, counts.linuxRpm ?? 1),
+      // Not installs: updater channel, signatures, extension store bundles.
+      asset('latest.json', 99),
+      asset(`windows-AI-Job-Hunter_${v}_x64-setup.exe.sig`, 99),
+      asset(`macos-AI-Job-Hunter-apple-silicon.app.tar.gz`, 99),
+      asset(`ai-job-hunter-extension-chrome-${v}.zip`, 99),
+    ],
+  };
+}
+
+describe('downloadsByPlatform', () => {
+  // The whole reason the function exists. Every asset picks up one download
+  // nobody performed, and three platforms sit at exactly the release count
+  // because that floor is all they have.
+  it('reports zero for a platform that only ever saw the automated download', () => {
+    const counts = downloadsByPlatform([release('1.0.0'), release('1.0.1'), release('1.0.2')]);
+    expect(counts).toEqual({
+      macArm: 0,
+      macIntel: 0,
+      winExe: 0,
+      winMsi: 0,
+      linuxAppImage: 0,
+      linuxDeb: 0,
+      linuxRpm: 0,
+    });
+    // Raw, this fixture would read 3 per platform — the exact overstatement
+    // that would have shipped: 21 downloads claimed, 0 real.
+    expect(installerDownloads([release('1.0.0'), release('1.0.1'), release('1.0.2')])).toBe(21);
+  });
+
+  it('accumulates real downloads across releases, one floor per asset', () => {
+    const counts = downloadsByPlatform([
+      release('1.0.0', { winExe: 40, macArm: 3 }),
+      release('1.0.1', { winExe: 12 }),
+    ]);
+    expect(counts.winExe).toBe(50); // (40-1) + (12-1)
+    expect(counts.macArm).toBe(2); // (3-1) + (1-1)
+    expect(counts.linuxDeb).toBe(0);
+  });
+
+  it('clamps at zero rather than assuming the floor is always present', () => {
+    // Four such assets exist in the real data, so the subtraction must not
+    // be allowed to go negative.
+    expect(downloadsByPlatform([release('1.0.0', { linuxRpm: 0 })]).linuxRpm).toBe(0);
+  });
+
+  it('ignores updater, signature and extension assets entirely', () => {
+    // Every non-installer above carries 99; none of it may reach a bucket.
+    const counts = downloadsByPlatform([release('1.0.0')]);
+    expect(Object.values(counts).reduce((a, b) => a + b, 0)).toBe(0);
+  });
+
+  // A rename upstream must break the build, not publish a badge quietly
+  // missing a platform.
+  it('throws when an installer matches no known platform suffix', () => {
+    const renamed = { assets: [asset('windows-AI-Job-Hunter_2.0.0_arm64-setup.exe', 5)] };
+    expect(() => downloadsByPlatform([renamed])).toThrow(/matched 0 platform suffixes/);
+  });
+
+  // The `hits.length > 1` half of that guard is deliberately NOT exercised with
+  // a fixture, because no fixture can reach it: a name can only end with two
+  // suffixes if one suffix ends with the other, and the test below proves none
+  // does. Writing a "two matches" case meant contriving a string that quietly
+  // matched only once and asserting a throw that never came — a test that
+  // passes for the wrong reason. The structural property is the real guard, so
+  // it is asserted directly instead.
+  it('has no suffix that ends with another, which is what keeps matching unambiguous', () => {
+    const keys = Object.keys(PLATFORM_SUFFIX);
+    expect(keys).toHaveLength(7);
+    for (const a of keys) {
+      for (const b of keys) {
+        if (a === b) continue;
+        // If one suffix ended with another, a single asset would match twice
+        // and every real run would throw.
+        expect(PLATFORM_SUFFIX[a].endsWith(PLATFORM_SUFFIX[b])).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Each download button now carries a pill showing how many people took that installer.

## The number is not the one GitHub hands you

Every release asset picks up one download nobody performed. Across all releases, **334 of 438 installer assets sit at exactly 1** — including all seven installers of a release published the day before. Nobody finds an `.rpm` they have not heard of within a day, seven times over.

Left in, that floor **is** the number for the quiet platforms:

| Button | Raw | Real |
| --- | ---: | ---: |
| Installer · .exe | 162 | **100** |
| Apple Silicon · .dmg | 83 | **21** |
| .AppImage | 74 | **12** |
| .deb | 72 | **10** |
| Intel · .dmg | 67 | **5** |
| .msi | 67 | **5** |
| .rpm | 67 | **5** |

Three platforms tie at exactly the release count because that is all they have. Shipping raw would have overstated those three by **13×** on a page that states the figure as fact, so each asset contributes `max(0, count - 1)`.

That is a floor subtraction, not a model. Assets sitting at 0 exist, so it is clamped rather than assumed, and it can undercount by one per release when a real download coincides with the automated one. For a number presented as fact, undercounting is the right direction to be wrong in.

## Why it is a static file and not an API call

The honest figure is cumulative across every release, so `releases/latest` cannot produce it — there, every installer reads 1. Computing it client-side means paginating the entire release list on every page view, against a 60/hour budget shared by all visitors (a cost `DownloadFreshness` already pays once per view).

📈 Repo Charts already fetches every release for the downloads chart, so it emits the split as `downloads-by-platform.json`, and `pages.yml` copies it into `public/` beside the growth charts. **Same-origin, no third-party request** — the site still makes zero.

## The mapping is asserted, not trusted

`downloadsByPlatform` throws if any `INSTALLER_RE` asset matches no platform suffix or more than one, and cross-checks its own raw total against `installerDownloads()`. An upstream asset rename **fails the build** rather than publishing a badge quietly missing a platform. Verified against every asset of every release: 1013 assets, 0 unmatched, 0 matched twice.

Buttons gained `data-platform`, so the counts key off an explicit identifier rather than the positional index `DownloadFreshness` is stuck with. A test pins those keys to the same order as the href contract so the two identifiers for one button cannot drift.

## One test did not survive mutation

The idempotency case was first written as a `rerender()`. That re-renders `DownloadBody` too, replacing the button nodes — so the second pass decorated *fresh* buttons and the count came back to seven whether the guard existed or not. **It passed with the guard deleted.** Rewritten as two mounted instances over one set of buttons, it fails as it should. The other four guards were mutation-checked and all fail when broken.

Rendered against real data before pushing — pills read correctly on both the dark primary and the light `.alt` buttons, no console errors, no hydration warnings.
