### PR TITLE
fix(export): render projects from resumes imported as pdf or docx

### DIFF
--- a/apps/desktop/src-tauri/src/export/parser/mod.rs
+++ b/apps/desktop/src-tauri/src/export/parser/mod.rs
@@ -248,11 +248,24 @@ pub(crate) fn is_project_stack_shaped(clean: &str) -> bool {
 /// extraction keeps the words and drops the styling, so a candidate's own CV
 /// carrying a perfectly-formed project block has no `**` and no `•` anywhere.
 ///
-/// The shape itself is the fallback signal: a short, non-sentence line whose
-/// NEXT line is a technology stack is a title. The stack line is what makes it
-/// unambiguous — prose does not sit directly above a `·`-separated list — and the
-/// line must not be a stack itself, or a two-stack sequence would open an entry
-/// on the second one.
+/// Three conditions, and all three are load-bearing:
+///
+/// * `at_paragraph_start` — the line opens a paragraph (first content line of
+///   the section, or preceded by a blank). Entries are separated by blank lines
+///   and a description line never is, which is what stops an unpunctuated line
+///   INSIDE an entry from hijacking a following stack line: `Used by 200 teams`
+///   above a second `Go · gRPC · Redis` line is prose, not a new project.
+/// * The next line is a technology stack — prose does not sit directly above a
+///   `·`-separated list. Callers must not look past the end of the section for
+///   it, or a separator-bearing HEADING (`SKILLS · TOOLS`) makes a title out of
+///   the last line of Projects.
+/// * The line is short, is not a sentence, and is not a stack itself — or a
+///   two-stack sequence would open an entry on the second one.
+///
+/// KNOWN LIMIT: a section whose entries are not blank-separated, or that has no
+/// stack lines at all, has no shape signal and is left to the markdown rules.
+/// Pinned by tests; widening it trades false negatives for false positives on a
+/// candidate's real prose, which is the worse failure.
 ///
 /// `pub(crate)` and deliberately SHARED: `model::adapter` groups a section into
 /// render entries with it and `validate::content::project_entry_starts` groups
@@ -260,9 +273,14 @@ pub(crate) fn is_project_stack_shaped(clean: &str) -> bool {
 /// answer to "where does an entry begin" would shift every following line by one
 /// — turning a stack line into a description and a truthful document into a
 /// `consistency.project_structure` warning.
-pub(crate) fn is_project_title_shaped(clean: &str, next_clean: Option<&str>) -> bool {
+pub(crate) fn is_project_title_shaped(
+    clean: &str,
+    next_clean: Option<&str>,
+    at_paragraph_start: bool,
+) -> bool {
     let clean = clean.trim();
-    !clean.is_empty()
+    at_paragraph_start
+        && !clean.is_empty()
         && clean.chars().count() <= 100
         && !clean.ends_with(['.', '!', '?'])
         && !is_project_stack_shaped(clean)

--- a/apps/desktop/src-tauri/src/export/parser/mod.rs
+++ b/apps/desktop/src-tauri/src/export/parser/mod.rs
@@ -241,6 +241,34 @@ pub(crate) fn is_project_stack_shaped(clean: &str) -> bool {
         && clean.chars().count() <= 120
 }
 
+/// Does this line look like a project TITLE purely by SHAPE — no markdown?
+///
+/// The generated project signature marks its title with a bold run, and a
+/// hand-written one often uses a bullet. Neither survives IMPORT: PDF and DOCX
+/// extraction keeps the words and drops the styling, so a candidate's own CV
+/// carrying a perfectly-formed project block has no `**` and no `•` anywhere.
+///
+/// The shape itself is the fallback signal: a short, non-sentence line whose
+/// NEXT line is a technology stack is a title. The stack line is what makes it
+/// unambiguous — prose does not sit directly above a `·`-separated list — and the
+/// line must not be a stack itself, or a two-stack sequence would open an entry
+/// on the second one.
+///
+/// `pub(crate)` and deliberately SHARED: `model::adapter` groups a section into
+/// render entries with it and `validate::content::project_entry_starts` groups
+/// the same section for the seeder, the normalizer and the tier grader. A second
+/// answer to "where does an entry begin" would shift every following line by one
+/// — turning a stack line into a description and a truthful document into a
+/// `consistency.project_structure` warning.
+pub(crate) fn is_project_title_shaped(clean: &str, next_clean: Option<&str>) -> bool {
+    let clean = clean.trim();
+    !clean.is_empty()
+        && clean.chars().count() <= 100
+        && !clean.ends_with(['.', '!', '?'])
+        && !is_project_stack_shaped(clean)
+        && next_clean.is_some_and(is_project_stack_shaped)
+}
+
 /// Contact-ish content that must never be read as a technology list: an email,
 /// a phone number, a URL scheme or markdown link, or a known contact host.
 ///

--- a/apps/desktop/src-tauri/src/model/adapter.rs
+++ b/apps/desktop/src-tauri/src/model/adapter.rs
@@ -23,7 +23,7 @@
 //! date, recipient, salutation, body, closing, signature) and stay on the legacy
 //! `export::pdf` path until a later phase models them explicitly.
 
-use crate::export::parser::{is_project_stack_shaped, parse_resume};
+use crate::export::parser::{is_project_stack_shaped, is_project_title_shaped, parse_resume};
 use crate::export::types::{DocumentType, LineKind, ParsedLine};
 
 use super::document::{Block, DocumentModel, EntryBlock, HeaderBlock, Section, SectionId};
@@ -86,20 +86,16 @@ fn next_content_line(lines: &[ParsedLine], idx: usize) -> Option<&ParsedLine> {
         .find(|l| !matches!(l.kind, LineKind::Blank) && !l.text.trim().is_empty())
 }
 
-/// Does this line open a project entry?
+/// Does this line open a project entry in the RENDER model?
 ///
-/// A leading bold run is the signal the generated signature carries and the one
-/// `validate::content`'s tier grader reads. But bold is MARKDOWN, and a résumé
-/// imported from PDF or DOCX has none — extraction keeps the words and drops the
-/// styling. A candidate's own CV can therefore carry a perfectly-formed project
-/// block (`AI Job Hunter   aijobhunter.app` / `Tauri 2 · Rust · React 19` / prose)
-/// and still be rendered as loose paragraphs, which is exactly the flat output
-/// this feature exists to remove.
+/// A leading bold run is the signal the generated signature carries. Failing
+/// that, the shape decides — see [`is_project_title_shaped`], which is shared
+/// with the pipeline's grouping so the two can never disagree about where an
+/// entry begins.
 ///
-/// So fall back to the SHAPE: a short, non-sentence line whose next line is a
-/// technology stack is a project title. The stack line is the discriminator —
-/// prose does not sit above a `·`-separated list — and the line must not be a
-/// stack itself, or a two-stack sequence would open an entry on the second one.
+/// A bullet is deliberately NOT an opener here: the compact tier
+/// (`• Name · Website · Github`) is a standalone one-liner, and the `Bullet` arm
+/// already appends bullets to whichever entry is open.
 fn opens_project_entry(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
     if line
         .segments
@@ -108,12 +104,7 @@ fn opens_project_entry(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
     {
         return true;
     }
-    let clean = line.text.trim();
-    !clean.is_empty()
-        && clean.chars().count() <= 100
-        && !clean.ends_with(['.', '!', '?'])
-        && !is_project_stack_shaped(clean)
-        && next.is_some_and(|n| is_project_stack_shaped(&n.text))
+    is_project_title_shaped(&line.text, next.map(|n| n.text.as_str()))
 }
 
 /// Regroup one line of a Projects section into an [`EntryBlock`], returning

--- a/apps/desktop/src-tauri/src/model/adapter.rs
+++ b/apps/desktop/src-tauri/src/model/adapter.rs
@@ -77,6 +77,45 @@ fn push_nonempty_section(section: Section, sections: &mut Vec<Section>) {
     }
 }
 
+/// The next line with content, skipping blanks. Blank lines separate projects,
+/// so a project's LAST description line looks ahead to the NEXT project's title
+/// rather than stopping at the gap.
+fn next_content_line(lines: &[ParsedLine], idx: usize) -> Option<&ParsedLine> {
+    lines[idx.saturating_add(1)..]
+        .iter()
+        .find(|l| !matches!(l.kind, LineKind::Blank) && !l.text.trim().is_empty())
+}
+
+/// Does this line open a project entry?
+///
+/// A leading bold run is the signal the generated signature carries and the one
+/// `validate::content`'s tier grader reads. But bold is MARKDOWN, and a résumé
+/// imported from PDF or DOCX has none — extraction keeps the words and drops the
+/// styling. A candidate's own CV can therefore carry a perfectly-formed project
+/// block (`AI Job Hunter   aijobhunter.app` / `Tauri 2 · Rust · React 19` / prose)
+/// and still be rendered as loose paragraphs, which is exactly the flat output
+/// this feature exists to remove.
+///
+/// So fall back to the SHAPE: a short, non-sentence line whose next line is a
+/// technology stack is a project title. The stack line is the discriminator —
+/// prose does not sit above a `·`-separated list — and the line must not be a
+/// stack itself, or a two-stack sequence would open an entry on the second one.
+fn opens_project_entry(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
+    if line
+        .segments
+        .first()
+        .is_some_and(|seg| seg.bold && !seg.text.trim().is_empty())
+    {
+        return true;
+    }
+    let clean = line.text.trim();
+    !clean.is_empty()
+        && clean.chars().count() <= 100
+        && !clean.ends_with(['.', '!', '?'])
+        && !is_project_stack_shaped(clean)
+        && next.is_some_and(|n| is_project_stack_shaped(&n.text))
+}
+
 /// Regroup one line of a Projects section into an [`EntryBlock`], returning
 /// `true` when the line was consumed.
 ///
@@ -103,6 +142,7 @@ fn push_nonempty_section(section: Section, sections: &mut Vec<Section>) {
 /// Experience or a custom heading are not touched.
 fn absorb_project_line(
     line: &ParsedLine,
+    next: Option<&ParsedLine>,
     entry: &mut Option<EntryBlock>,
     current: &mut Option<Section>,
     preamble: &mut Vec<Block>,
@@ -111,13 +151,7 @@ fn absorb_project_line(
         return false;
     }
 
-    // A bold-led line is the start of the next project — the same signal
-    // `validate::content`'s project-tier grader reads.
-    if line
-        .segments
-        .first()
-        .is_some_and(|seg| seg.bold && !seg.text.trim().is_empty())
-    {
+    if opens_project_entry(line, next) {
         flush_entry(entry, current, preamble);
         *entry = Some(EntryBlock {
             // `line.raw` so the bold run and the markdown links survive.
@@ -171,7 +205,7 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
     let mut current: Option<Section> = None;
     let mut entry: Option<EntryBlock> = None;
 
-    for line in &parsed.lines {
+    for (idx, line) in parsed.lines.iter().enumerate() {
         match line.kind {
             LineKind::Blank => {}
 
@@ -194,7 +228,13 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
                     // Header contact: keep the raw (un-stripped) line so markdown
                     // links `[label](url)` tokenize into clickable runs.
                     contact_parts.push(line.raw.clone());
-                } else if !absorb_project_line(line, &mut entry, &mut current, &mut preamble) {
+                } else if !absorb_project_line(
+                    line,
+                    next_content_line(&parsed.lines, idx),
+                    &mut entry,
+                    &mut current,
+                    &mut preamble,
+                ) {
                     flush_entry(&mut entry, &mut current, &mut preamble);
                     push_block(
                         Block::Paragraph(tokenize_rich(&line.raw)),
@@ -272,7 +312,13 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
                     && is_title_like(&line.text)
                 {
                     title = Some(line.text.clone());
-                } else if !absorb_project_line(line, &mut entry, &mut current, &mut preamble) {
+                } else if !absorb_project_line(
+                    line,
+                    next_content_line(&parsed.lines, idx),
+                    &mut entry,
+                    &mut current,
+                    &mut preamble,
+                ) {
                     flush_entry(&mut entry, &mut current, &mut preamble);
                     push_block(
                         Block::Paragraph(tokenize_rich(&line.raw)),
@@ -1133,6 +1179,57 @@ Framework-agnostic component library published to npm.
             ],
             "the link stays body content, in source order"
         );
+    }
+
+    /// An IMPORTED résumé carries no markdown: PDF and DOCX extraction keeps the
+    /// words and drops the bold. A candidate's own CV with a perfectly-formed
+    /// project block therefore has no `**` anywhere, and a bold-only opener
+    /// rendered the whole section as loose paragraphs — the exact flat output
+    /// this feature exists to remove. Real shape, taken from an imported CV.
+    #[test]
+    fn a_project_title_is_recognized_without_markdown_bold() {
+        let m = model_from_resume_text(
+            "PROJECTS
+
+             AI Job Hunter   aijobhunter.app
+             Tauri 2 · Rust · React 19 · TypeScript
+             Local-first Windows and macOS desktop application with local SQLite storage.
+
+             CrossKit   crosskit.iamsaeed.dev
+             TypeScript · React · Vue
+             Framework-agnostic component library published to npm.
+",
+        );
+        let found = entries(&m);
+        assert_eq!(found.len(), 2, "one entry per project, got {found:?}");
+        assert_eq!(flat(&found[0].title), "AI Job Hunter   aijobhunter.app");
+        assert_eq!(
+            found[0].subtitle.as_ref().map(flat).as_deref(),
+            Some("Tauri 2 · Rust · React 19 · TypeScript")
+        );
+        assert_eq!(
+            found[0].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec!["Local-first Windows and macOS desktop application with local SQLite storage."]
+        );
+        assert_eq!(flat(&found[1].title), "CrossKit   crosskit.iamsaeed.dev");
+        assert_eq!(
+            found[1].subtitle.as_ref().map(flat).as_deref(),
+            Some("TypeScript · React · Vue")
+        );
+    }
+
+    /// The shape fallback must not fire on ordinary prose. A description line is
+    /// only ever followed by more prose or the next title, never by a stack.
+    #[test]
+    fn prose_followed_by_prose_never_opens_an_entry() {
+        let m = model_from_resume_text(
+            "PROJECTS
+
+             Built an internal deploy tool used by the whole team
+             and documented it for the on-call rotation.
+",
+        );
+        assert!(entries(&m).is_empty(), "no stack line, so no entry opens");
     }
 
     /// A2: the same text under a German heading takes the same path. Before this

--- a/apps/desktop/src-tauri/src/model/adapter.rs
+++ b/apps/desktop/src-tauri/src/model/adapter.rs
@@ -77,12 +77,18 @@ fn push_nonempty_section(section: Section, sections: &mut Vec<Section>) {
     }
 }
 
-/// The next line with content, skipping blanks. Blank lines separate projects,
-/// so a project's LAST description line looks ahead to the NEXT project's title
-/// rather than stopping at the gap.
+/// The next line with content WITHIN the current section, skipping blanks.
+///
+/// Blanks separate projects, so a project's last description line must still
+/// see the next project's title. A [`LineKind::SectionHeader`] ends the search
+/// instead: looking past it let a separator-bearing heading (`SKILLS · TOOLS`)
+/// turn the final line of Projects into a title, and the sibling groupings in
+/// `pipeline::resume::source` and `validate::content` are section-scoped by
+/// construction — this is what keeps all three answering alike.
 fn next_content_line(lines: &[ParsedLine], idx: usize) -> Option<&ParsedLine> {
     lines[idx.saturating_add(1)..]
         .iter()
+        .take_while(|l| !matches!(l.kind, LineKind::SectionHeader))
         .find(|l| !matches!(l.kind, LineKind::Blank) && !l.text.trim().is_empty())
 }
 
@@ -96,7 +102,11 @@ fn next_content_line(lines: &[ParsedLine], idx: usize) -> Option<&ParsedLine> {
 /// A bullet is deliberately NOT an opener here: the compact tier
 /// (`• Name · Website · Github`) is a standalone one-liner, and the `Bullet` arm
 /// already appends bullets to whichever entry is open.
-fn opens_project_entry(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
+fn opens_project_entry(
+    line: &ParsedLine,
+    next: Option<&ParsedLine>,
+    at_paragraph_start: bool,
+) -> bool {
     if line
         .segments
         .first()
@@ -104,7 +114,11 @@ fn opens_project_entry(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
     {
         return true;
     }
-    is_project_title_shaped(&line.text, next.map(|n| n.text.as_str()))
+    is_project_title_shaped(
+        &line.text,
+        next.map(|n| n.text.as_str()),
+        at_paragraph_start,
+    )
 }
 
 /// Regroup one line of a Projects section into an [`EntryBlock`], returning
@@ -134,6 +148,7 @@ fn opens_project_entry(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
 fn absorb_project_line(
     line: &ParsedLine,
     next: Option<&ParsedLine>,
+    at_paragraph_start: bool,
     entry: &mut Option<EntryBlock>,
     current: &mut Option<Section>,
     preamble: &mut Vec<Block>,
@@ -142,7 +157,7 @@ fn absorb_project_line(
         return false;
     }
 
-    if opens_project_entry(line, next) {
+    if opens_project_entry(line, next, at_paragraph_start) {
         flush_entry(entry, current, preamble);
         *entry = Some(EntryBlock {
             // `line.raw` so the bold run and the markdown links survive.
@@ -196,7 +211,16 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
     let mut current: Option<Section> = None;
     let mut entry: Option<EntryBlock> = None;
 
+    // True when the line about to be handled opens a paragraph: the first
+    // content line after a blank or a section heading. Projects are separated by
+    // blank lines and a description line never is, which is what keeps an
+    // unpunctuated line INSIDE an entry from being read as the next title.
+    let mut at_paragraph_start = true;
     for (idx, line) in parsed.lines.iter().enumerate() {
+        let at_paragraph_start = std::mem::replace(
+            &mut at_paragraph_start,
+            matches!(line.kind, LineKind::Blank | LineKind::SectionHeader),
+        );
         match line.kind {
             LineKind::Blank => {}
 
@@ -222,6 +246,7 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
                 } else if !absorb_project_line(
                     line,
                     next_content_line(&parsed.lines, idx),
+                    at_paragraph_start,
                     &mut entry,
                     &mut current,
                     &mut preamble,
@@ -306,6 +331,7 @@ pub fn model_from_resume_text(text: &str) -> DocumentModel {
                 } else if !absorb_project_line(
                     line,
                     next_content_line(&parsed.lines, idx),
+                    at_paragraph_start,
                     &mut entry,
                     &mut current,
                     &mut preamble,
@@ -1221,6 +1247,60 @@ Framework-agnostic component library published to npm.
 ",
         );
         assert!(entries(&m).is_empty(), "no stack line, so no entry opens");
+    }
+
+    /// The shape signal must not read across a section boundary. A
+    /// separator-bearing HEADING (`SKILLS · TOOLS`, and German/French headings
+    /// like `KENNTNISSE · SPRACHEN` are the same shape) sits right after the last
+    /// line of Projects, and looking past the heading made that line a title.
+    #[test]
+    fn the_shape_signal_never_looks_past_a_section_heading() {
+        let m = model_from_resume_text(
+            "PROJECTS
+
+             Ledger CLI   example.dev
+             Rust · SQLite
+             A bookkeeping tool I maintain
+
+             SKILLS · TOOLS
+             Rust, Python
+",
+        );
+        let found = entries(&m);
+        assert_eq!(found.len(), 1, "one project, got {found:?}");
+        assert_eq!(
+            found[0].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec!["A bookkeeping tool I maintain"],
+            "the last line stays this project's body"
+        );
+    }
+
+    /// A line INSIDE an entry must not hijack a following stack line. Entries are
+    /// blank-separated and a description line never is, which is the signal that
+    /// separates the two: `Used by 200 teams` above a SECOND stack is prose.
+    #[test]
+    fn an_unpunctuated_body_line_above_a_stack_is_not_a_title() {
+        let m = model_from_resume_text(
+            "PROJECTS
+
+             Ledger CLI   example.dev
+             Rust · SQLite
+             Used by 200 teams
+             Go · gRPC · Redis
+",
+        );
+        let found = entries(&m);
+        assert_eq!(found.len(), 1, "one project, got {found:?}");
+        assert_eq!(
+            found[0].subtitle.as_ref().map(flat).as_deref(),
+            Some("Rust · SQLite"),
+            "the FIRST stack stays the technology line"
+        );
+        assert_eq!(
+            found[0].bullets.iter().map(flat).collect::<Vec<_>>(),
+            vec!["Used by 200 teams", "Go · gRPC · Redis"],
+            "both later lines stay body content, in order"
+        );
     }
 
     /// A2: the same text under a German heading takes the same path. Before this

--- a/apps/desktop/src-tauri/src/pipeline/resume/projects.rs
+++ b/apps/desktop/src-tauri/src/pipeline/resume/projects.rs
@@ -45,11 +45,18 @@ use super::stages::sections;
 /// when it did — content-free (ADR-027), for the draft-stage ledger.
 ///
 /// Every extractor in `extraction::*` (PDF/DOCX/RTF) emits plain prose, no
-/// markdown at all — `source::entries` groups a section's lines by
-/// `project_entry_starts` (bold or bullet) OR "first line of the section",
-/// and that second arm exists only so a section with exactly one project
-/// still seeds. On a plain-text section it is the only arm that fires, so a
-/// multi-project section collapses into fewer, garbled entries.
+/// markdown at all. `project_entry_starts` therefore reads a THIRD signal
+/// besides bold and bullet: a short, non-sentence line directly above a
+/// technology stack is a title (`export::parser::is_project_title_shaped`).
+/// Before that, the only arm a plain-text section could fire was "first line
+/// of the section", so a multi-project section collapsed into ONE garbled
+/// mega-entry whose description swallowed every following project's title —
+/// which the `link_in_description` bail below then correctly refused to
+/// normalize from. A plain-prose section now groups correctly, so these bails
+/// fire on genuinely broken input rather than on every imported résumé.
+///
+/// They are still load-bearing: a section with no stack lines at all has no
+/// shape signal either, and still collapses.
 ///
 /// Three independent, WHOLE-BAIL guards (a partial filter would still leave
 /// the rest of a mis-grouped section to normalize from):

--- a/apps/desktop/src-tauri/src/pipeline/resume/source.rs
+++ b/apps/desktop/src-tauri/src/pipeline/resume/source.rs
@@ -186,15 +186,22 @@ static MD_LINK_RE: LazyLock<Regex> =
 pub(crate) fn entries(section: &SourceSection) -> Vec<Vec<&SourceLine>> {
     // Collected first: the shape rule reads the NEXT content line, and blanks
     // (which separate projects) must not hide the following title from it.
-    let lines: Vec<&SourceLine> = section
-        .lines
-        .iter()
-        .filter(|l| !matches!(l.parsed.kind, LineKind::Blank) && !l.parsed.text.trim().is_empty())
-        .collect();
+    // Each kept line carries whether it OPENED a paragraph, computed before the
+    // blanks are dropped — the shape rule needs it and the filter destroys it.
+    let mut lines: Vec<(&SourceLine, bool)> = Vec::new();
+    let mut at_paragraph_start = true;
+    for line in &section.lines {
+        if matches!(line.parsed.kind, LineKind::Blank) || line.parsed.text.trim().is_empty() {
+            at_paragraph_start = true;
+            continue;
+        }
+        lines.push((line, at_paragraph_start));
+        at_paragraph_start = false;
+    }
     let mut out: Vec<Vec<&SourceLine>> = Vec::new();
-    for (idx, line) in lines.iter().enumerate() {
-        let next = lines.get(idx + 1).map(|l| &l.parsed);
-        if project_entry_starts(&line.parsed, next) || out.is_empty() {
+    for (idx, (line, opens_paragraph)) in lines.iter().enumerate() {
+        let next = lines.get(idx + 1).map(|(l, _)| &l.parsed);
+        if project_entry_starts(&line.parsed, next, *opens_paragraph) || out.is_empty() {
             out.push(vec![line]);
         } else if let Some(last) = out.last_mut() {
             last.push(line);

--- a/apps/desktop/src-tauri/src/pipeline/resume/source.rs
+++ b/apps/desktop/src-tauri/src/pipeline/resume/source.rs
@@ -184,13 +184,17 @@ static MD_LINK_RE: LazyLock<Regex> =
 /// the seeder and the normalizer can never disagree about where an entry
 /// starts.
 pub(crate) fn entries(section: &SourceSection) -> Vec<Vec<&SourceLine>> {
-    let mut out: Vec<Vec<&SourceLine>> = Vec::new();
-    for line in section
+    // Collected first: the shape rule reads the NEXT content line, and blanks
+    // (which separate projects) must not hide the following title from it.
+    let lines: Vec<&SourceLine> = section
         .lines
         .iter()
         .filter(|l| !matches!(l.parsed.kind, LineKind::Blank) && !l.parsed.text.trim().is_empty())
-    {
-        if project_entry_starts(&line.parsed) || out.is_empty() {
+        .collect();
+    let mut out: Vec<Vec<&SourceLine>> = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        let next = lines.get(idx + 1).map(|l| &l.parsed);
+        if project_entry_starts(&line.parsed, next) || out.is_empty() {
             out.push(vec![line]);
         } else if let Some(last) = out.last_mut() {
             last.push(line);

--- a/apps/desktop/src-tauri/src/pipeline/resume/test.rs
+++ b/apps/desktop/src-tauri/src/pipeline/resume/test.rs
@@ -5024,3 +5024,75 @@ fn a_bare_code_host_stack_token_survives_as_a_technology_not_a_link() {
         projects[0].stack
     );
 }
+
+/// An IMPORTED résumé has no markdown — PDF/DOCX extraction keeps the words and
+/// drops the bold — so before the shape signal existed, `source::entries`
+/// collapsed a multi-project section into ONE mega-entry whose description
+/// swallowed the next project's title and stack. Measured on the real shape a
+/// user reported: three projects seeded as one, with `link_in_description`
+/// then correctly refusing to normalize anything at all.
+#[test]
+fn a_plain_prose_projects_section_seeds_one_entry_per_project() {
+    let source = "PROJECTS
+
+AI Job Hunter   aijobhunter.app
+Tauri 2 · Rust · React 19 · TypeScript
+Local-first Windows and macOS desktop application with local SQLite storage.
+
+CrossKit   crosskit.iamsaeed.dev
+TypeScript · React · Vue
+Framework-agnostic component library published to npm.
+";
+    let seeded = super::source::seed_projects(source);
+    assert_eq!(seeded.len(), 2, "one seed per project, got {seeded:?}");
+    assert_eq!(
+        seeded[0].stack,
+        vec!["Tauri 2", "Rust", "React 19", "TypeScript"]
+    );
+    assert_eq!(
+        seeded[0].description,
+        "Local-first Windows and macOS desktop application with local SQLite storage.",
+        "the next project's title must not be swallowed into this description"
+    );
+    assert_eq!(seeded[1].stack, vec!["TypeScript", "React", "Vue"]);
+    assert_eq!(
+        seeded[1].description,
+        "Framework-agnostic component library published to npm."
+    );
+
+    // The whole-bail guards must now see plausible seeds rather than refusing
+    // to normalize every imported résumé.
+    let (seeds, bail) = super::projects::seed_projects_for_normalize(source);
+    assert_eq!(bail, None, "no bail reason expected, got {bail:?}");
+    assert_eq!(seeds.len(), 2);
+}
+
+/// The LIMIT of the shape signal, pinned so it is not mistaken for fixed: the
+/// signal is "a line sitting directly above a technology stack", so a Projects
+/// section with NO stack lines anywhere has nothing to key on and still
+/// collapses into one mega-entry.
+///
+/// Pre-existing and unchanged by the shape signal — this shape had no bold, no
+/// bullet and no stack before it either. Recorded because the collapse is NOT
+/// caught by the whole-bail guards: the merged description carries no URL, and
+/// a single collapsed seed has no sibling for `seeds_are_plausible` to compare
+/// against. Normalization would run from this garbled seed.
+#[test]
+fn a_projects_section_with_no_stack_lines_still_collapses() {
+    let source = "PROJECTS
+
+Ledger CLI
+A double-entry bookkeeping tool for the terminal that I built and maintain.
+
+Beta Sync
+A small file synchroniser used by a handful of people.
+";
+    let (seeds, bail) = super::projects::seed_projects_for_normalize(source);
+    assert_eq!(bail, None);
+    assert_eq!(seeds.len(), 1, "no stack line anywhere, so no shape signal");
+    assert!(
+        seeds[0].description.contains("Beta Sync"),
+        "the second project is still swallowed: {:?}",
+        seeds[0].description
+    );
+}

--- a/apps/desktop/src-tauri/src/validate/content/consistency.rs
+++ b/apps/desktop/src-tauri/src/validate/content/consistency.rs
@@ -475,10 +475,18 @@ enum ProjectTier {
 /// second answer to "where does an entry begin" there would shift every
 /// subsequent line by one — turning a stack line into a description and a
 /// truthful document into a `consistency.project_structure` warning.
-pub fn project_entry_starts(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
+pub fn project_entry_starts(
+    line: &ParsedLine,
+    next: Option<&ParsedLine>,
+    at_paragraph_start: bool,
+) -> bool {
     matches!(line.kind, LineKind::Bullet)
         || line.segments.iter().any(|s| s.bold)
-        || crate::export::parser::is_project_title_shaped(&line.text, next.map(|n| n.text.as_str()))
+        || crate::export::parser::is_project_title_shaped(
+            &line.text,
+            next.map(|n| n.text.as_str()),
+            at_paragraph_start,
+        )
 }
 
 /// Group a projects section's non-blank lines into entries.
@@ -492,14 +500,22 @@ pub fn project_entry_starts(line: &ParsedLine, next: Option<&ParsedLine>) -> boo
 pub(super) fn project_entries(section: &Section) -> Vec<Vec<&ParsedLine>> {
     // Collected first: the shape rule reads the NEXT content line, and blanks
     // (which separate projects) must not hide the following title from it.
-    let lines: Vec<&ParsedLine> = section
-        .lines
-        .iter()
-        .filter(|l| !matches!(l.kind, LineKind::Blank) && !l.text.trim().is_empty())
-        .collect();
+    // Each kept line carries whether it OPENED a paragraph, computed before the
+    // blanks are dropped — the shape rule needs it and the filter destroys it.
+    let mut lines: Vec<(&ParsedLine, bool)> = Vec::new();
+    let mut at_paragraph_start = true;
+    for line in &section.lines {
+        if matches!(line.kind, LineKind::Blank) || line.text.trim().is_empty() {
+            at_paragraph_start = true;
+            continue;
+        }
+        lines.push((line, at_paragraph_start));
+        at_paragraph_start = false;
+    }
     let mut entries: Vec<Vec<&ParsedLine>> = Vec::new();
-    for (idx, line) in lines.iter().enumerate() {
-        let starts_entry = project_entry_starts(line, lines.get(idx + 1).copied());
+    for (idx, (line, opens_paragraph)) in lines.iter().enumerate() {
+        let starts_entry =
+            project_entry_starts(line, lines.get(idx + 1).map(|(l, _)| *l), *opens_paragraph);
         if starts_entry || entries.is_empty() {
             entries.push(vec![line]);
         } else if let Some(last) = entries.last_mut() {

--- a/apps/desktop/src-tauri/src/validate/content/consistency.rs
+++ b/apps/desktop/src-tauri/src/validate/content/consistency.rs
@@ -475,8 +475,10 @@ enum ProjectTier {
 /// second answer to "where does an entry begin" there would shift every
 /// subsequent line by one — turning a stack line into a description and a
 /// truthful document into a `consistency.project_structure` warning.
-pub fn project_entry_starts(line: &ParsedLine) -> bool {
-    matches!(line.kind, LineKind::Bullet) || line.segments.iter().any(|s| s.bold)
+pub fn project_entry_starts(line: &ParsedLine, next: Option<&ParsedLine>) -> bool {
+    matches!(line.kind, LineKind::Bullet)
+        || line.segments.iter().any(|s| s.bold)
+        || crate::export::parser::is_project_title_shaped(&line.text, next.map(|n| n.text.as_str()))
 }
 
 /// Group a projects section's non-blank lines into entries.
@@ -488,13 +490,16 @@ pub fn project_entry_starts(line: &ParsedLine) -> bool {
 /// which line is the stack line — two graders disagreeing about where an entry
 /// starts is how a structure warning and a link Critical contradict each other.
 pub(super) fn project_entries(section: &Section) -> Vec<Vec<&ParsedLine>> {
-    let mut entries: Vec<Vec<&ParsedLine>> = Vec::new();
-    for line in section
+    // Collected first: the shape rule reads the NEXT content line, and blanks
+    // (which separate projects) must not hide the following title from it.
+    let lines: Vec<&ParsedLine> = section
         .lines
         .iter()
         .filter(|l| !matches!(l.kind, LineKind::Blank) && !l.text.trim().is_empty())
-    {
-        let starts_entry = project_entry_starts(line);
+        .collect();
+    let mut entries: Vec<Vec<&ParsedLine>> = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        let starts_entry = project_entry_starts(line, lines.get(idx + 1).copied());
         if starts_entry || entries.is_empty() {
             entries.push(vec![line]);
         } else if let Some(last) = entries.last_mut() {

--- a/packages/prompts/src/generate/generate.test.ts
+++ b/packages/prompts/src/generate/generate.test.ts
@@ -1071,6 +1071,14 @@ describe('buildEmphasisDirectivesBlock (#15)', () => {
 });
 
 describe('buildResumePrompt', () => {
+  it('asks for project technologies on their own line, so the export can style them', () => {
+    const prompt = buildResumePrompt(RESUME_WITH_LINKS, 'Job ad', META, 'ats');
+    // Without this the model merges the stack into the description sentence and
+    // the export has no technologies line to render as its own meta row.
+    expect(prompt).toContain("put them on their OWN line directly under that item's title");
+    expect(prompt).toContain('omit the line entirely rather than inventing a stack');
+  });
+
   it('includes candidate context and a language note', () => {
     const prompt = buildResumePrompt(RESUME_WITH_LINKS, 'Job ad', META, 'ats');
     expect(prompt).toContain('John Doe');

--- a/packages/prompts/src/generate/resume/resume.ts
+++ b/packages/prompts/src/generate/resume/resume.ts
@@ -397,6 +397,8 @@ Category: Skill1, **Skill2**, Skill3
 (blank line)
 (ONLY if CANDIDATE PROJECT / PUBLICATION LINKS were provided AND a link has no natural home in a role above — add a PROJECTS or PUBLICATIONS section here, one item per line as "Item title", using the project's real name as it appears in the résumé — never the machine label and never a URL slug — UNLESS that specific entry's own instruction (e.g. a "SHORT KEYS" list) explicitly says to write it verbatim, in which case follow that instead. If two links belong to the same project (e.g. a repo and its live site), keep them as TWO separate items — do NOT merge them — and name each item for what it actually is, rather than appending a generic disambiguator like "Web". Otherwise omit this section entirely.)
 
+If <candidate_resume> lists the technologies used on a project, put them on their OWN line directly under that item's title, separated by · , and begin the description on the line after. Copy the technologies verbatim — never invent, add or drop one, and never merge them into the description sentence. If the résumé lists none for that project, omit the line entirely rather than inventing a stack.
+
 Every entry in CANDIDATE PROJECT / PUBLICATION LINKS should end up with exactly one matching item somewhere in the output — follow each entry's own instruction above for how to name it, but never invent a title or context just to force one in. Keep any [label](url) markdown links already present in <candidate_resume> intact on their items.
 
 Start the resume now:`;


### PR DESCRIPTION
Follow-up to #1071, from a real export that still came out flat. Two independent defects, both diagnosed by measurement rather than inspection.

## Defect 1 — the export path required markdown bold

A project entry only opened on a leading `**bold**` run. **Bold is markdown, and an imported résumé has none** — PDF and DOCX extraction keeps the words and drops the styling. So a candidate's own CV carrying a perfectly-formed project block

```
AI Job Hunter   aijobhunter.app
Tauri 2 · Rust · React 19 · TypeScript      <- already a real · stack line
Local-first Windows and macOS desktop application with local SQLite storage.
```

still rendered as six loose paragraphs — the exact flat output #1071 exists to remove. Run through `model_from_resume_text`, it produced zero entries.

Fall back to the SHAPE when there is no bold: a short, non-sentence line whose NEXT line is a technology stack is a title. The stack line is the discriminator — prose does not sit directly above a `·`-separated list — and the line must not be a stack itself, or a two-stack sequence would open an entry on the second one.

## Defect 2 — the pipeline seeder had the same blind spot, and it mangled data

`project_entry_starts` is deliberately shared: its doc comment says a second answer to "where does an entry begin" would shift every following line by one. It had the identical bold-or-bullet limitation, so a plain-prose section fell through to the "first line of the section" arm. Measured on the real source:

```
SEEDED 1 projects
  name  = "AI Job Hunter   aijobhunter.app"
  desc  = "Local-first Windows and macOS desktop application... CrossKit   crosskit.iamsaeed.dev TypeScript · React · Vue"
```

Three projects collapsed into one, with the next project's title and stack swallowed into the first's description. `seed_projects_for_normalize`'s `link_in_description` bail then **correctly** refused to normalize from it — which is why a generated Projects section kept whatever free-form shape the model chose. After the fix: two clean seeds, `bail=None`.

The shape rule is defined **once**, in `export::parser::is_project_title_shaped`, and shared by the adapter and the predicate, rather than copied — the property that predicate's doc comment exists to protect.

## Defect 2b — nothing ever asked the generator for a tech line

The job-ad résumé prompt has no projects-shape rule, so the model merged the stack into the description sentence (`Tauri 2, Rust, React 19, TypeScript. Local-first-Desktop-App für...`) and the export had no meta line to style. #1071 added that rule to the *builder* prompt only. Added to the job-ad path, additively — it does not touch the item/link rules around it.

## Limits pinned as tests, not left to be rediscovered

- The shape signal needs a stack line. A **prose-only** Projects section has no signal and still collapses into one mega-entry — and the whole-bail guards do **not** catch that shape (merged description carries no URL; a single collapsed seed has no sibling for `seeds_are_plausible`). Pre-existing and unchanged here, now asserted so it cannot be mistaken for fixed.
- `projects.rs`'s module doc described the old collapse as unavoidable. It was accurate before this change and would have become a lie; updated.

## Verification

Rust suite 4650 passed · TS suite 7272 passed · `lint:strict`, `typecheck`, `clippy --all-features`, `cargo fmt --check` clean. No existing validator or normalizer test changed behaviour. Rendered to PNG on Classic and Deedy from the real imported-CV shape and compared against the reference design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved imported resume parsing to recognize unformatted project titles and group projects correctly.
  * Prevented regular prose from being mistaken for a project entry.
  * Preserved project technology stacks and descriptions during normalization.

* **Improvements**
  * Generated project entries now place technologies on a separate line beneath the title when available.
  * Added coverage for plain-text project sections and technology formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->