### PR TITLE
build(extension): name the manifest import's file extension

### DIFF
--- a/apps/extension/vite.config.mts
+++ b/apps/extension/vite.config.mts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { defineConfig, type Plugin } from 'vite';
 
-import { type BrowserTarget, buildManifest } from './src/manifest';
+import { type BrowserTarget, buildManifest } from './src/manifest.ts';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const srcDir = resolve(here, 'src');


### PR DESCRIPTION
Every extension build prints:

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`,
    which is planned to become the default in a future major version of Vite:
  - import "./src/manifest" without a file extension (vite.config.mts:7:51)
```

It is only a warning today, but the native loader is slated to become the default — so this is a build that works now and breaks on a future Vite major, announcing itself on every run until then.

One character short of one line: `./src/manifest` → `./src/manifest.ts`.

`.ts` rather than `.js` because Node's native TypeScript support resolves the real file, and `tsc` never typechecks this config — the package's `include` is `src*`, so no `allowImportingTsExtensions` is required and nothing else shifts.

## Verified

- Warning reproduced before the change, **absent after**, on both `build:chrome` and `build:firefox`.
- `eslint` clean on the file, `pnpm typecheck` 13/13, extension tests 588/588.
- Audited every other vite/vitest config in the repo for the same shape — this was the only one.

Suppressing it with `VITE_CONFIG_NATIVE_IGNORE_WARNING=true`, as the message offers, would have hidden the same future breakage instead of removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
