### PR TITLE
docs: repair the citations the history rewrite broke, and stop citing shas

### DIFF
--- a/docs/EXPORT_TEMPLATES.md
+++ b/docs/EXPORT_TEMPLATES.md
@@ -357,8 +357,11 @@ confined to the test function; no typst types appear in production code paths.
 
 **Dev note — preview-regen.** The two preview generators are `#[ignore]`
 libtest fns (`generate_templates_showcase_banner` and
-`generate_cover_template_previews` in `typst_engine/test.rs`). Local `cargo test`
-now works on branches containing the build.rs delay-load fix (2fb85227). Preview
+`generate_cover_template_previews` in `typst_engine/test.rs`). Local `cargo test` works
+unconditionally — the delay-load fix that used to be branch-dependent lives in
+`apps/desktop/src-tauri/build.rs` on main (grep `DELAYLOAD`). The sha that
+caveat named stopped resolving in an earlier history rewrite and went unnoticed,
+which is the argument for naming the file rather than the commit. Preview
 assets may still be stale/incomplete: `cadence`, `regent`, `aria`,
 and `saffron` may lack `.svg` (résumé + cover), the `classic` preview
 may still reflect older `classic.typ`, and the résumé showcase banner may show the old nine. **Regenerate in CI or on

--- a/docs/knowledge/decision-records/0005-network-egress-privacy-boundary.md
+++ b/docs/knowledge/decision-records/0005-network-egress-privacy-boundary.md
@@ -63,8 +63,12 @@ No runtime behavior changes: every current call already complies. The fix is to 
 - Opt-in setting: `apps/desktop/src/renderer/store/preferences-schema/preferences-schema.ts` (company-logo preference, default OFF).
 - Machine-readable inventory: `apps/desktop/src-tauri/tests/egress.rs` (EGRESS const).
 - Audit finding: `p2-contra-cross-001`, §4 of the 2026-08-16 full-history audit.
-  That report was a 1.5 MB one-off snapshot scoped to `v0.123.0` and is no longer in
-  the tree; read it with `git show cd1219ef7:AUDIT_REPORT.md`. That sha moved once
-  already, in the history rewrite of PR #1033 — if it stops resolving, find the
-  commit for PR #1000 and read the file there. Its `path:line` citations
-  point at that commit's HEAD, not this one.
+  That report was a 1.5 MB one-off snapshot scoped to
+  `v0.123.0`. It is not in the tree and, since the 2026-08-21 history rewrite,
+  not in any commit either — read it at
+  [AUDIT_REPORT.md on the `assets` branch](https://raw.githubusercontent.com/saeedkolivand/ai-job-hunter-app/assets/AUDIT_REPORT.md).
+  Deliberately no longer cited by commit sha: this citation has now been broken
+  by two separate rewrites, and a sha in a doc is precisely the drift-prone
+  literal rule 17 forbids. The `assets` branch is parentless and force-pushed,
+  so the URL is stable and the file costs no history. Its `path:line` citations
+  point at the tree as of PR #1000, not this one.

--- a/docs/knowledge/decision-records/0006-support-page-faq-only-diagnostics-removed.md
+++ b/docs/knowledge/decision-records/0006-support-page-faq-only-diagnostics-removed.md
@@ -71,9 +71,12 @@ need — not by resurrecting this speculative, backendless subtree.
 - Orphaned subtree: the other 22 components under `apps/desktop/src/renderer/features/support/components/`.
 - Backend: `export_diagnostics` + `get_system_info` registration in `apps/desktop/src-tauri/src/lib.rs`; `support` client namespace in `apps/desktop/src/tauri-client/namespaces/support/`.
 - Audit findings: `renderer-feat-3-001`, `p2-b1-ipc-chain-001`, `p2-b1-ipc-chain-002`,
-  §4 of the 2026-08-16 full-history audit. That report was a 1.5 MB one-off snapshot
-  scoped to `v0.123.0` and is no longer in the tree; read it with
-  `git show cd1219ef7:AUDIT_REPORT.md`. That sha moved once already, in the history
-  rewrite of PR #1033 — if it stops resolving, find the commit for PR #1000 and read
-  the file there. Its `path:line` citations point at that commit's
-  HEAD, not this one.
+  §4 of the 2026-08-16 full-history audit. That report was a 1.5 MB one-off snapshot scoped to
+  `v0.123.0`. It is not in the tree and, since the 2026-08-21 history rewrite,
+  not in any commit either — read it at
+  [AUDIT_REPORT.md on the `assets` branch](https://raw.githubusercontent.com/saeedkolivand/ai-job-hunter-app/assets/AUDIT_REPORT.md).
+  Deliberately no longer cited by commit sha: this citation has now been broken
+  by two separate rewrites, and a sha in a doc is precisely the drift-prone
+  literal rule 17 forbids. The `assets` branch is parentless and force-pushed,
+  so the URL is stable and the file costs no history. Its `path:line` citations
+  point at the tree as of PR #1000, not this one.

--- a/docs/knowledge/decision-records/0015-ripbook-notebook-landing.md
+++ b/docs/knowledge/decision-records/0015-ripbook-notebook-landing.md
@@ -25,7 +25,8 @@ The GL landing shipped through P0-P5 as the "living sketchbook" of
 [ADR 0014](0014-landing-gl-takeover.md) - a scroll-scrubbed camera Journey through
 8 Beats - then was reset to an empty `apps/landing` in #710. The owner judged the
 sketchbook journey **not premium enough** and approved a rebuild under a new concept,
-**RIPBOOK**. The old Next 16 app at git `66c36c68` remains **salvage material**, not the
+**RIPBOOK**. The old Next 16 app, as of PR #709 (`d72a401652` after the 2026-08-21 history
+rewrite — cite the PR, the sha moves), remains **salvage material**, not the
 baseline.
 
 Everything structural in 0014 still constrains this rebuild: the deploy stays a Next 16

--- a/docs/knowledge/decision-records/adr-018-revive-accent-tinted-aurora-ambient-background.md
+++ b/docs/knowledge/decision-records/adr-018-revive-accent-tinted-aurora-ambient-background.md
@@ -1,12 +1,13 @@
 # ADR-018: Revive accent-tinted aurora ambient background
 
-Last updated: 2026-07-16
+Last updated: 2026-08-21
 
 **Status:** Accepted
 
 ## Context
 
-The aurora/cinematic backdrop was removed in commit `8688eb91` ("apple design system + UX overhaul") as part of restraint-driven design and performance optimization. At that time, `CinematicBackground` became a flat fill, shedding parallax orbs, streaks, grid, film-grain, and the animated aurora ribbons + nebulae.
+The aurora/cinematic backdrop was removed in PR #313 (`2b254fbcac` after the
+2026-08-21 history rewrite — cite the PR, the sha moves) ("apple design system + UX overhaul") as part of restraint-driven design and performance optimization. At that time, `CinematicBackground` became a flat fill, shedding parallax orbs, streaks, grid, film-grain, and the animated aurora ribbons + nebulae.
 
 The two-tone accent-gradient work (brand → brand-2 hue pair) introduced a visual opportunity: a living accent-tinted surface for the gradient to inhabit. The flat backdrop had become inert with respect to the customizable accent, making it visually disconnected from user personalization choices.
 


### PR DESCRIPTION
The history rewrite moved every commit sha. Four references in tracked docs pointed at main commits and stopped resolving.

**I reported one, and that was wrong.** My sweep only tested shas that happened to resolve in my local clone at the time, so it undercounted. Re-checked against the pre-rewrite mirror, every one of them resolved before the rewrite and does not resolve in a fresh clone now. (GitHub's API still answers for the old shas, because it holds force-push orphans for a while — which is exactly why "it still works when I try it" was not evidence.)

## One was worse than a stale sha

Two ADRs cite findings from the 2026-08-16 full-history audit and told the reader to run `git show cd1219ef7:AUDIT_REPORT.md`.

`AUDIT_REPORT.md` was a dead path, so the rewrite removed it from **every commit**. Refreshing the sha would not have helped — the file no longer existed anywhere in the repo, and the doc's own fallback ("find the commit for PR #1000 and read it there") was dead for the same reason.

Recovered from the pre-rewrite mirror and published to the parentless `assets` branch. Verified: **1,588,368 bytes**, and all four finding ids the ADRs name (`p2-contra-cross-001`, `renderer-feat-3-001`, `p2-b1-ipc-chain-001`, `p2-b1-ipc-chain-002`) are present in it. That branch is the right home for something read occasionally and revised never — 1.5 MB once, no history growth.

## The rest

| Doc | Was | Now |
| --- | --- | --- |
| `0015-ripbook-notebook-landing` | `66c36c68` | PR #709 (`d72a401652`) |
| `adr-018-…-aurora-…` | `8688eb91` | PR #313 (`2b254fbcac`) |
| `EXPORT_TEMPLATES.md` | `2fb85227` | names the file, not a commit |

That last one is its own small finding: the sha was **already dangling before this rewrite** — an earlier one broke it and nobody noticed — and the caveat was obsolete anyway. It said `cargo test` works "on branches containing the build.rs delay-load fix". `DELAYLOAD` is in `apps/desktop/src-tauri/build.rs` on main, so it is unconditional.

## The actual lesson, now written into each site

A commit sha in a doc is precisely the drift-prone literal rule 17 forbids, and this repo has now had the same citation broken by **two separate rewrites**. The ADRs anchor on PR numbers, which no rewrite can move, and carry the sha only as a convenience explicitly labelled perishable.

## Checked, not assumed

Six shas in `.claude/scratch/` notes name commits that were **never on main** — unmerged branch work, still served through GitHub's `refs/pull/*`, which a rewrite of main cannot touch. Verified against the pre-rewrite mirror rather than left to inference. Untouched.

Final sweep: zero references in `docs/` or `.claude/` fail to resolve in a fresh clone.
