### PR TITLE
feat(export): render projects as bold name, technologies meta line, description

### DIFF
--- a/apps/desktop/src-tauri/src/export/model_docx/test.rs
+++ b/apps/desktop/src-tauri/src/export/model_docx/test.rs
@@ -453,3 +453,55 @@ fn resume_docx_header_name_paragraph_has_explicit_spacing_before_contact() {
          before the run reaches the contact line; paragraph head: {para_head}"
     );
 }
+
+/// A project's `·`-separated tech-stack line must reach DOCX as the entry
+/// SUBTITLE — the italic run `RunOpts::subtitle` styles — and not as an ordinary
+/// body paragraph. This is the structural guard for the adapter regrouping
+/// (`model::adapter::absorb_project_line`) surviving all the way to the second
+/// export format: the PDF matrix test can only see that the WORDS rendered,
+/// while run properties here can tell a styled meta line from flat prose.
+const PROJECTS_RESUME: &str = "\
+Jane Doe
+jane@example.com
+
+PROJECTS
+
+**Ledger CLI** · https://github.com/janedoe/ledger
+Rust · SQLite · Clap
+A double-entry bookkeeping tool for the terminal.
+";
+
+#[test]
+fn project_tech_stack_lands_in_the_italic_subtitle_run() {
+    let template = Template::get(TemplateId::Classic);
+    let docx =
+        generate_resume_docx(PROJECTS_RESUME, None, &template, false).expect("generate docx");
+    let mut buffer = Cursor::new(Vec::new());
+    docx.build().pack(&mut buffer).expect("pack docx");
+    let xml = part(&buffer.into_inner(), "word/document.xml");
+
+    let idx = xml
+        .find("SQLite")
+        .expect("the tech-stack text must appear in document.xml");
+    let run_start = xml[..idx].rfind("<w:r>").expect("enclosing run start");
+    let run_end = idx + xml[idx..].find("</w:r>").expect("enclosing run end");
+    let run_xml = &xml[run_start..run_end];
+    assert!(
+        run_xml.contains("<w:i "),
+        "the tech-stack line must render as the italic subtitle run, not flat \
+         body prose; run xml: {run_xml:?}"
+    );
+
+    // The project NAME stays bold, and the description is still there.
+    let name_idx = xml
+        .find("Ledger CLI")
+        .expect("project name in document.xml");
+    let name_start = xml[..name_idx].rfind("<w:r>").expect("name run start");
+    let name_end = name_idx + xml[name_idx..].find("</w:r>").expect("name run end");
+    assert!(
+        xml[name_start..name_end].contains("<w:b "),
+        "the project name must stay bold; run xml: {:?}",
+        &xml[name_start..name_end]
+    );
+    assert!(xml.contains("double-entry bookkeeping"));
+}

--- a/apps/desktop/src-tauri/src/export/parser/mod.rs
+++ b/apps/desktop/src-tauri/src/export/parser/mod.rs
@@ -236,9 +236,34 @@ pub(crate) fn is_project_stack_shaped(clean: &str) -> bool {
     let clean = clean.trim();
     !clean.is_empty()
         && separator_count(clean) >= 1
-        && !clean.contains('@')
+        && !is_contactish_for_stack(clean)
         && !clean.ends_with(['.', '!', '?', ':'])
         && clean.chars().count() <= 120
+}
+
+/// Contact-ish content that must never be read as a technology list: an email,
+/// a phone number, a URL scheme or markdown link, or a known contact host.
+///
+/// NOT [`is_contact_shaped`]: that treats ≥ 2 separators as contact-shaped, which
+/// is exactly what a three-item technology stack looks like, so reusing it would
+/// reject the common case outright.
+///
+/// [`URL_RE`] alone is not enough either — it only knows the contact platforms
+/// and a scheme ANCHORED at the start of the line, so a trailing link like
+/// `Demo · https://example.dev` slips past it. The unanchored `://` / `](` /
+/// `www.` tests are what actually catch a link sitting after a separator.
+///
+/// A bare-domain test is deliberately absent: `Node.js · socket.io · Express` is a
+/// real stack, and every heuristic that catches `demo.example.dev` also catches
+/// `socket.io`. A bare-domain link line is left accepted rather than corrupting
+/// a genuine stack — the failure it causes is cosmetic, the other is not.
+fn is_contactish_for_stack(clean: &str) -> bool {
+    clean.contains('@')
+        || clean.contains("://")
+        || clean.contains("](")
+        || clean.to_ascii_lowercase().contains("www.")
+        || PHONE_RE.is_match(clean)
+        || URL_RE.is_match(clean)
 }
 
 /// The line-0-ONLY Contact test — narrower than [`is_contact_shaped`]: just an

--- a/apps/desktop/src-tauri/src/export/parser/mod.rs
+++ b/apps/desktop/src-tauri/src/export/parser/mod.rs
@@ -215,6 +215,32 @@ pub(crate) fn is_contact_shaped(clean: &str) -> bool {
         || URL_RE.is_match(clean)
 }
 
+/// The project TECH-STACK line shape: the `·`-separated technologies line that
+/// sits directly under a project's bold title in the locked project signature
+/// (`pipeline::resume::project_render::render_project`).
+///
+/// Deliberately looser than [`is_contact_shaped`] on separator count — a
+/// two-item stack (`Rust · SQLite`) has only ONE separator and would otherwise
+/// fall through to `Text` — and tighter on everything else, because the only
+/// other thing that can appear in that slot is the project's prose description.
+/// Terminal sentence punctuation and length are what separate the two: a stack
+/// is a short list, a description is a sentence. The `@` arm keeps a stray
+/// contact line out.
+///
+/// Shape-only, and NOT section-aware: the caller
+/// (`crate::model::adapter`) applies it exclusively inside a
+/// [`SectionId::Projects`](crate::model::document::SectionId) section and only
+/// for the line immediately under an entry title, so a `·`-bearing line
+/// anywhere else is unaffected.
+pub(crate) fn is_project_stack_shaped(clean: &str) -> bool {
+    let clean = clean.trim();
+    !clean.is_empty()
+        && separator_count(clean) >= 1
+        && !clean.contains('@')
+        && !clean.ends_with(['.', '!', '?', ':'])
+        && clean.chars().count() <= 120
+}
+
 /// The line-0-ONLY Contact test — narrower than [`is_contact_shaped`]: just an
 /// `@` or a phone shape, with no pipe/URL arms. This is what decides Name vs
 /// Contact for the résumé's first line (`parse_line`'s `idx == 0` case) — a

--- a/apps/desktop/src-tauri/src/export/parser/test.rs
+++ b/apps/desktop/src-tauri/src/export/parser/test.rs
@@ -1067,7 +1067,24 @@ fn project_stack_shape_accepts_stacks_and_rejects_prose() {
         assert!(is_project_stack_shaped(stack), "must accept {stack:?}");
     }
 
+    // A stack may carry a dotted package name; every bare-domain heuristic that
+    // rejects `demo.example.dev` also rejects these, so they pin the line.
+    for stack in [
+        "Node.js · socket.io · Express",
+        "TypeScript · React · GitHub Actions",
+    ] {
+        assert!(is_project_stack_shaped(stack), "must accept {stack:?}");
+    }
+
     for prose in [
+        // Contact content in the slot directly under a project title. `URL_RE`
+        // alone does NOT catch the first of these — its scheme arm is anchored at
+        // the start of the line — which is why the predicate tests `://` too.
+        "Demo · https://example.dev",
+        "Support · +1 555 0100",
+        "github.com/x/y · demo.example.dev",
+        "Docs · [handbook](https://example.dev/handbook)",
+        "Mirror · www.example.dev",
         // No separator at all — an ordinary description line.
         "A double-entry bookkeeping tool for the terminal.",
         // Separators, but it is a sentence.

--- a/apps/desktop/src-tauri/src/export/parser/test.rs
+++ b/apps/desktop/src-tauri/src/export/parser/test.rs
@@ -1053,3 +1053,35 @@ Jan 2021 – Heute, Berlin
         "a contact line was turned into a job entry: {contact:?}"
     );
 }
+
+/// `is_project_stack_shaped` must accept a two-item stack (ONE separator, which
+/// `is_contact_shaped` misses) and reject the prose that shares its slot.
+#[test]
+fn project_stack_shape_accepts_stacks_and_rejects_prose() {
+    for stack in [
+        "Rust · SQLite · Clap",
+        "Rust · SQLite",
+        "TypeScript | React | Vite",
+        "Tauri 2 · Rust · React 19 · TypeScript · Zod",
+    ] {
+        assert!(is_project_stack_shaped(stack), "must accept {stack:?}");
+    }
+
+    for prose in [
+        // No separator at all — an ordinary description line.
+        "A double-entry bookkeeping tool for the terminal.",
+        // Separators, but it is a sentence.
+        "Ships on Windows · macOS · Linux.",
+        // A trailing colon introduces prose that follows.
+        "Built with · tested against:",
+        // A contact line that wandered into the section.
+        "jane@example.com · https://janedoe.dev",
+        // Long enough to be prose no matter how many separators it holds.
+        "Designed and shipped the ingest layer · the scheduler · the reporting \
+         API · and the operator console for a distributed rate limiter",
+        "",
+        "   ",
+    ] {
+        assert!(!is_project_stack_shaped(prose), "must reject {prose:?}");
+    }
+}

--- a/apps/desktop/src-tauri/src/export/typst_engine/test.rs
+++ b/apps/desktop/src-tauri/src/export/typst_engine/test.rs
@@ -7326,3 +7326,68 @@ fn letter_system_prompt_still_promises_the_export_adds_the_salutation() {
          Got:\n{prompt}"
     );
 }
+
+// ── Projects: bold name + technologies meta line ──────────────────────────────
+
+/// A Projects section in the locked signature `pipeline::resume::project_render`
+/// emits: bold name + link, a `·`-separated tech-stack line, then prose. Kept
+/// separate from `FIXTURE_RESUME` on purpose — that fixture is shared by
+/// page-count and layout assertions, and growing it would move them.
+const PROJECTS_FIXTURE: &str = "\
+Jane Doe
+jane@example.com | https://github.com/janedoe
+
+PROJECTS
+
+**Ledger CLI** · https://github.com/janedoe/ledger
+Rust · SQLite · Clap
+A double-entry bookkeeping tool for the terminal.
+
+**Atlas** · https://atlas.example.dev
+TypeScript · React · Vite
+Framework-agnostic component library published to npm.
+";
+
+/// The tech-stack line rides the entry SUBTITLE slot, which every template
+/// already styles. This is the guard that the adapter's regrouping actually
+/// reaches rendered output on all 16 templates — a template that dropped or
+/// never rendered `subtitle` would lose the candidate's technology list
+/// silently, and no `%PDF`-header or page-count check would notice.
+#[test]
+fn every_template_renders_the_project_tech_stack_line() {
+    let model = model_from_resume_text(PROJECTS_FIXTURE);
+    for id in canonical_template_ids() {
+        let template = Template::get(id);
+        let bytes = render_pdf(
+            &model,
+            TypstTemplate::from_template(&template),
+            &opts_a4(),
+            Some(&template),
+        )
+        .unwrap_or_else(|e| panic!("render_pdf({id:?}) should succeed: {e:?}"));
+
+        let extracted = pdf_extract::extract_text_from_mem(&bytes)
+            .unwrap_or_else(|e| panic!("{id:?}: pdf-extract must succeed: {e:?}"));
+        let lower: String = extracted.split_whitespace().collect::<Vec<_>>().join(" ");
+        let lower = lower.to_lowercase();
+
+        assert!(
+            lower.contains("ledger cli") && lower.contains("atlas"),
+            "{id:?}: project names missing\n---\n{extracted:?}"
+        );
+        // Both stacks, so a template that renders only the FIRST entry's
+        // subtitle cannot pass.
+        assert!(
+            lower.contains("rust") && lower.contains("sqlite") && lower.contains("clap"),
+            "{id:?}: first project's tech stack missing\n---\n{extracted:?}"
+        );
+        assert!(
+            lower.contains("typescript") && lower.contains("react") && lower.contains("vite"),
+            "{id:?}: second project's tech stack missing\n---\n{extracted:?}"
+        );
+        assert!(
+            lower.contains("double-entry bookkeeping"),
+            "{id:?}: project description missing\n---\n{extracted:?}"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/model/adapter.rs
+++ b/apps/desktop/src-tauri/src/model/adapter.rs
@@ -1107,6 +1107,34 @@ Framework-agnostic component library published to npm.
         );
     }
 
+    /// A résumé that puts its project links on their OWN line, rather than on the
+    /// title line the locked signature uses, must not have that link line styled
+    /// as the technology list. It stays body content; the entry simply has no
+    /// subtitle, which is what it rendered as before this feature existed.
+    #[test]
+    fn a_link_line_under_the_title_is_never_styled_as_the_tech_list() {
+        let m = model_from_resume_text(
+            "PROJECTS\n\n\
+             **Ledger CLI**\n\
+             Demo · https://example.dev\n\
+             A double-entry bookkeeping tool for the terminal.\n",
+        );
+        let found = entries(&m);
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].subtitle, None,
+            "a link line must not be mistaken for a technology stack"
+        );
+        assert_eq!(
+            found[0].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec![
+                "Demo · example.dev",
+                "A double-entry bookkeeping tool for the terminal.",
+            ],
+            "the link stays body content, in source order"
+        );
+    }
+
     /// A2: the same text under a German heading takes the same path. Before this
     /// change `Projekte` classified as `Custom` and the whole feature was
     /// silently English-only.

--- a/apps/desktop/src-tauri/src/model/adapter.rs
+++ b/apps/desktop/src-tauri/src/model/adapter.rs
@@ -23,8 +23,8 @@
 //! date, recipient, salutation, body, closing, signature) and stay on the legacy
 //! `export::pdf` path until a later phase models them explicitly.
 
-use crate::export::parser::parse_resume;
-use crate::export::types::{DocumentType, LineKind};
+use crate::export::parser::{is_project_stack_shaped, parse_resume};
+use crate::export::types::{DocumentType, LineKind, ParsedLine};
 
 use super::document::{Block, DocumentModel, EntryBlock, HeaderBlock, Section, SectionId};
 use super::rich::tokenize_rich;
@@ -75,6 +75,69 @@ fn push_nonempty_section(section: Section, sections: &mut Vec<Section>) {
     if !section.blocks.is_empty() {
         sections.push(section);
     }
+}
+
+/// Regroup one line of a Projects section into an [`EntryBlock`], returning
+/// `true` when the line was consumed.
+///
+/// Projects are the one section whose entries carry no date, and that is why
+/// they arrive here as loose lines. The parser reads a project's title line
+/// (`**Ledger CLI** · https://github.com/…`) as `Contact` — it holds a URL — and
+/// its `·`-separated tech-stack line as `Contact` or `Text` depending only on how
+/// many technologies are listed, so the generic arms below flatten a whole
+/// project into three indistinguishable paragraphs. Every template already
+/// styles an entry's title and subtitle; nothing styles three paragraphs. This
+/// rebuilds the entry the text was always describing:
+///
+/// ```text
+/// **Ledger CLI** · https://github.com/janedoe/ledger   <- title  (bold-led)
+/// Rust · SQLite · Clap                                 <- subtitle (stack line)
+/// A double-entry bookkeeping tool for the terminal.    <- bullet  (description)
+/// ```
+///
+/// Only the line DIRECTLY under a title can claim the subtitle slot
+/// (`subtitle.is_none() && bullets.is_empty()`), so a later `·`-bearing sentence
+/// stays body content. A line that opens no entry and has no entry to join is
+/// left to the caller untouched, so a prose-only Projects section renders exactly
+/// as it does today. Scoped to [`SectionId::Projects`]: the same shapes under
+/// Experience or a custom heading are not touched.
+fn absorb_project_line(
+    line: &ParsedLine,
+    entry: &mut Option<EntryBlock>,
+    current: &mut Option<Section>,
+    preamble: &mut Vec<Block>,
+) -> bool {
+    if !matches!(current, Some(section) if section.id == SectionId::Projects) {
+        return false;
+    }
+
+    // A bold-led line is the start of the next project — the same signal
+    // `validate::content`'s project-tier grader reads.
+    if line
+        .segments
+        .first()
+        .is_some_and(|seg| seg.bold && !seg.text.trim().is_empty())
+    {
+        flush_entry(entry, current, preamble);
+        *entry = Some(EntryBlock {
+            // `line.raw` so the bold run and the markdown links survive.
+            title: tokenize_rich(&line.raw),
+            subtitle: None,
+            date: None,
+            bullets: Vec::new(),
+        });
+        return true;
+    }
+
+    let Some(open) = entry.as_mut() else {
+        return false;
+    };
+    if open.subtitle.is_none() && open.bullets.is_empty() && is_project_stack_shaped(&line.text) {
+        open.subtitle = Some(tokenize_rich(&line.raw));
+    } else {
+        open.bullets.push(tokenize_rich(&line.raw));
+    }
+    true
 }
 
 /// Close the in-progress entry (if any), emitting it as a [`Block::Entry`].
@@ -131,7 +194,7 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
                     // Header contact: keep the raw (un-stripped) line so markdown
                     // links `[label](url)` tokenize into clickable runs.
                     contact_parts.push(line.raw.clone());
-                } else {
+                } else if !absorb_project_line(line, &mut entry, &mut current, &mut preamble) {
                     flush_entry(&mut entry, &mut current, &mut preamble);
                     push_block(
                         Block::Paragraph(tokenize_rich(&line.raw)),
@@ -209,7 +272,7 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
                     && is_title_like(&line.text)
                 {
                     title = Some(line.text.clone());
-                } else {
+                } else if !absorb_project_line(line, &mut entry, &mut current, &mut preamble) {
                     flush_entry(&mut entry, &mut current, &mut preamble);
                     push_block(
                         Block::Paragraph(tokenize_rich(&line.raw)),
@@ -878,5 +941,186 @@ jane@example.com | [linkedin.com/in/jane](https://linkedin.com/in/jane)
             "expected a link run, got {:?}",
             m.header.contact
         );
+    }
+
+    // ── Projects: bold title / tech-stack subtitle / description ──────────────
+
+    /// The locked project signature `pipeline::resume::project_render` emits:
+    /// bold name + links, a `·`-separated stack line, then prose. Two projects,
+    /// so entry GROUPING is under test and not just a single lucky line.
+    const PROJECTS: &str = "\
+PROJECTS
+
+**Ledger CLI** · https://github.com/janedoe/ledger
+Rust · SQLite · Clap
+A double-entry bookkeeping tool for the terminal.
+
+**Atlas** · https://atlas.example.dev
+TypeScript · React
+Framework-agnostic component library published to npm.
+";
+
+    fn entries(model: &DocumentModel) -> Vec<&EntryBlock> {
+        model
+            .sections
+            .iter()
+            .flat_map(|s| &s.blocks)
+            .filter_map(|b| match b {
+                Block::Entry(e) => Some(e),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn project_lines_regroup_into_entries_with_a_stack_subtitle() {
+        let m = model_from_resume_text(PROJECTS);
+        let found = entries(&m);
+        assert_eq!(found.len(), 2, "one entry per project, got {found:?}");
+
+        // Absolute expected strings — not a comparison against another value
+        // derived from the same parse, which would stay green if BOTH drifted.
+        // `tokenize_rich` shows a bare URL without its scheme; the href itself
+        // stays intact (asserted in `project_title_keeps_its_bold_run_and_link`).
+        assert_eq!(
+            flat(&found[0].title),
+            "Ledger CLI · github.com/janedoe/ledger"
+        );
+        assert_eq!(
+            found[0].subtitle.as_ref().map(flat).as_deref(),
+            Some("Rust · SQLite · Clap"),
+            "the tech line must land in the subtitle slot every template styles"
+        );
+        assert_eq!(
+            found[0].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec!["A double-entry bookkeeping tool for the terminal."]
+        );
+        assert_eq!(found[0].date, None, "projects carry no date column");
+
+        // The second project proves the first entry was CLOSED, not extended.
+        assert_eq!(flat(&found[1].title), "Atlas · atlas.example.dev");
+        assert_eq!(
+            found[1].subtitle.as_ref().map(flat).as_deref(),
+            Some("TypeScript · React"),
+            "a two-item stack has only ONE separator — it must still be a stack"
+        );
+        assert_eq!(
+            found[1].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec!["Framework-agnostic component library published to npm."]
+        );
+    }
+
+    #[test]
+    fn project_title_keeps_its_bold_run_and_link() {
+        let m = model_from_resume_text(PROJECTS);
+        let title = &entries(&m)[0].title;
+        assert!(
+            title
+                .iter()
+                .any(|r| r.bold && r.text.contains("Ledger CLI")),
+            "the project NAME must stay bold: {title:?}"
+        );
+        assert!(
+            title
+                .iter()
+                .any(|r| r.link.as_deref() == Some("https://github.com/janedoe/ledger")),
+            "the project link must stay clickable: {title:?}"
+        );
+    }
+
+    /// The regression guard that matters: the identical shapes under any OTHER
+    /// heading must keep rendering exactly as they did before this change.
+    #[test]
+    fn the_same_shapes_under_experience_are_untouched() {
+        let text = PROJECTS.replacen("PROJECTS", "EXPERIENCE", 1);
+        let m = model_from_resume_text(&text);
+        assert!(
+            entries(&m).is_empty(),
+            "no Projects section, so no project regrouping may happen"
+        );
+        let paragraphs = m
+            .sections
+            .iter()
+            .flat_map(|s| &s.blocks)
+            .filter(|b| matches!(b, Block::Paragraph(_)))
+            .count();
+        assert_eq!(paragraphs, 6, "all six lines stay paragraphs");
+    }
+
+    #[test]
+    fn a_prose_only_projects_section_stays_paragraphs() {
+        let m = model_from_resume_text(
+            "PROJECTS\n\nBuilt an internal deploy tool used by the whole team.\n",
+        );
+        assert!(entries(&m).is_empty(), "nothing bold-led opens an entry");
+        assert_eq!(m.sections[0].blocks.len(), 1);
+        assert!(matches!(m.sections[0].blocks[0], Block::Paragraph(_)));
+    }
+
+    /// A `·`-bearing sentence AFTER the description must not be mistaken for a
+    /// second stack line — only the line directly under the title can be one.
+    #[test]
+    fn only_the_line_under_the_title_can_be_the_stack() {
+        let m = model_from_resume_text(
+            "PROJECTS\n\n\
+             **Ledger CLI** · https://github.com/janedoe/ledger\n\
+             Rust · SQLite\n\
+             Ships on Windows · macOS · Linux\n",
+        );
+        let found = entries(&m);
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].subtitle.as_ref().map(flat).as_deref(),
+            Some("Rust · SQLite")
+        );
+        assert_eq!(
+            found[0].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec!["Ships on Windows · macOS · Linux"],
+            "the second separator line is body content, not a second subtitle"
+        );
+    }
+
+    /// The `bullets.is_empty()` half of the stack guard, which the "only the
+    /// line under the title" case above does NOT reach (there the subtitle slot
+    /// is already taken). A project with NO stack line has an empty subtitle for
+    /// its whole run, so without this half a later `·`-bearing sentence would be
+    /// hoisted into the subtitle slot and RENDER ABOVE the description it
+    /// followed — reordering the candidate's own prose.
+    #[test]
+    fn a_separator_line_after_the_description_is_never_hoisted() {
+        let m = model_from_resume_text(
+            "PROJECTS\n\n\
+             **Ledger CLI** · https://github.com/janedoe/ledger\n\
+             A double-entry bookkeeping tool for the terminal.\n\
+             Ships on Windows · macOS · Linux\n",
+        );
+        let found = entries(&m);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].subtitle, None, "this project has no stack line");
+        assert_eq!(
+            found[0].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec![
+                "A double-entry bookkeeping tool for the terminal.",
+                "Ships on Windows · macOS · Linux",
+            ],
+            "body order must survive verbatim"
+        );
+    }
+
+    /// A2: the same text under a German heading takes the same path. Before this
+    /// change `Projekte` classified as `Custom` and the whole feature was
+    /// silently English-only.
+    #[test]
+    fn a_localized_projects_heading_takes_the_same_path() {
+        for heading in ["PROJEKTE", "PROJETS", "PROYECTOS", "PROGETTI", "PROJECTEN"] {
+            let text = PROJECTS.replacen("PROJECTS", heading, 1);
+            let m = model_from_resume_text(&text);
+            assert_eq!(
+                m.sections[0].id,
+                SectionId::Projects,
+                "{heading} must classify as Projects"
+            );
+            assert_eq!(entries(&m).len(), 2, "{heading} must regroup its entries");
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/model/document.rs
+++ b/apps/desktop/src-tauri/src/model/document.rs
@@ -60,7 +60,21 @@ impl SectionId {
             SectionId::Education
         } else if has("skill") || has("competenc") || has("technolog") {
             SectionId::Skills
-        } else if has("project") {
+        } else if has("project")
+            || has("projekt")
+            || has("projet")
+            || has("proyecto")
+            || has("progetti")
+        {
+            // Every résumé market this app writes for (`locale::resume`) gets its
+            // own Projects heading, so an English-only test silently downgraded
+            // German/French/Spanish/Italian documents to `Custom` — which costs
+            // them both the Projects entry rendering AND their place in the
+            // market section order (`transform::reorder_sections` sorts an
+            // unknown id last). Dutch "projecten" and Portuguese "projeto(s)"
+            // need no arm of their own: they already contain "project"/"projet".
+            // Same stem set as `documents::evidence::PROJECT_HEADINGS` — keep the
+            // two in step.
             SectionId::Projects
         } else if has("certification") || has("certificate") || has("license") {
             SectionId::Certifications

--- a/apps/desktop/src-tauri/src/model/transform.rs
+++ b/apps/desktop/src-tauri/src/model/transform.rs
@@ -136,4 +136,38 @@ mod tests {
             ]
         );
     }
+
+    /// A German résumé's `Projekte` heading used to classify as
+    /// `SectionId::Custom`, and `reorder_sections` sorts an unknown id to
+    /// `usize::MAX` — so ATS mode silently dumped the candidate's projects at the
+    /// BOTTOM of the document, contradicting `DE_ORDER`, which places Projects
+    /// between Languages and Awards. Built from real text (not hand-placed ids)
+    /// so it fails if either `SectionId::from_header` or the order regresses.
+    ///
+    /// The `Custom` neighbours are NOT an oversight in this fixture: they pin a
+    /// KNOWN, WIDER gap this change deliberately does not close. `from_header`
+    /// is English-only for every OTHER section too, so `BERUFSERFAHRUNG` and
+    /// `SPRACHEN` still classify as `Custom` and still sort last. Only the
+    /// Projects arm was localized here. Closing the rest reorders every
+    /// non-English résumé and is its own change with its own review.
+    #[test]
+    fn a_german_projekte_heading_linearizes_into_its_market_slot() {
+        let mut m = crate::model::adapter::model_from_resume_text(
+            "BERUFSERFAHRUNG\n\nAcme GmbH  2020 - Heute\n\
+             - Ein Team von fünf Ingenieuren geleitet\n\n\
+             PROJEKTE\n\n**Ledger CLI** · https://github.com/janedoe/ledger\n\
+             Rust · SQLite\nEin Buchhaltungswerkzeug für das Terminal.\n\n\
+             SPRACHEN\n\nDeutsch, Englisch\n",
+        );
+        linearize(&mut m, "de");
+        assert_eq!(
+            ids(&m),
+            vec![
+                SectionId::Projects,
+                SectionId::Custom("BERUFSERFAHRUNG".to_string()),
+                SectionId::Custom("SPRACHEN".to_string()),
+            ],
+            "Projekte must carry a real id and sort by DE_ORDER, not last"
+        );
+    }
 }

--- a/apps/desktop/src/renderer/features/resume-builder/components/BuilderWizard/index.tsx
+++ b/apps/desktop/src/renderer/features/resume-builder/components/BuilderWizard/index.tsx
@@ -67,6 +67,7 @@ function toFormValues(answers: InterviewAnswers): BuilderForm {
       name: p.name ?? '',
       description: p.description ?? '',
       link: p.link ?? '',
+      technologies: p.technologies ?? '',
     })),
     publications: (answers.publications ?? []).map((p) => ({
       title: p.title ?? '',

--- a/apps/desktop/src/renderer/features/resume-builder/components/GitHubImportModal/index.tsx
+++ b/apps/desktop/src/renderer/features/resume-builder/components/GitHubImportModal/index.tsx
@@ -36,7 +36,12 @@ interface GitHubImportModalProps {
   open: boolean;
   onClose: () => void;
   /** Called with each generated project entry to append to the field array. */
-  onAppend: (entry: { name: string; description: string; link: string }) => void;
+  onAppend: (entry: {
+    name: string;
+    description: string;
+    link: string;
+    technologies: string;
+  }) => void;
 }
 
 type FetchState = 'idle' | 'fetching' | 'done' | 'error';

--- a/apps/desktop/src/renderer/features/resume-builder/components/wizard-steps/StepExtras/index.tsx
+++ b/apps/desktop/src/renderer/features/resume-builder/components/wizard-steps/StepExtras/index.tsx
@@ -48,7 +48,9 @@ export function StepExtras() {
             </Button>
             <FieldArrayList
               fields={projects.fields}
-              onAppend={() => projects.append({ name: '', description: '', link: '' })}
+              onAppend={() =>
+                projects.append({ name: '', description: '', link: '', technologies: '' })
+              }
               onRemove={projects.remove}
               addLabel={t('build.extras.projects.add')}
               removeLabel={t('build.remove')}
@@ -83,6 +85,24 @@ export function StepExtras() {
                           onBlur={field.onBlur}
                           rows={2}
                           placeholder={t('build.extras.projects.descriptionPlaceholder')}
+                        />
+                      )}
+                    />
+                  </WizardField>
+                  <WizardField
+                    label={t('build.extras.projects.technologies')}
+                    hint={t('build.extras.projects.technologiesHint')}
+                  >
+                    <Controller
+                      control={control}
+                      name={`projects.${index}.technologies`}
+                      render={({ field }) => (
+                        <Input
+                          className="w-full"
+                          value={field.value ?? ''}
+                          onChange={field.onChange}
+                          onBlur={field.onBlur}
+                          placeholder={t('build.extras.projects.technologiesPlaceholder')}
                         />
                       )}
                     />

--- a/apps/desktop/src/renderer/features/resume-builder/lib/schema.ts
+++ b/apps/desktop/src/renderer/features/resume-builder/lib/schema.ts
@@ -105,6 +105,15 @@ const projectSchema = z.object({
   name: z.string(),
   description: z.string(),
   link: urlField,
+  /**
+   * Free-text list — `renderProjects` normalizes the separators.
+   *
+   * `.optional()`, not a required string: builder drafts persist in the session
+   * store, and every draft saved before this field existed has no
+   * `technologies` key. A required string would fail `safeParse` on those and
+   * discard the candidate's in-progress answers.
+   */
+  technologies: z.string().optional(),
 });
 
 const publicationSchema = z.object({

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.test.ts
@@ -1377,6 +1377,7 @@ describe('generateGitHubProjects', () => {
       name: 'Merry Oasis',
       description: 'Built a local-first task planner • Implemented offline sync',
       link: 'https://github.com/me/merry-oasis',
+      technologies: 'TypeScript · offline-first',
     });
     // Link is the repo's verbatim htmlUrl, in input order.
     expect(out[1]?.link).toBe('https://github.com/me/tiny-parser');
@@ -1409,8 +1410,59 @@ describe('generateGitHubProjects', () => {
       name: 'Merry Oasis',
       description: 'A local-first task planner.',
       link: 'https://github.com/me/merry-oasis',
+      technologies: 'TypeScript · offline-first',
     });
     expect(out[1]?.link).toBe('https://github.com/me/tiny-parser');
+  });
+
+  it('builds technologies from repo metadata only — deduped, capped, never from the AI', async () => {
+    const client = createMockClient({
+      ai: { generatePipeline: vi.fn().mockRejectedValue(new Error('no provider configured')) },
+      jobs: { get: vi.fn().mockResolvedValue(null), cancel: vi.fn() },
+    });
+    _registerClient(client);
+
+    const noisy: GitHubRepo[] = [
+      {
+        name: 'kitchen-sink',
+        description: 'Everything.',
+        htmlUrl: 'https://github.com/me/kitchen-sink',
+        language: 'Rust',
+        topics: [
+          '  rust  ', // duplicate of the language, case- and space-insensitive
+          'cli',
+          'a'.repeat(60), // over the per-item cap
+          '',
+          't4',
+          't5',
+          't6',
+          't7',
+          't8',
+          't9',
+          't10',
+          't11', // past the 10-item cap
+        ],
+        stars: 0,
+      },
+    ];
+
+    const [out] = await generateGitHubProjects({ repos: noisy, model: 'llama3' });
+    const items = (out?.technologies ?? '').split(' · ');
+
+    expect(items).toEqual([
+      'Rust',
+      'cli',
+      'a'.repeat(40),
+      't4',
+      't5',
+      't6',
+      't7',
+      't8',
+      't9',
+      't10',
+    ]);
+    // The model was never asked for, and never supplied, a technology list.
+    expect(out?.technologies).not.toContain('t11');
   });
 
   it('fills missing entries from the fallback when the model returns fewer than the repos', async () => {
@@ -1429,6 +1481,7 @@ describe('generateGitHubProjects', () => {
       name: 'Tiny Parser',
       description: 'Zero-dependency JSON parser.',
       link: 'https://github.com/me/tiny-parser',
+      technologies: 'Rust',
     });
   });
 
@@ -1482,11 +1535,13 @@ describe('generateGitHubProjects', () => {
       name: 'Merry Oasis',
       description: 'Built a local-first task planner',
       link: 'https://github.com/me/merry-oasis',
+      technologies: 'TypeScript · offline-first',
     });
     expect(out[1]).toEqual({
       name: 'Tiny Parser',
       description: 'Wrote a zero-dependency JSON parser',
       link: 'https://github.com/me/tiny-parser',
+      technologies: 'Rust',
     });
   });
 

--- a/apps/desktop/src/renderer/lib/generate/generation/generation.ts
+++ b/apps/desktop/src/renderer/lib/generate/generation/generation.ts
@@ -1333,6 +1333,40 @@ export interface GeneratedGitHubProject {
   name: string;
   description: string;
   link: string;
+  /** `·`-joined tech list, built from the repo's own metadata — see
+   *  {@link repoTechnologies}. Never written by the AI. */
+  technologies: string;
+}
+
+/** Cap mirroring `buildGitHubReposBlock`'s `MAX_TOPICS` / `MAX_TOPIC`
+    (`packages/prompts/src/generate/github-projects`), so a repo with a hundred
+    hostile topics cannot flood the résumé line either. */
+const MAX_TECH_ITEMS = 10;
+const MAX_TECH_ITEM_CHARS = 40;
+
+/**
+ * The project's technology list, taken STRAIGHT from the repo's own metadata
+ * (primary language first, then topics) rather than from the model.
+ *
+ * The prompt already shows the model `language` and `topics`, but it is
+ * forbidden from emitting anything except NAME/DESC — so asking it for the tech
+ * list would add a fabrication surface for data the caller already holds
+ * verbatim. Repo topics are untrusted, attacker-influenceable text, so they are
+ * capped and land in an editable form field the candidate reviews before any
+ * résumé is generated.
+ */
+function repoTechnologies(repo: GitHubRepo): string {
+  const seen = new Set<string>();
+  const items: string[] = [];
+  for (const raw of [repo.language, ...(repo.topics ?? [])]) {
+    const item = (raw ?? '').replace(/\s+/g, ' ').trim().slice(0, MAX_TECH_ITEM_CHARS);
+    const key = item.toLowerCase();
+    if (!item || seen.has(key)) continue;
+    seen.add(key);
+    items.push(item);
+    if (items.length === MAX_TECH_ITEMS) break;
+  }
+  return items.join(' · ');
 }
 
 /** De-slug a repo name for the offline fallback title ("my-cool-app" → "My Cool App"). */
@@ -1347,7 +1381,12 @@ function deslugRepoName(name: string): string {
  *  name when empty), with the canonical link attached. Import always works. */
 function fallbackProject(repo: GitHubRepo): GeneratedGitHubProject {
   const description = repo.description?.trim() || deslugRepoName(repo.name);
-  return { name: deslugRepoName(repo.name), description, link: repo.htmlUrl };
+  return {
+    name: deslugRepoName(repo.name),
+    description,
+    link: repo.htmlUrl,
+    technologies: repoTechnologies(repo),
+  };
 }
 
 /** Normalize a title/repo name to a match key: de-slug, lowercase, drop every
@@ -1455,7 +1494,12 @@ export async function generateGitHubProjects(params: {
     if (description) {
       const name = entry?.name.trim() || deslugRepoName(repo.name);
       // Link is ALWAYS the repo's own URL — never the AI, never the matched entry.
-      return { name, description, link: repo.htmlUrl };
+      return {
+        name,
+        description,
+        link: repo.htmlUrl,
+        technologies: repoTechnologies(repo),
+      };
     }
     return fallbackProject(repo);
   });

--- a/packages/prompts/src/builder/builder-prompt.ts
+++ b/packages/prompts/src/builder/builder-prompt.ts
@@ -34,6 +34,21 @@ const SUMMARY_RULE = `PROFESSIONAL SUMMARY:
 - If the candidate wrote a summary, keep its substance and claims (you may lightly polish grammar and flow) — do NOT replace it with a generic one.
 - If they wrote none, write a 2–3 sentence summary derived strictly from the answers (seniority and domain inferred from their roles) — invent no years, metrics, or claims.`;
 
+/**
+ * The Projects shape, shared by all three system-prompt depths.
+ *
+ * The export adapter rebuilds a project into a styled entry (bold title, a
+ * technologies meta line, then the description) by reading exactly this
+ * three-line signature out of the finished résumé text. Getting it wrong is not
+ * fatal — the lines simply render as plain paragraphs, which is what they did
+ * before — but getting it right is what puts the tech list in its own styled
+ * line in the PDF and the DOCX.
+ */
+const PROJECTS_RULE = `PROJECTS: write each project as EXACTLY three lines and nothing else:
+1. **Project Name** · [label](url) — the name in double asterisks; append the link only if the answers gave one.
+2. The technologies for that project, separated by · — ONLY when the answers list them, and copied verbatim; never invent, add or reorder a technology.
+3. One or two sentences of plain description. No bullet marker on any of the three lines.`;
+
 function buildBuilderSystemFull(): string {
   return `You are an expert résumé writer with deep knowledge of ATS systems, recruiter behavior, and modern hiring practices. Build a complete, ATS-ready résumé from the candidate's interview answers.
 
@@ -52,6 +67,8 @@ BULLET POINTS:
 
 SKILLS: group ATS-style (e.g. Languages / Frameworks / Tools / Platforms) when the entries support it; otherwise a single clean line.
 
+${PROJECTS_RULE}
+
 OUTPUT: plain text only. Start with the candidate's name, then a contact line. Standard localized section headers, "•" for bullets, **double asterisks** for emphasis, no other markdown, no commentary, no XML tags. Output ONLY the résumé.`;
 }
 
@@ -63,6 +80,8 @@ ${HARD_RULES}
 ${SUMMARY_RULE}
 
 REQUIRED SECTION HEADERS: use the localized headers the task provides, consistently. Add optional sections (Projects, Publications, Certifications) only when the answers include them.
+
+${PROJECTS_RULE}
 
 DATE FORMAT: one consistent format (the task gives an example); en-dash for ranges; the target language's word for "Present" for current roles.
 
@@ -85,6 +104,9 @@ ACCEPTANCE CHECKS — verify and revise until all pass:
 - No skill, employer, date, or number appears that the candidate did not provide.
 - Every provided link is preserved inline on its item.
 - Optional sections appear only when the answers contain them.
+- Every Projects entry follows the three-line shape below.
+
+${PROJECTS_RULE}
 
 OUTPUT: the finished résumé (plain text; name + contact line first; "•" bullets; only **bold** markdown).`;
 }
@@ -135,12 +157,31 @@ function renderEducation(items: InterviewEducation[]): string {
     .join('\n');
 }
 
+/**
+ * The `·` a résumé's project signature separates technologies with — the same
+ * separator the Rust side renders with and the export adapter reads back
+ * (`pipeline/resume/project_render.rs`). A candidate types
+ * "React, TypeScript, Node"; commas and semicolons both normalize to it, so the
+ * answer sheet always hands the model the shape the résumé wants.
+ */
+const TECH_SEPARATOR = ' · ';
+
+function renderTechnologies(value: string | undefined): string {
+  return (value ?? '')
+    .split(/[,;·|]/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .join(TECH_SEPARATOR);
+}
+
 function renderProjects(items: InterviewProject[]): string {
   return items
     .filter((p) => p.name?.trim())
     .map((p) => {
       const desc = p.description?.trim() ? ` — ${p.description.trim()}` : '';
-      return `- ${p.name.trim()}${desc}${linkSuffix(p.name, p.link)}`;
+      const tech = renderTechnologies(p.technologies);
+      const stack = tech ? `\n  tech: ${tech}` : '';
+      return `- ${p.name.trim()}${desc}${linkSuffix(p.name, p.link)}${stack}`;
     })
     .join('\n');
 }
@@ -233,6 +274,7 @@ Build a complete, single-column, ATS-ready résumé from the answers above.
 - Then Work Experience (every role, most relevant bullets first within each role), Education, and Skills.
 - Add Projects / Publications / Certifications / Awards / Volunteering / Languages sections ONLY when the answers include them, using the market's standard header names.
 - Keep every provided link inline on its item as [label](url).
+- Render each Projects entry as three lines: **Name** · link, then its technologies separated by · (only if the answers list them), then the description.
 
 Output ONLY the résumé as plain text — name + contact line first, standard localized section headers, "•" bullets, **double asterisks** for emphasis only.`;
 }

--- a/packages/prompts/src/builder/builder.test.ts
+++ b/packages/prompts/src/builder/builder.test.ts
@@ -76,6 +76,42 @@ describe('renderInterviewAnswers', () => {
     expect(out).toContain('[On Caches](https://doi.org/10.1/abc)');
   });
 
+  it('renders a project tech stack as its own middot-separated line', () => {
+    const out = renderInterviewAnswers({
+      ...ANSWERS,
+      projects: [
+        {
+          name: 'OSS Tool',
+          description: 'A CLI',
+          link: 'https://github.com/x/y',
+          // Comma-typed by the candidate, semicolon and stray middot mixed in:
+          // all three normalize to the one separator the résumé renders with.
+          technologies: 'React,  TypeScript ; Node · Vite',
+        },
+      ],
+    });
+    expect(out).toContain('\n  tech: React · TypeScript · Node · Vite');
+  });
+
+  it('omits the tech line entirely when no technologies were given', () => {
+    const out = renderInterviewAnswers({
+      ...ANSWERS,
+      projects: [{ name: 'OSS Tool', description: 'A CLI', technologies: '  ,  ; ' }],
+    });
+    expect(out).toContain('- OSS Tool — A CLI');
+    expect(out).not.toContain('tech:');
+  });
+
+  it('tells the model the three-line project shape at every prompt depth', () => {
+    for (const target of ['large', 'medium', 'small'] as const) {
+      const system = buildBuilderSystemPrompt(target);
+      expect(system, target).toContain('PROJECTS: write each project as EXACTLY three lines');
+    }
+    expect(buildInterviewResumePrompt(ANSWERS, META)).toContain(
+      'Render each Projects entry as three lines'
+    );
+  });
+
   it('renders awards, volunteering, languages, and certifications when present', () => {
     const out = renderInterviewAnswers({
       ...ANSWERS,

--- a/packages/prompts/src/builder/types.ts
+++ b/packages/prompts/src/builder/types.ts
@@ -44,6 +44,14 @@ export interface InterviewProject {
   description?: string;
   /** Repo / live / case-study URL — kept inline as `[name](link)`. */
   link?: string;
+  /**
+   * Technologies used, as the candidate typed them — a free-text list, NOT an
+   * array. The résumé-builder form binds a single text input to this field, and
+   * `schema.ts`'s compile-time assignability guard keeps the two in step; an
+   * array would force a mapping layer on both sides for no gain.
+   * `renderProjects` normalizes the separators.
+   */
+  technologies?: string;
 }
 
 /** One publication (optional, repeatable) — academic résumés. DOI/url is a body link (#18). */

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -128,6 +128,9 @@
         "namePlaceholder": "z. B. Payment-Service",
         "description": "Beschreibung",
         "descriptionPlaceholder": "Was es leistet und deine Rolle.",
+        "technologies": "Technologien",
+        "technologiesHint": "Wird als eigene Zeile unter dem Projektnamen dargestellt.",
+        "technologiesPlaceholder": "z. B. React, TypeScript, Node",
         "github": {
           "trigger": "Von GitHub importieren",
           "modalTitle": "GitHub-Projekte importieren",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -128,6 +128,9 @@
         "namePlaceholder": "e.g. Payments service",
         "description": "Description",
         "descriptionPlaceholder": "What it does and your role.",
+        "technologies": "Technologies",
+        "technologiesHint": "Rendered as its own line under the project name.",
+        "technologiesPlaceholder": "e.g. React, TypeScript, Node",
         "github": {
           "trigger": "Import from GitHub",
           "modalTitle": "Import GitHub Projects",


### PR DESCRIPTION
## Why

A project's locked signature — bold name + links, a `·`-separated tech-stack line, then prose — arrived at the renderer as three indistinguishable paragraphs. The parser reads the title line as `Contact` (it holds a URL) and the stack line as `Contact` or `Text` depending only on how many technologies are listed, and `model/adapter.rs` turned every in-section `Contact` into a plain `Block::Paragraph`. Every template already styles an entry title and subtitle; nothing styles three paragraphs. `validate/content/consistency.rs` already warned this "may render unevenly" — this is that defect.

Second half: nothing outside an uploaded CV could author a tech list at all. The builder wizard's project form had name/description/link, and the GitHub import fed `language`/`topics` into the prompt only to get name + description back.

## What changed

**Render (`model/adapter.rs`)** — regroup a Projects section's lines back into the `EntryBlock` the text always described: bold-led line opens the entry, the line *directly* under it becomes the subtitle when it is stack-shaped, the rest are the entry's body.

No template file, no DOCX renderer and no model field changed: both export formats build from `model_from_resume_text` (`export/pdf/mod.rs:73`, `export/model_docx.rs:86`), so PDF, DOCX and the live SVG preview pick it up together.

**Capture** — `technologies` on the interview contract + wizard form (separators normalized to the one the résumé renders with), and one shared `PROJECTS_RULE` telling the model the three-line shape at all three prompt depths. The GitHub import fills it deterministically from the repo's own `language` + `topics` rather than asking the model, which would add a fabrication surface for data the caller already holds verbatim; topics are untrusted text, so the list is deduped and capped the same way the prompt block caps them, and lands in an editable field.

The zod field is `.optional()` on purpose: builder drafts persist, and a required string would fail `safeParse` on every draft saved before this field existed and discard the candidate's answers.

## Deliberate behaviour change, not a footnote

`SectionId::from_header` matched only `"project"`, so a German `Projekte` heading classified as `Custom` — and `transform::reorder_sections` sorts an unknown id to `usize::MAX`, i.e. appends it last. **In ATS mode that silently dumped those projects at the bottom of the document**, contradicting `DE_ORDER`, which places Projects between Languages and Awards. Localizing the Projects arm moves them into their intended slot. Pinned by `a_german_projekte_heading_linearizes_into_its_market_slot`.

Every *other* section stays English-only — `BERUFSERFAHRUNG`/`SPRACHEN` still classify as `Custom` and still sort last. That is a wider gap with a much larger blast radius; the test fixture pins the current state so it can't be mistaken for fixed.

## Trade-offs taken

- The description reuses the entry's `bullets` slot, so it renders with a bullet glyph. `EntryBlock` has no prose slot, and leaving the description outside the entry orphans it — `sp-entry` is 15pt while a paragraph's own gap is 4pt, so it would sit far from its own project and flush against the next one.
- The tech line reuses each template's existing subtitle style (Deedy renders it as a grey meta line, most others italic) rather than adding a projects-only branch to 11 `.typ` files.

## Tests

- `model/adapter.rs` — entry grouping across two projects, bold run + link survival, a two-item stack (one separator), a `·`-bearing sentence never claiming the subtitle slot, prose-only sections untouched, and **the identical shapes under EXPERIENCE unchanged**.
- `export/parser` — the stack-shape predicate's accepts and rejects.
- `typst_engine` — all 16 templates render both projects' stacks (mutation-checked: deleting one template's subtitle block fails it).
- `model_docx` — the stack lands in the *italic subtitle run*, not a body paragraph; the name stays bold.
- `builder.test.ts` / `generation.test.ts` — separator normalization, omission when empty, the rule present at every prompt depth, and technologies deduped/capped from repo metadata only.

Guards mutation-checked, and assertions are against absolute expected values rather than another value derived from the same parse.

## Verification

Full Rust suite 4645 passed · TS suite 7271 passed · `lint:strict --max-warnings 0`, `typecheck`, `clippy --all-features`, `cargo fmt --check`, `check:agent-system`, `check:event-subscriptions`, `gen:api:check` all clean. Rendered to PNG and compared against the reference design on Classic, Deedy and Swiss Minimal.

**Not included:** the 13 template preview SVGs are already stale on `main` — running the ignored showcase generator against unmodified `origin/main` source dirties the same 13 files, so that drift is pre-existing and left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Technologies field to project entries in the resume builder.
  * GitHub-imported projects now include normalized technology lists.
  * Project technologies are displayed consistently across generated resumes and exports.
  * Added support for localized Projects section headings, including German, French, Spanish, and Italian.
  * Added guidance to keep project entries structured as name, technologies, and description.

* **Bug Fixes**
  * Improved project formatting so names, technology subtitles, links, and descriptions retain their intended styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->