### PR TITLE
fix(ci): publish downloads-by-platform.json, and stop it from blocking deploys

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -87,17 +87,35 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --depth 1 origin badges
-          for f in stars.svg downloads.svg downloads-by-platform.json; do
+          # REQUIRED. The home page embeds these two in <img>, so a missing one
+          # is a broken image on the landing page. `git show` into a redirect
+          # leaves an empty file behind on failure, so check for content, not
+          # existence. Failing is the correct outcome — the last good site stays
+          # up. Same rule as readJsonArray in scripts/lib/downloads-history.mjs.
+          for f in stars.svg downloads.svg; do
             git show "FETCH_HEAD:$f" > "apps/landing/public/$f"
-            # `git show` into a redirect leaves an empty file behind on failure,
-            # so check for content, not just existence. Failing the build is the
-            # correct outcome: the last good site stays up, whereas shipping a
-            # broken <img> onto the home page is a visible defect. Same rule as
-            # readJsonArray in scripts/lib/downloads-history.mjs — never publish
-            # reduced output quietly.
             [ -s "apps/landing/public/$f" ] || { echo "::error::$f missing or empty on the badges branch"; exit 1; }
             echo "fetched $f ($(wc -c < "apps/landing/public/$f") bytes)"
           done
+
+          # OPTIONAL, and the distinction is deliberate. DownloadCounts fetches
+          # this at runtime and no-ops when it is absent, so the failure mode is
+          # /download without its count pills — invisible, not broken. Taking the
+          # whole site's deploy down for that would block every unrelated fix
+          # behind a decorative file, which is a worse outcome than the thing it
+          # is guarding against. Warned rather than silent, so a persistently
+          # missing file is still visible in the run summary.
+          #
+          # It shipped missing exactly once, because repo-charts.yml builds the
+          # badges tree from its own hardcoded file list: adding an output to
+          # build-repo-charts.mjs publishes nothing until that list names it too.
+          if git show "FETCH_HEAD:downloads-by-platform.json" > apps/landing/public/downloads-by-platform.json 2>/dev/null \
+            && [ -s apps/landing/public/downloads-by-platform.json ]; then
+            echo "fetched downloads-by-platform.json ($(wc -c < apps/landing/public/downloads-by-platform.json) bytes)"
+          else
+            rm -f apps/landing/public/downloads-by-platform.json
+            echo "::warning::downloads-by-platform.json missing on the badges branch — /download ships without its count pills. Check the publish list in repo-charts.yml."
+          fi
 
       - name: 🏗️ Build landing (static export)
         run: pnpm --filter @ajh/landing build

--- a/.github/workflows/repo-charts.yml
+++ b/.github/workflows/repo-charts.yml
@@ -113,7 +113,11 @@ jobs:
 
           # Build the tree from whichever outputs exist.
           tree="$(
-            for f in downloads.json downloads-history.json downloads.svg stars.svg; do
+            # Every file build-repo-charts.mjs emits must be listed here AND in
+            # pages.yml's fetch loop. Adding an output to the script alone publishes
+            # nothing — which is exactly how downloads-by-platform.json shipped
+            # missing and broke the next Pages deploy.
+            for f in downloads.json downloads-by-platform.json downloads-history.json downloads.svg stars.svg; do
               [ -f "badge-out/$f" ] || continue
               printf '100644 blob %s\t%s\n' "$(git hash-object -w "badge-out/$f")" "$f"
             done | git mktree


### PR DESCRIPTION
**The Pages deploy after #1068 failed.** This fixes it.

#1068 added an output to `build-repo-charts.mjs` and taught `pages.yml` to fetch it — but `repo-charts.yml` builds the `badges` tree from **its own hardcoded file list**, and that list was never updated. So the file was generated on every run and published on none, and the next deploy failed on a file that could not exist.

One output, three registration points, two of them updated. Confirmed by dispatching 📈 Repo Charts by hand: it went green and `badges` still held only the original four files.

## Two fixes

**`repo-charts.yml`** now names the file in the publish list, with a comment stating that this list and `pages.yml`'s fetch loop have to move together.

**`pages.yml`** no longer treats it as required, which it never should have been. The distinction now written into the step:

| File | Consumed by | Missing means | Verdict |
| --- | --- | --- | --- |
| `stars.svg`, `downloads.svg` | `<img>` on the home page | visibly broken image | **fatal** — last good site stays up |
| `downloads-by-platform.json` | `DownloadCounts`, at runtime | `/download` without count pills | **warn** |

`DownloadCounts` already no-ops when the file is absent — that is its documented design. Blocking every unrelated fix behind a decorative file is a worse outcome than the thing the guard was protecting against. Warned rather than silent, so a persistently missing file still shows up in the run summary.

## Verified rather than assumed

The optional branch was exercised against the **real `badges` branch in its current file-missing state**: it survives `set -euo pipefail`, emits the warning, and leaves no empty file behind for `next build` to pick up. (`git show` into a redirect creates the file before it fails, which is why the `rm -f` is there and not decoration.)

Worth noting the guard worked exactly as intended for the SVGs — the failed deploy left the previous site up rather than publishing a page with broken images. The bug was applying that same severity to a file whose absence nobody can see.
