### PR TITLE
docs: record the agent surface decisions and sharpen its vocabulary

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -502,3 +502,46 @@ Was the shader-driven wobble of ink strokes (`uBoil`) that gave RIPBOOK its hand
 Retired - TERMINAL VELOCITY is a PBR realistic film, no ink boil. The only "on twos" that
 carries over is character animation stepped at ~12 fps against a smooth 60 fps camera.
 _Avoid_: reusing Line boil / `uBoil` for any TERMINAL VELOCITY effect
+
+## Domain — Agent CLI surface
+
+**Command**:
+A `#[tauri::command]` Rust function. There are 164, and the set is exactly 1:1 with the
+`generate_handler!` registration list — diffed both directions, no ghosts, no unregistered
+commands. This is the **authoritative registry** of what the app can do, and the only source a
+parity surface may derive from.
+_Avoid_: "channel" (a different, incomplete set) / "endpoint" (there is no HTTP surface)
+
+**Channel**:
+A TypeScript-side `namespace:verb` string in `IPC_CHANNELS`, used by the renderer to call a
+Command. **Not authoritative and not complete**: `NOTIFICATIONS_CHANNELS` is literally
+`{} as const`, and `AI_CHANNELS` carries 5 entries for a 29-method contract. A surface derived
+from Channels silently cannot do things the UI can.
+_Avoid_: treating the Channel list as "the API" — it is one renderer-side view of it
+
+**Resource**:
+A hand-written, allowlist-**projected** read surface of the agent CLI (`best-matches`, `job`,
+`profile`, `automations`, `schema`). A Resource never returns a raw record: its response type
+cannot express the forbidden fields, nested types included. The curated tier.
+_Avoid_: "endpoint" / using Resource for anything that mutates
+
+**Verb**:
+The token a caller types after `ajh-tauri agent`. A Verb resolves either to a Resource (curated
+tier) or, via `call`, to a Command (generic tier). Verbs are derived from one table that also
+generates `--help` and `schema`, so the three cannot disagree.
+_Avoid_: using Verb and Command interchangeably — one is the CLI's word, the other is the app's
+
+**Effect class**:
+The declared blast radius of a Command in the policy table — Read, Reversible, Irreversible, or
+NotExposed (with a stated reason). Declared, never inferred, and pessimistic by default: an
+unclassified Command fails CI rather than defaulting to safe. The table must match the Command
+registry exactly, which is [ADR-014](knowledge/decision-records/adr-014-cli-agent-shell-plugin-static-allowlist.md)'s
+static-allowlist invariant applied to inbound dispatch.
+_Avoid_: "permission" (nothing is granted per-caller; every caller is the user)
+
+**Confirm proof**:
+The value an Irreversible Command demands before it will run. It is deliberately **withheld from
+the refusal** — the refusal names which Resource yields it, never the value — so satisfying it
+requires a second call to a different Verb, and therefore requires having actually read the
+record. This is the safety property that survives the absence of a dry-run.
+_Avoid_: "confirmation prompt" (there is no interactive prompt; an autonomous caller cannot answer one)

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -506,17 +506,19 @@ _Avoid_: reusing Line boil / `uBoil` for any TERMINAL VELOCITY effect
 ## Domain — Agent CLI surface
 
 **Command**:
-A `#[tauri::command]` Rust function. There are 164, and the set is exactly 1:1 with the
-`generate_handler!` registration list — diffed both directions, no ghosts, no unregistered
-commands. This is the **authoritative registry** of what the app can do, and the only source a
-parity surface may derive from.
+A `#[tauri::command]` Rust function. The set is exactly 1:1 with the `generate_handler!`
+registration list in `lib.rs` — that list is the **authoritative registry** of what the app can
+do, and the only source a parity surface may derive from. Read the macro for current membership;
+the agent-CLI policy table and its test are what stop anything being added without a declared
+Effect class.
 _Avoid_: "channel" (a different, incomplete set) / "endpoint" (there is no HTTP surface)
 
 **Channel**:
 A TypeScript-side `namespace:verb` string in `IPC_CHANNELS`, used by the renderer to call a
-Command. **Not authoritative and not complete**: `NOTIFICATIONS_CHANNELS` is literally
-`{} as const`, and `AI_CHANNELS` carries 5 entries for a 29-method contract. A surface derived
-from Channels silently cannot do things the UI can.
+Command. **Not authoritative and not complete** — at least one namespace declares no channels at
+all, and others declare far fewer than their contract has methods (compare any
+`packages/shared/src/ipc/contracts/*.ts` contract interface against its `*_CHANNELS` const). A
+surface derived from Channels silently cannot do things the UI can.
 _Avoid_: treating the Channel list as "the API" — it is one renderer-side view of it
 
 **Resource**:

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -81,7 +81,7 @@ Read the minimum; **stop at ~90% confidence**.
 | [ADR-035](decision-records/adr-035-work-type-filter-declared-data-only.md)                   | Work-type filter classifies from declared board data only; undeclared is kept             |
 | [ADR-036](decision-records/adr-036-cross-autopilot-best-matches.md)                          | Cross-autopilot best matches: fuzzy clustering, rank by ADR-020 two-block rule            |
 | [ADR-037](decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md)                  | Agent CLI is a mode of the shipped binary and a thin client over the loopback bridge      |
-| [ADR-038](decision-records/adr-038-agent-cli-full-parity-two-tier.md)                        | Full CLI parity via a 164-row policy table; curated and generic tiers kept apart          |
+| [ADR-038](decision-records/adr-038-agent-cli-full-parity-two-tier.md)                        | Full CLI parity via a per-command policy table; curated and generic tiers kept apart          |
 
 ### The `NNNN-` series (closed)
 

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -1,6 +1,6 @@
 # Knowledge base (`docs/knowledge/`)
 
-Last updated: 2026-08-27
+Last updated: 2026-08-31
 
 A **thin, pointer-style** index for AI agents (and humans). It describes _shape and contracts_ and points at the **owning source symbol**; it deliberately does **not** copy drift-prone literals (scoring weights, template/board counts) — those live in code.
 
@@ -80,6 +80,8 @@ Read the minimum; **stop at ~90% confidence**.
 | [ADR-034](decision-records/adr-034-cover-letter-export-boundary-completion.md)               | Cover-letter export boundary completes a body-only letter (salutation/sign-off/signature) |
 | [ADR-035](decision-records/adr-035-work-type-filter-declared-data-only.md)                   | Work-type filter classifies from declared board data only; undeclared is kept             |
 | [ADR-036](decision-records/adr-036-cross-autopilot-best-matches.md)                          | Cross-autopilot best matches: fuzzy clustering, rank by ADR-020 two-block rule            |
+| [ADR-037](decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md)                  | Agent CLI is a mode of the shipped binary and a thin client over the loopback bridge      |
+| [ADR-038](decision-records/adr-038-agent-cli-full-parity-two-tier.md)                        | Full CLI parity via a 164-row policy table; curated and generic tiers kept apart          |
 
 ### The `NNNN-` series (closed)
 

--- a/docs/knowledge/decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md
+++ b/docs/knowledge/decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md
@@ -37,8 +37,11 @@ client over the extension bridge** that already exists. The app must be running.
    `register_native_host`'s existing best-effort lifecycle — the binary is not on `PATH` on Windows,
    macOS or Linux AppImage.
 
-4. **Every payload is an allowlist projection**, nested types included, and third-party scraped text
-   goes through `prompt_fence` ([ADR-010](adr-010-untrusted-input-fencing.md)).
+4. **Every payload of these five Resources is an allowlist projection**, nested types included, and
+   third-party scraped text goes through `prompt_fence`
+   ([ADR-010](adr-010-untrusted-input-fencing.md)). This guarantee is scoped to the **curated tier**:
+   [ADR-038](adr-038-agent-cli-full-parity-two-tier.md) later adds a generic tier that deliberately
+   returns records raw, and fencing is the only half that carries over to it.
 
 ## Consequences
 

--- a/docs/knowledge/decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md
+++ b/docs/knowledge/decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md
@@ -1,0 +1,72 @@
+# ADR-037 — Agent CLI is a mode of the shipped binary and a thin client over the loopback bridge
+
+**Status:** Accepted
+
+**Date:** 2026-08-31
+
+**Deciders:** repo owner, main session
+
+## Context
+
+Issue #1084 asked for a localhost-only, token-gated read-only HTTP API plus an `openapi.json`, because
+a Tauri desktop app is a native window an AI agent cannot read or drive — agents have browser
+automation, not window automation.
+
+An HTTP listener would have added a port, a CORS policy, an origin allowlist and a token file on disk,
+and every one of those is a surface to secure. An agent that can run shell commands needs none of them.
+
+Two independent questions then had to be answered: **where the CLI lives** (a second binary, or a mode
+of the existing one) and **where it gets data** (the app's stores, or the running app).
+
+## Decision
+
+**A mode of the existing `ajh-tauri` binary**, selected by an argv sentinel in `main.rs`, and a **thin
+client over the extension bridge** that already exists. The app must be running.
+
+1. **Not a second `[[bin]]`.** The release upload globs read only `target/release/bundle/**`
+   (`.github/workflows/release.yml`), so a second binary would ship to nobody. The exe is already
+   installed and already registered in the native-messaging manifests.
+
+2. **The sentinel's position is load-bearing in both directions.** It sits BELOW the native-host
+   short-circuit and ABOVE `ajh_tauri::run()`: `run()` forks the minidump supervisor as its first act,
+   and the single-instance plugin would otherwise hand the CLI's argv to the running GUI, pop its
+   window, and exit having printed nothing.
+
+3. **A thin client, never a second reader of the stores.** Query logic stays in one place, and the app
+   writes a pointer file (`exePath` from `current_exe()`, `dataDir`) on every launch, on
+   `register_native_host`'s existing best-effort lifecycle — the binary is not on `PATH` on Windows,
+   macOS or Linux AppImage.
+
+4. **Every payload is an allowlist projection**, nested types included, and third-party scraped text
+   goes through `prompt_fence` ([ADR-010](adr-010-untrusted-input-fencing.md)).
+
+## Consequences
+
+### Positive
+
+- **Zero distribution work.** No bundler, installer, updater or CI change: it _is_ the binary every
+  installer already contains.
+- **No new attack surface.** No port, listener, credential or capability entry; it reuses the bridge's
+  v2 mutual HMAC handshake ([ADR-0010](0010-bridge-hmac-handshake.md)).
+- **Leak-resistant by construction.** A projection type cannot express the forbidden fields, so a new
+  PII field cannot ride out on an existing resource.
+
+### Tradeoffs
+
+- **The app must be running.** With it closed the CLI exits non-zero with a parseable error. This was
+  chosen deliberately over reading the stores.
+- **Windows has no console in release.** `windows_subsystem = "windows"` with `panic = "abort"` means an
+  interactive run has a NULL stdout handle and `println!` aborts silently, so the CLI probes
+  `GetStdHandle` first and attaches only when there is nothing inherited.
+
+### Why reading the stores directly was rejected
+
+It is not read-only, on evidence rather than principle. `ApplicationStore::open` unconditionally runs
+`link_orphaned_generations` + `backfill_from_generations`, which open `ai_generations.db` read-write,
+run `ALTER TABLE … ADD COLUMN`, and **create `Application` rows**. Worse, `run_migrations` reads
+`user_version` outside any transaction, so two processes at the same version both apply migration N+1;
+the loser gets "duplicate column name", and if the loser is the app, `lib.rs` swallows it as non-fatal
+and boots with **no `ApplicationStore`** — the user's entire application tracker silently reads empty.
+
+The data directory also holds ~15 separate SQLite files plus JSON stores, so a second reader would
+reimplement the store layer, and `AJH_DATA_DIR` never escapes the app process anyway.

--- a/docs/knowledge/decision-records/adr-038-agent-cli-full-parity-two-tier.md
+++ b/docs/knowledge/decision-records/adr-038-agent-cli-full-parity-two-tier.md
@@ -1,0 +1,84 @@
+# ADR-038 — Full CLI parity: a policy table over all 164 commands, curated and generic tiers kept apart
+
+**Status:** Accepted
+
+**Date:** 2026-08-31
+
+**Deciders:** repo owner, main session
+
+## Context
+
+[ADR-037](adr-037-agent-cli-as-binary-mode-thin-client.md) shipped five hand-written, projected read
+Resources. The owner then asked for `gh`-style parity: the CLI should perform **any** action the user
+can perform in the UI, **including** irreversible ones (`privacy:reset_app`, `sign_out_all`,
+`credentials:*`, the `*_remove` family, and application submission when it exists), with the dispatcher
+**derived** from the registry so a new capability needs no CLI work.
+
+Three facts, each independently reproduced, shaped the design:
+
+- There are **164** `#[tauri::command]` sites, exactly 1:1 with `generate_handler!` (`lib.rs`), diffed
+  both directions.
+- **`IPC_CHANNELS` is not that registry.** `NOTIFICATIONS_CHANNELS` is literally `{} as const` and
+  `AI_CHANNELS` has 5 entries for a 29-method contract, so deriving from it ships a CLI that silently
+  cannot do what the UI does.
+- **`Webview::on_message(InvokeRequest, responder)` is `pub`** in tauri 2.11.5 (verified in the vendored
+  pinned source), so invoking a command by name from Rust needs **no** codegen.
+
+Four commands have **zero** renderer references, one of them destructive — so registry parity gives the
+CLI _more_ than the UI, not the same. That is accepted and is why the policy table is explicit.
+
+## Decision
+
+**1. A committed policy table is the allowlist, and it must match the registry exactly.** Every one of
+the 164 commands carries a declared `Effect` — `Read`, `Reversible`, `Irreversible`, or `NotExposed`
+with a stated reason — and a test asserts the table and `generate_handler!` agree with no extras and no
+missing entries. This is [ADR-014](adr-014-cli-agent-shell-plugin-static-allowlist.md)'s static-allowlist
+invariant applied to _inbound_ dispatch: an unclassified command fails CI instead of shipping. Effects
+are declared, never inferred, and pessimistic by default.
+
+**2. Two tiers with visibly different grammars.** `agent <resource>` is curated and projected;
+`agent call <ns>:<command>` is generic. AWS ships exactly this split (`s3` vs `s3api`) and documents
+that the curated tier loses the generated tier's machinery. Keeping the grammars distinct means the
+caller knows _before running_ whether the reply carries a projection guarantee.
+
+**3. The generic tier returns the record raw.** No PII redaction — see the amendment below.
+Third-party scraped text is still fenced: that protects the agent from an attacker-authored posting,
+not the user from their own résumé, and the two are different concerns.
+
+**4. An irreversible command demands a proof the refusal does not contain.** There is no derivable
+dry-run — no simulation path exists anywhere in the app — so the safety property comes from _where the
+token lives_: the refusal names which Resource yields it and withholds the value, so satisfying it
+requires a second call to a different Verb, and therefore requires having actually read the record.
+A one-hop ceremony that hands back its own answer stops nothing.
+
+**5. `ok` is not overloaded in the generic tier.** ~47 commands signal failure in-band inside a `Value`
+rather than as `Err`, so the dispatcher cannot know whether a call succeeded. It reports `dispatched`
+and returns the payload verbatim; the curated tier keeps a truthful `ok` because those five are
+hand-written. The alternative — a per-command failure-detection column derived from doc comments — is
+exactly the drift-prone hand-maintained literal AGENTS.md rule 17 forbids.
+
+## Consequences
+
+### Positive
+
+- **Spend limits survive for free.** `limiter.acquire` and `charge_provider_daily` sit _inside_ the
+  command bodies (`commands/ai/mod.rs`), and `on_message` invokes the real command in the app's own
+  process against its single managed `Limiter`. The guard that exists so "a looping/XSS'd renderer
+  can't drive unbounded paid-API spend" catches a looping agent too, unchanged.
+- **A new capability appears with no CLI work**, and a new _unclassified_ one fails CI.
+- No codegen, no build-step model, no second source of truth.
+
+### Tradeoffs
+
+- **The policy table is 164 rows of one-time manual classification.** That tedium is the point: it is
+  the enumerated allowlist.
+- **Parity exceeds the UI.** Four commands the UI never calls become reachable, one destructive.
+- **No preview.** Irreversible commands cannot be simulated; the ceremony is the only control.
+
+### Amends ADR-0005 (network egress privacy boundary)
+
+[ADR-0005](0005-network-egress-privacy-boundary.md)'s network-egress privacy boundary is hereby **scoped to the
+curated tier**. `agent call` returns records raw, including `resume_text` and `cover_letter`, into a
+consumer that is by design an LLM context. This was put to the owner with the consequence stated and
+chosen deliberately. It is recorded here rather than left implicit, because a promise that quietly
+became false is worse than one that was openly narrowed.


### PR DESCRIPTION
Follow-up to #1085, which merged without the per-PR steward pass — so the architecture it settled had no decision record, while the standards skill it shipped says "settled — do not redesign without an ADR". This closes that, and adds the glossary section a grill against the domain model produced.

## ADR-037 — what shipped

A mode of the existing binary rather than a second `[[bin]]` (release upload globs read only `target/release/bundle/**`, so a second binary ships to nobody); the argv sentinel placement that is load-bearing in both directions; and a thin client over the bridge rather than a second reader of the stores.

That last one was rejected on evidence, not taste: `ApplicationStore::open` runs backfills that write `ai_generations.db` and can **create** `Application` rows, and two processes racing `run_migrations` can leave the app booted with **no** `ApplicationStore` — the whole application tracker silently reads empty.

## ADR-038 — the approved parity approach

- A **164-row policy table** that must match `generate_handler!` exactly, asserted by test. That is ADR-014's static-allowlist invariant applied to *inbound* dispatch — an unclassified command fails CI instead of shipping.
- **Two tiers, visibly different grammars** (`agent <resource>` vs `agent call <ns>:<command>`) — the `aws s3` / `s3api` split, so a caller knows before running whether the reply carries a projection guarantee.
- **An irreversible command demands a proof its own refusal withholds.** There is no derivable dry-run — no simulation path exists anywhere in the app — so safety comes from *where the token lives*: satisfying it requires a second call to a different verb, and therefore requires having actually read the record.
- **`dispatched`, not an overloaded `ok`.** ~47 commands signal failure in-band inside a `Value`, so the dispatcher cannot know whether a call succeeded; it should not claim to.

It also **amends ADR-0005 in the open**: `agent call` returns records raw, résumé text included, into what is by design an LLM context. That was chosen deliberately, and is written down rather than left implicit — a promise that quietly became false is worse than one openly narrowed.

## Vocabulary

`CONTEXT.md` gains six terms the repo had been overloading: **Command** (164, the authoritative registry), **Channel** (marked explicitly non-authoritative — `NOTIFICATIONS_CHANNELS` is literally `{} as const`), **Resource**, **Verb**, **Effect class**, **Confirm proof**.

## Two citation corrections

Found while writing these, and worth knowing: the repo runs **two ADR families**, so `ADR-005` and `ADR-0005` are different documents. The local-data promise is ADR-0005 (`0005-network-egress-privacy-boundary`), not `adr-005`; the bridge handshake is ADR-0010, not `adr-015`. `check:adr-citations` confirms 23 closed plus 38 open, none ambiguous.

Docs only — no source changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a glossary explaining Agent CLI concepts, command behavior, safety classifications, and confirmation requirements.
  * Documented the Agent CLI’s architecture as a thin client that communicates with the running app.
  * Documented full CLI parity with the app through curated and generic command tiers.
  * Updated the knowledge-base index with new decision records and the latest update date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->