### PR TITLE
fix: make the agent CLI reachable after an install or update

### DIFF
--- a/Casks/ai-job-hunter.rb
+++ b/Casks/ai-job-hunter.rb
@@ -29,6 +29,15 @@ cask "ai-job-hunter" do
 
   app "AI Job Hunter.app"
 
+  # The agent CLI is the SAME binary in argv mode (ADR-037): `ajh-tauri agent
+  # <verb>` is detected from argv and short-circuits before the GUI (and before
+  # the single-instance plugin) ever starts. Symlinking it onto PATH is what
+  # makes the CLI reachable by a human — the app's own ~/.ajh-agent/agent.json
+  # pointer solves discovery for *agents*, but nothing put the binary on PATH.
+  # Verified against the shipped bundle, not assumed: the executable inside the
+  # bundle is named after the Cargo [[bin]] (`ajh-tauri`), NOT productName.
+  binary "#{appdir}/AI Job Hunter.app/Contents/MacOS/ajh-tauri"
+
   # The app is not notarized; clear the quarantine flag after install so
   # Gatekeeper doesn't refuse to open it.
   postflight do

--- a/README.md
+++ b/README.md
@@ -307,6 +307,43 @@ pnpm dev
 
 </details>
 
+<details>
+<summary><strong>CLI agent — `ajh-tauri agent <verb>` (headless mode)</strong></summary>
+
+Run commands from your shell or an LLM agent, with the desktop app already running:
+
+```bash
+# Find the best matches across all autopilots
+ajh-tauri agent best-matches --limit 10
+
+# Get full details for one job by URL
+ajh-tauri agent job "https://example.com/job/123"
+
+# Export your profile for autofill (requires opt-in consent)
+ajh-tauri agent profile
+
+# List all autopilots and their status
+ajh-tauri agent automations
+
+# Generic command dispatch (advanced: read/reversible commands, irreversible with proof)
+ajh-tauri agent call "namespace:command" --input '{"key":"value"}'
+
+# Show help
+ajh-tauri agent --help
+```
+
+**Platform-specific paths:** The CLI is the same binary as the desktop app, no separate install needed. On **Linux** and **Homebrew/macOS** it is already on `PATH`. On **macOS with dmg drag-install**, add the path to your shell profile:
+
+```bash
+export PATH="/Applications/AI Job Hunter.app/Contents/MacOS:$PATH"
+```
+
+On **Windows**, invoke the binary by full path (check your per-user install directory, or use `~/.ajh-agent/agent.json` to locate it programmatically).
+
+**Requirements:** The app must be running (except `--help`). The CLI communicates over a local loopback bridge with mutual HMAC-SHA256 authentication (the pairing token is used only as an HMAC key and is never sent on the wire). Run `ajh-tauri agent --help` to see all verbs, exit codes, and error sentinels. For the design rationale and full policy table, see <a href="docs/knowledge/decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md" target="_blank" rel="noopener noreferrer">ADR-037</a> and <a href="docs/knowledge/decision-records/adr-038-agent-cli-full-parity-two-tier.md" target="_blank" rel="noopener noreferrer">ADR-038</a>.
+
+</details>
+
 ---
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ ajh-tauri agent --help
 export PATH="/Applications/AI Job Hunter.app/Contents/MacOS:$PATH"
 ```
 
-On **Windows**, invoke the binary by full path (check your per-user install directory, or use `~/.ajh-agent/agent.json` to locate it programmatically).
+On **Windows**, the installer adds the per-user install directory to your `PATH` — **from the next release onward**. On v0.145.0 and earlier, invoke the binary by full path (use `~/.ajh-agent/agent.json` to locate it programmatically).
 
 **Requirements:** The app must be running (except `--help`). The CLI communicates over a local loopback bridge with mutual HMAC-SHA256 authentication (the pairing token is used only as an HMAC key and is never sent on the wire). Run `ajh-tauri agent --help` to see all verbs, exit codes, and error sentinels. For the design rationale and full policy table, see <a href="docs/knowledge/decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md" target="_blank" rel="noopener noreferrer">ADR-037</a> and <a href="docs/knowledge/decision-records/adr-038-agent-cli-full-parity-two-tier.md" target="_blank" rel="noopener noreferrer">ADR-038</a>.
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -52,7 +52,8 @@
     "resources": [],
     "windows": {
       "nsis": {
-        "installMode": "currentUser"
+        "installMode": "currentUser",
+        "installerHooks": "./windows/hooks.nsh"
       },
       "webviewInstallMode": {
         "type": "downloadBootstrapper"

--- a/apps/desktop/src-tauri/windows/hooks.nsh
+++ b/apps/desktop/src-tauri/windows/hooks.nsh
@@ -1,0 +1,293 @@
+; ---------------------------------------------------------------------------
+; NSIS installer hooks: put the agent CLI (`ajh-tauri agent <verb>`, see
+; docs/knowledge/agent-cli.md and ADR-037/038) on the per-user PATH so a
+; human (or a shell an agent drives) can type it directly. The app already
+; writes a machine-discoverable pointer file on every launch
+; (extension_bridge/register.rs, write_agent_pointer) — this hook exists
+; purely for interactive shell use, which the pointer file cannot provide.
+;
+; Wired via bundle.windows.nsis.installerHooks in tauri.conf.json. Hooked
+; into the generated installer.nsi as:
+;   !ifmacrodef NSIS_HOOK_POSTINSTALL   -> !insertmacro NSIS_HOOK_POSTINSTALL
+;   !ifmacrodef NSIS_HOOK_POSTUNINSTALL -> !insertmacro NSIS_HOOK_POSTUNINSTALL
+; both pasted inline into the installer's/uninstaller's Section body, so
+; $INSTDIR is already valid and these must stay plain instructions — no
+; `Function`/`FunctionEnd` blocks here, since a Function cannot be nested
+; inside a Section.
+;
+; Tauri's bundled NSIS toolchain does not ship the third-party EnVar plugin,
+; and the one bundled utility plugin (nsis_tauri_utils) has no PATH-related
+; exports (verified against the shipped x86-unicode plugin set: FindProcess,
+; KillProcess, RunAsUser, SemverCompare, StrReplace — nothing else). So this
+; is implemented with core NSIS instructions plus the already-available
+; System plugin for the one thing core NSIS cannot do: reading a registry
+; value's type (REG_SZ vs REG_EXPAND_SZ) without guessing.
+;
+; This mutates a registry value whose corruption breaks the user's shell, so
+; every step below is written defensively: a failure anywhere just leaves
+; PATH untouched and logs via DetailPrint. Nothing here may abort the
+; install/uninstall.
+; ---------------------------------------------------------------------------
+
+!ifndef AJH_PATH_HOOKS_INCLUDED
+!define AJH_PATH_HOOKS_INCLUDED
+
+!include "LogicLib.nsh"
+!include "WinMessages.nsh"
+!include "WinCore.nsh"   ; HKEY_CURRENT_USER / HKCU
+!include "StrFunc.nsh"
+${Using:StrFunc} StrLoc  ; no-op if the outer installer.nsi already did this (it does)
+
+; The per-user environment key/value Windows itself uses for PATH. Named so
+; a future edit that touches the wrong value is obvious in review. `/ifndef`
+; lets a local verification build override these (e.g. via `makensis -D...`)
+; to point at a scratch registry key instead of the real per-user PATH.
+!define /ifndef AJH_PATH_REGKEY "Environment"
+!define /ifndef AJH_PATH_REGVALUE "Path"
+
+; RegQueryValueEx's REG_* type constants we care about (winnt.h / winreg.h).
+; Anything else (REG_MULTI_SZ, REG_BINARY, ...) is not a shape we understand
+; well enough to safely rewrite, so both hooks below treat it as "leave
+; untouched" rather than guess.
+!define AJH_REG_SZ 1
+!define AJH_REG_EXPAND_SZ 2
+
+; Not exported by any bundled NSIS header (only the HKEY_* root constants
+; are); value from winnt.h.
+!define AJH_KEY_QUERY_VALUE 0x0001
+
+; NSIS variables (and values crossing the plugin-call stack) are capped at
+; this many characters in the Unicode NSIS build Tauri bundles — see
+; NSIS_MAX_STRLEN in the NSIS source (Source/exehead/config.h), 1024 by
+; default and not queryable from script. `ReadRegStr` on a value longer than
+; this SILENTLY TRUNCATES what lands in the variable, so a value read this
+; close to the cap cannot be trusted to be the real, complete PATH — writing
+; it back (with or without our own edit) risks permanently dropping whatever
+; didn't fit. Both hooks below refuse to touch PATH once its length is
+; within one character of this cap, rather than risk that.
+!define AJH_NSIS_MAX_STRLEN 1024
+
+; Extra headroom below the cap that any *new* value must also respect: our
+; separator plus a little slack, so we never write a result flush against
+; the truncation boundary above.
+!define AJH_PATH_SAFETY_MARGIN 8
+
+; Pre-computed at compile time (LogicLib's ${If} takes a single comparison
+; value, not an inline expression, so the arithmetic has to happen here).
+!define /math AJH_PATH_TRUNCATION_GUARD ${AJH_NSIS_MAX_STRLEN} - 1
+!define /math AJH_PATH_APPEND_BUDGET ${AJH_NSIS_MAX_STRLEN} - ${AJH_PATH_SAFETY_MARGIN}
+
+; ---------------------------------------------------------------------------
+; Shared: query the current type of AJH_PATH_REGVALUE (REG_SZ / REG_EXPAND_SZ
+; / absent / anything else), leaving the type in $2 and the Win32 result
+; code in $1 (0 = success; non-zero means absent-or-unreadable — callers
+; branch on this rather than the type when $1 != 0). Only ever opens the key
+; for KEY_QUERY_VALUE, never for write, so it cannot itself corrupt anything.
+; ---------------------------------------------------------------------------
+!macro AJH_QueryPathType
+  System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_QUERY_VALUE}, *i .r0) i .r1'
+  ${If} $1 == 0
+    System::Call 'Advapi32::RegQueryValueExW(i r0, w "${AJH_PATH_REGVALUE}", i 0, *i .r2, i 0, i 0) i .r1'
+    System::Call 'Advapi32::RegCloseKey(i r0)'
+  ${EndIf}
+!macroend
+
+; Best-effort environment-change broadcast so already-open shells pick up
+; the new PATH without a reboot. `/TIMEOUT` makes NSIS use SendMessageTimeout
+; internally so one wedged top-level window cannot hang the (un)installer.
+!macro AJH_BroadcastEnvironmentChange
+  SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+!macroend
+
+!macro NSIS_HOOK_POSTINSTALL
+  Push $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+  Push $5
+  Push $6
+  Push $7
+
+  !insertmacro AJH_QueryPathType
+
+  ${If} $1 != 0
+    ; No existing Path value (or the Environment key itself is new): create
+    ; a fresh single-entry value. REG_EXPAND_SZ matches what Windows itself
+    ; writes for a brand-new per-user PATH.
+    ClearErrors
+    WriteRegExpandStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" "$INSTDIR"
+    ${IfNot} ${Errors}
+      DetailPrint "ajh: added the agent CLI directory to the per-user PATH"
+      !insertmacro AJH_BroadcastEnvironmentChange
+    ${Else}
+      DetailPrint "ajh: could not create a per-user PATH value; leaving PATH untouched"
+    ${EndIf}
+    Goto ajh_addpath_done
+  ${EndIf}
+
+  ${If} $2 != ${AJH_REG_SZ}
+  ${AndIf} $2 != ${AJH_REG_EXPAND_SZ}
+    DetailPrint "ajh: per-user PATH has an unexpected registry type; leaving it untouched"
+    Goto ajh_addpath_done
+  ${EndIf}
+
+  ClearErrors
+  ReadRegStr $3 HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}"
+  ${If} ${Errors}
+    DetailPrint "ajh: could not read the existing per-user PATH; leaving it untouched"
+    Goto ajh_addpath_done
+  ${EndIf}
+
+  StrLen $4 $3
+  ${If} $4 >= ${AJH_PATH_TRUNCATION_GUARD}
+    DetailPrint "ajh: per-user PATH is at NSIS's string-length limit and may already be truncated; leaving it untouched"
+    Goto ajh_addpath_done
+  ${EndIf}
+
+  ; Idempotency: match $INSTDIR as a whole ';'-delimited segment, not a
+  ; substring. Padding both sides with ';' turns this into a plain substring
+  ; search that cannot false-match a sibling directory sharing our prefix
+  ; (e.g. "...\AI Job HunterX" must not count as already present).
+  StrCpy $5 ";$3;"
+  ${StrLoc} $6 $5 ";$INSTDIR;" ">"
+  ${If} $6 != ""
+    DetailPrint "ajh: agent CLI directory is already on the per-user PATH"
+    Goto ajh_addpath_done
+  ${EndIf}
+
+  ; The appended result must also stay inside the same budget, for the same
+  ; truncation reason as above.
+  StrLen $6 "$INSTDIR"
+  IntOp $6 $6 + 1 ; the separator we're about to add
+  IntOp $6 $6 + $4
+  ${If} $6 >= ${AJH_PATH_APPEND_BUDGET}
+    DetailPrint "ajh: appending to the per-user PATH would approach NSIS's string-length limit; leaving it untouched"
+    Goto ajh_addpath_done
+  ${EndIf}
+
+  StrCpy $7 $3 1 -1
+  ${If} $7 == ";"
+    StrCpy $5 "$3$INSTDIR"
+  ${Else}
+    StrCpy $5 "$3;$INSTDIR"
+  ${EndIf}
+
+  ClearErrors
+  ${If} $2 == ${AJH_REG_EXPAND_SZ}
+    WriteRegExpandStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
+  ${Else}
+    WriteRegStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
+  ${EndIf}
+  ${IfNot} ${Errors}
+    DetailPrint "ajh: added the agent CLI directory to the per-user PATH"
+    !insertmacro AJH_BroadcastEnvironmentChange
+  ${Else}
+    DetailPrint "ajh: failed to update the per-user PATH; leaving it untouched"
+  ${EndIf}
+
+  ajh_addpath_done:
+  Pop $7
+  Pop $6
+  Pop $5
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  Push $0
+  Push $1
+  Push $2
+  Push $3
+  Push $4
+  Push $5
+  Push $6
+  Push $7
+
+  !insertmacro AJH_QueryPathType
+
+  ${If} $1 != 0
+    DetailPrint "ajh: no per-user PATH value to clean up"
+    Goto ajh_rmpath_done
+  ${EndIf}
+
+  ${If} $2 != ${AJH_REG_SZ}
+  ${AndIf} $2 != ${AJH_REG_EXPAND_SZ}
+    DetailPrint "ajh: per-user PATH has an unexpected registry type; leaving it untouched"
+    Goto ajh_rmpath_done
+  ${EndIf}
+
+  ClearErrors
+  ReadRegStr $3 HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}"
+  ${If} ${Errors}
+    DetailPrint "ajh: could not read the existing per-user PATH; leaving it untouched"
+    Goto ajh_rmpath_done
+  ${EndIf}
+
+  StrLen $4 $3
+  ${If} $4 >= ${AJH_PATH_TRUNCATION_GUARD}
+    ; Same truncation risk as the install-time guard: a value read this
+    ; close to NSIS's cap may already be an incomplete copy, so rewriting
+    ; anything derived from it could drop entries that never made it in.
+    DetailPrint "ajh: per-user PATH is at NSIS's string-length limit and may already be truncated; leaving it untouched"
+    Goto ajh_rmpath_done
+  ${EndIf}
+
+  ; Same padded-segment search as install; the match's start offset ($6)
+  ; lets us splice the entry out including exactly the one delimiter on
+  ; each side it owns, never a neighbour's.
+  StrCpy $5 ";$3;"
+  ${StrLoc} $6 $5 ";$INSTDIR;" ">"
+  ${If} $6 == ""
+    DetailPrint "ajh: agent CLI directory is not on the per-user PATH; nothing to remove"
+    Goto ajh_rmpath_done
+  ${EndIf}
+
+  StrCpy $7 $5 $6 ; everything before the match, still ';'-prefixed (or empty)
+  ${If} $7 != ""
+    StrCpy $7 $7 "" 1 ; drop the leading ';' that isn't ours to keep
+  ${EndIf}
+
+  StrLen $4 ";$INSTDIR;"
+  IntOp $4 $6 + $4
+  StrCpy $3 $5 "" $4 ; everything after the match, still ';'-suffixed (or empty)
+  ${If} $3 != ""
+    StrCpy $3 $3 -1 ; drop the trailing ';' that isn't ours to keep
+  ${EndIf}
+
+  ${If} $7 == ""
+    StrCpy $5 $3
+  ${ElseIf} $3 == ""
+    StrCpy $5 $7
+  ${Else}
+    StrCpy $5 "$7;$3"
+  ${EndIf}
+
+  ClearErrors
+  ${If} $2 == ${AJH_REG_EXPAND_SZ}
+    WriteRegExpandStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
+  ${Else}
+    WriteRegStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
+  ${EndIf}
+  ${IfNot} ${Errors}
+    DetailPrint "ajh: removed the agent CLI directory from the per-user PATH"
+    !insertmacro AJH_BroadcastEnvironmentChange
+  ${Else}
+    DetailPrint "ajh: failed to update the per-user PATH; leaving it untouched"
+  ${EndIf}
+
+  ajh_rmpath_done:
+  Pop $7
+  Pop $6
+  Pop $5
+  Pop $4
+  Pop $3
+  Pop $2
+  Pop $1
+  Pop $0
+!macroend
+
+!endif ; AJH_PATH_HOOKS_INCLUDED

--- a/apps/desktop/src-tauri/windows/hooks.nsh
+++ b/apps/desktop/src-tauri/windows/hooks.nsh
@@ -13,20 +13,40 @@
 ; both pasted inline into the installer's/uninstaller's Section body, so
 ; $INSTDIR is already valid and these must stay plain instructions — no
 ; `Function`/`FunctionEnd` blocks here, since a Function cannot be nested
-; inside a Section.
+; inside a Section. The uninstall macro runs inside NSIS's real `Section
+; Uninstall`, which forbids `Call`ing any Function not prefixed `un.` — this
+; file never declares an NSIS Function at all (see the System::Call note
+; below), so that restriction never applies to it.
+;
+; This hardcodes HKCU (the per-user environment). It is only correct when
+; the installer itself is per-user; under perMachine/both an elevated
+; installer would run as a different (admin) principal and this would
+; silently edit *that* account's PATH instead of the real user's.
+!if "${INSTALLMODE}" != "currentUser"
+  !error "windows/hooks.nsh hardcodes HKCU for the per-user PATH and is only safe for bundle.windows.nsis.installMode == currentUser; wire a per-machine (HKLM) path or drop this hook before changing installMode."
+!endif
 ;
 ; Tauri's bundled NSIS toolchain does not ship the third-party EnVar plugin,
 ; and the one bundled utility plugin (nsis_tauri_utils) has no PATH-related
 ; exports (verified against the shipped x86-unicode plugin set: FindProcess,
-; KillProcess, RunAsUser, SemverCompare, StrReplace — nothing else). So this
-; is implemented with core NSIS instructions plus the already-available
-; System plugin for the one thing core NSIS cannot do: reading a registry
-; value's type (REG_SZ vs REG_EXPAND_SZ) without guessing.
+; KillProcess, RunAsUser, SemverCompare, StrReplace — nothing else).
 ;
-; This mutates a registry value whose corruption breaks the user's shell, so
-; every step below is written defensively: a failure anywhere just leaves
-; PATH untouched and logs via DetailPrint. Nothing here may abort the
-; install/uninstall.
+; The per-user PATH on a real machine routinely exceeds NSIS's ~1024-
+; character string-variable cap (`${NSIS_MAX_STRLEN}`, itself a compiler
+; builtin — not something this file can raise, since by the time it is
+; `!include`d partway through Tauri's generated installer.nsi, the exehead's
+; variable layout is already fixed). Reading such a value with `ReadRegStr`
+; does not silently truncate it — it sets the NSIS error flag and yields an
+; empty string — so that failure mode was never the risk. The real problem
+; is narrower but unavoidable: our own working copy of the value (padded,
+; searched, and rebuilt with the new entry) would itself be truncated the
+; moment it has to live in a $var, corrupting whatever didn't fit the moment
+; it gets written back. So neither the read nor the write ever puts the
+; PATH value in an NSIS variable: both go through `System::Call` against
+; raw, `GlobalAlloc`-backed memory (`Advapi32::RegQueryValueExW` /
+; `RegSetValueExW`, with `Shlwapi::StrStrW` for the substring search), which
+; has no such cap. Only short, fixed-size things ($INSTDIR, the literal
+; separator) ever pass through a plain NSIS string.
 ; ---------------------------------------------------------------------------
 
 !ifndef AJH_PATH_HOOKS_INCLUDED
@@ -35,8 +55,6 @@
 !include "LogicLib.nsh"
 !include "WinMessages.nsh"
 !include "WinCore.nsh"   ; HKEY_CURRENT_USER / HKCU
-!include "StrFunc.nsh"
-${Using:StrFunc} StrLoc  ; no-op if the outer installer.nsi already did this (it does)
 
 ; The per-user environment key/value Windows itself uses for PATH. Named so
 ; a future edit that touches the wrong value is obvious in review. `/ifndef`
@@ -52,42 +70,40 @@ ${Using:StrFunc} StrLoc  ; no-op if the outer installer.nsi already did this (it
 !define AJH_REG_SZ 1
 !define AJH_REG_EXPAND_SZ 2
 
-; Not exported by any bundled NSIS header (only the HKEY_* root constants
-; are); value from winnt.h.
+; Registry access rights and error codes (winnt.h / winerror.h) — not
+; exported by any bundled NSIS header (only the HKEY_* root constants are).
 !define AJH_KEY_QUERY_VALUE 0x0001
+!define AJH_KEY_SET_VALUE 0x0002
+!define AJH_ERROR_FILE_NOT_FOUND 2
 
-; NSIS variables (and values crossing the plugin-call stack) are capped at
-; this many characters in the Unicode NSIS build Tauri bundles — see
-; NSIS_MAX_STRLEN in the NSIS source (Source/exehead/config.h), 1024 by
-; default and not queryable from script. `ReadRegStr` on a value longer than
-; this SILENTLY TRUNCATES what lands in the variable, so a value read this
-; close to the cap cannot be trusted to be the real, complete PATH — writing
-; it back (with or without our own edit) risks permanently dropping whatever
-; didn't fit. Both hooks below refuse to touch PATH once its length is
-; within one character of this cap, rather than risk that.
-!define AJH_NSIS_MAX_STRLEN 1024
-
-; Extra headroom below the cap that any *new* value must also respect: our
-; separator plus a little slack, so we never write a result flush against
-; the truncation boundary above.
-!define AJH_PATH_SAFETY_MARGIN 8
-
-; Pre-computed at compile time (LogicLib's ${If} takes a single comparison
-; value, not an inline expression, so the arithmetic has to happen here).
-!define /math AJH_PATH_TRUNCATION_GUARD ${AJH_NSIS_MAX_STRLEN} - 1
-!define /math AJH_PATH_APPEND_BUDGET ${AJH_NSIS_MAX_STRLEN} - ${AJH_PATH_SAFETY_MARGIN}
+; GMEM_FIXED (0x0000) | GMEM_ZEROINIT (0x0040): a plain, zero-initialized
+; block whose handle IS its usable pointer (no GlobalLock needed). The
+; zero-init matters — every buffer below is sized exactly to its content
+; plus a NUL, and relies on that final NUL already being zero rather than
+; writing it explicitly.
+!define AJH_GPTR 0x0040
 
 ; ---------------------------------------------------------------------------
-; Shared: query the current type of AJH_PATH_REGVALUE (REG_SZ / REG_EXPAND_SZ
-; / absent / anything else), leaving the type in $2 and the Win32 result
-; code in $1 (0 = success; non-zero means absent-or-unreadable — callers
-; branch on this rather than the type when $1 != 0). Only ever opens the key
-; for KEY_QUERY_VALUE, never for write, so it cannot itself corrupt anything.
+; Shared: query the current value's type and byte size (including its
+; terminating NUL) without reading its content. Populates:
+;   $1 = Win32 result code (0 = value exists and was queried successfully)
+;   $2 = registry value type   (only meaningful when $1 == 0)
+;   $3 = value size in bytes   (only meaningful when $1 == 0)
+; $1 is the ONLY thing callers may branch on to decide whether the value
+; exists — and only a literal ${AJH_ERROR_FILE_NOT_FOUND} counts as a
+; *confirmed* absence. Anything else non-zero (a real permissions error, an
+; unexpected Win32 code, or — if a future edit typos an export name —
+; System::Call's own "error" string sentinel, which is neither 0 nor a
+; small integer) must be treated as "unknown", never as "absent": the
+; install-side hook creates a fresh PATH value when absence is confirmed,
+; and confusing "unknown" with "absent" there means overwriting the user's
+; entire PATH with just $INSTDIR. Only ever opens the key for
+; KEY_QUERY_VALUE, never for write, so it cannot itself corrupt anything.
 ; ---------------------------------------------------------------------------
-!macro AJH_QueryPathType
+!macro AJH_QueryPathTypeAndSize
   System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_QUERY_VALUE}, *i .r0) i .r1'
   ${If} $1 == 0
-    System::Call 'Advapi32::RegQueryValueExW(i r0, w "${AJH_PATH_REGVALUE}", i 0, *i .r2, i 0, i 0) i .r1'
+    System::Call 'Advapi32::RegQueryValueExW(i r0, w "${AJH_PATH_REGVALUE}", i 0, *i .r2, i 0, *i .r3) i .r1'
     System::Call 'Advapi32::RegCloseKey(i r0)'
   ${EndIf}
 !macroend
@@ -108,12 +124,16 @@ ${Using:StrFunc} StrLoc  ; no-op if the outer installer.nsi already did this (it
   Push $5
   Push $6
   Push $7
+  Push $8
+  Push $9
 
-  !insertmacro AJH_QueryPathType
+  StrCpy $1 "" ; unknown until proven otherwise — see AJH_QueryPathTypeAndSize
+  !insertmacro AJH_QueryPathTypeAndSize
 
-  ${If} $1 != 0
-    ; No existing Path value (or the Environment key itself is new): create
-    ; a fresh single-entry value. REG_EXPAND_SZ matches what Windows itself
+  ${If} $1 == ${AJH_ERROR_FILE_NOT_FOUND}
+    ; Positively confirmed absent (missing key or missing value): safe to
+    ; create. $INSTDIR is always short, so this is the one place a plain
+    ; NSIS string write is fine. REG_EXPAND_SZ matches what Windows itself
     ; writes for a brand-new per-user PATH.
     ClearErrors
     WriteRegExpandStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" "$INSTDIR"
@@ -126,67 +146,86 @@ ${Using:StrFunc} StrLoc  ; no-op if the outer installer.nsi already did this (it
     Goto ajh_addpath_done
   ${EndIf}
 
+  ${If} $1 != 0
+    ; Not a confirmed absence — do nothing rather than guess (see the macro
+    ; doc comment above for why this must never fall through to "create").
+    DetailPrint "ajh: could not determine whether a per-user PATH value exists; leaving it untouched"
+    Goto ajh_addpath_done
+  ${EndIf}
+
   ${If} $2 != ${AJH_REG_SZ}
   ${AndIf} $2 != ${AJH_REG_EXPAND_SZ}
     DetailPrint "ajh: per-user PATH has an unexpected registry type; leaving it untouched"
     Goto ajh_addpath_done
   ${EndIf}
 
-  ClearErrors
-  ReadRegStr $3 HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}"
-  ${If} ${Errors}
-    DetailPrint "ajh: could not read the existing per-user PATH; leaving it untouched"
+  ; From here: the value exists, type is SZ/EXPAND_SZ ($2), size is $3 bytes
+  ; (including its NUL). Build padBuf ($4) = ';' + <value> + ';' + NUL in
+  ; raw memory, so a single substring search proves *whole-segment*
+  ; membership — a sibling directory sharing our prefix (e.g.
+  ; "...\AI Job HunterX") cannot match ";$INSTDIR;". $3 bytes already
+  ; include the value's own NUL, so padBuf needs exactly $3+4 bytes (one
+  ; ';' added on each side, reusing the space the original NUL occupied).
+  IntOp $0 $3 + 4
+  System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r0) i .r4'
+  System::Call 'Kernel32::lstrcpyW(i r4, w ";") i .r1'
+
+  IntOp $0 $4 + 2
+  System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_QUERY_VALUE}, *i .r5) i .r1'
+  System::Call 'Advapi32::RegQueryValueExW(i r5, w "${AJH_PATH_REGVALUE}", i 0, i 0, i r0, *i r3) i .r1'
+  System::Call 'Advapi32::RegCloseKey(i r5)'
+  ${If} $1 != 0
+    DetailPrint "ajh: could not re-read the per-user PATH; leaving it untouched"
+    System::Call 'Kernel32::GlobalFree(i r4)'
     Goto ajh_addpath_done
   ${EndIf}
 
-  StrLen $4 $3
-  ${If} $4 >= ${AJH_PATH_TRUNCATION_GUARD}
-    DetailPrint "ajh: per-user PATH is at NSIS's string-length limit and may already be truncated; leaving it untouched"
-    Goto ajh_addpath_done
-  ${EndIf}
+  ; Overwrite the value's own NUL (now sitting at padBuf+$3) with the
+  ; trailing pad ';', then a fresh NUL right after — both fit in the extra
+  ; 4 bytes allocated above.
+  IntOp $0 $4 + $3
+  System::Call 'Kernel32::lstrcpyW(i r0, w ";") i .r5'
 
-  ; Idempotency: match $INSTDIR as a whole ';'-delimited segment, not a
-  ; substring. Padding both sides with ';' turns this into a plain substring
-  ; search that cannot false-match a sibling directory sharing our prefix
-  ; (e.g. "...\AI Job HunterX" must not count as already present).
-  StrCpy $5 ";$3;"
-  ${StrLoc} $6 $5 ";$INSTDIR;" ">"
-  ${If} $6 != ""
+  ; Whole-segment membership check (idempotency).
+  System::Call 'Shlwapi::StrStrW(i r4, w ";$INSTDIR;") i .r5'
+  ${If} $5 != 0
     DetailPrint "ajh: agent CLI directory is already on the per-user PATH"
+    System::Call 'Kernel32::GlobalFree(i r4)'
     Goto ajh_addpath_done
   ${EndIf}
 
-  ; The appended result must also stay inside the same budget, for the same
-  ; truncation reason as above.
-  StrLen $6 "$INSTDIR"
-  IntOp $6 $6 + 1 ; the separator we're about to add
-  IntOp $6 $6 + $4
-  ${If} $6 >= ${AJH_PATH_APPEND_BUDGET}
-    DetailPrint "ajh: appending to the per-user PATH would approach NSIS's string-length limit; leaving it untouched"
-    Goto ajh_addpath_done
-  ${EndIf}
+  ; Not present: build newBuf ($7) = <original value> + ';' + $INSTDIR + NUL.
+  StrLen $6 ";$INSTDIR"
+  IntOp $6 $6 + 1
+  IntOp $6 $6 * 2
+  IntOp $0 $3 - 2
+  IntOp $6 $6 + $0                ; $6 = newBytes
 
-  StrCpy $7 $3 1 -1
-  ${If} $7 == ";"
-    StrCpy $5 "$3$INSTDIR"
-  ${Else}
-    StrCpy $5 "$3;$INSTDIR"
-  ${EndIf}
+  System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r6) i .r7'
+  IntOp $0 $4 + 2                 ; original value starts right after the leading pad
+  IntOp $8 $3 - 2                 ; its length in bytes, excluding its own NUL
+  System::Call 'Kernel32::RtlMoveMemory(i r7, i r0, i r8)'
+  IntOp $0 $7 + $8
+  System::Call 'Kernel32::lstrcpyW(i r0, w ";$INSTDIR") i .r5'
 
   ClearErrors
-  ${If} $2 == ${AJH_REG_EXPAND_SZ}
-    WriteRegExpandStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
-  ${Else}
-    WriteRegStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
+  System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_SET_VALUE}, *i .r0) i .r1'
+  ${If} $1 == 0
+    System::Call 'Advapi32::RegSetValueExW(i r0, w "${AJH_PATH_REGVALUE}", i 0, i r2, i r7, i r6) i .r1'
+    System::Call 'Advapi32::RegCloseKey(i r0)'
   ${EndIf}
-  ${IfNot} ${Errors}
+  ${If} $1 == 0
     DetailPrint "ajh: added the agent CLI directory to the per-user PATH"
     !insertmacro AJH_BroadcastEnvironmentChange
   ${Else}
     DetailPrint "ajh: failed to update the per-user PATH; leaving it untouched"
   ${EndIf}
+  System::Call 'Kernel32::GlobalFree(i r7)'
+  System::Call 'Kernel32::GlobalFree(i r4)'
 
   ajh_addpath_done:
+  Pop $9
+  Pop $8
   Pop $7
   Pop $6
   Pop $5
@@ -206,10 +245,16 @@ ${Using:StrFunc} StrLoc  ; no-op if the outer installer.nsi already did this (it
   Push $5
   Push $6
   Push $7
+  Push $8
+  Push $9
 
-  !insertmacro AJH_QueryPathType
+  StrCpy $1 ""
+  !insertmacro AJH_QueryPathTypeAndSize
 
   ${If} $1 != 0
+    ; Either confirmed absent (${AJH_ERROR_FILE_NOT_FOUND}) or unknown (any
+    ; other code) — unlike install, both cases are safe to treat the same
+    ; way here: skipping a cleanup never destroys anything.
     DetailPrint "ajh: no per-user PATH value to clean up"
     Goto ajh_rmpath_done
   ${EndIf}
@@ -220,66 +265,96 @@ ${Using:StrFunc} StrLoc  ; no-op if the outer installer.nsi already did this (it
     Goto ajh_rmpath_done
   ${EndIf}
 
-  ClearErrors
-  ReadRegStr $3 HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}"
-  ${If} ${Errors}
-    DetailPrint "ajh: could not read the existing per-user PATH; leaving it untouched"
+  ; padBuf ($4), built the same way as install — see NSIS_HOOK_POSTINSTALL
+  ; for the full rationale on why this goes through raw memory.
+  IntOp $0 $3 + 4
+  System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r0) i .r4'
+  System::Call 'Kernel32::lstrcpyW(i r4, w ";") i .r1'
+  IntOp $0 $4 + 2
+  System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_QUERY_VALUE}, *i .r5) i .r1'
+  System::Call 'Advapi32::RegQueryValueExW(i r5, w "${AJH_PATH_REGVALUE}", i 0, i 0, i r0, *i r3) i .r1'
+  System::Call 'Advapi32::RegCloseKey(i r5)'
+  ${If} $1 != 0
+    DetailPrint "ajh: could not re-read the per-user PATH; leaving it untouched"
+    System::Call 'Kernel32::GlobalFree(i r4)'
     Goto ajh_rmpath_done
   ${EndIf}
+  IntOp $0 $4 + $3
+  System::Call 'Kernel32::lstrcpyW(i r0, w ";") i .r5'
 
-  StrLen $4 $3
-  ${If} $4 >= ${AJH_PATH_TRUNCATION_GUARD}
-    ; Same truncation risk as the install-time guard: a value read this
-    ; close to NSIS's cap may already be an incomplete copy, so rewriting
-    ; anything derived from it could drop entries that never made it in.
-    DetailPrint "ajh: per-user PATH is at NSIS's string-length limit and may already be truncated; leaving it untouched"
-    Goto ajh_rmpath_done
-  ${EndIf}
-
-  ; Same padded-segment search as install; the match's start offset ($6)
-  ; lets us splice the entry out including exactly the one delimiter on
-  ; each side it owns, never a neighbour's.
-  StrCpy $5 ";$3;"
-  ${StrLoc} $6 $5 ";$INSTDIR;" ">"
-  ${If} $6 == ""
+  System::Call 'Shlwapi::StrStrW(i r4, w ";$INSTDIR;") i .r5'
+  ${If} $5 == 0
     DetailPrint "ajh: agent CLI directory is not on the per-user PATH; nothing to remove"
+    System::Call 'Kernel32::GlobalFree(i r4)'
     Goto ajh_rmpath_done
   ${EndIf}
 
-  StrCpy $7 $5 $6 ; everything before the match, still ';'-prefixed (or empty)
-  ${If} $7 != ""
-    StrCpy $7 $7 "" 1 ; drop the leading ';' that isn't ours to keep
+  ; Splice out exactly our segment plus the one delimiter it owns on each
+  ; side. $6 (prefixLen) and $7 (suffixLen) legitimately come out as 0 when
+  ; our entry is first/last/only — the two ${If}/clamp pairs below exist
+  ; *because* the naive formula goes negative in exactly those cases (a
+  ; negative length handed to RtlMoveMemory is a huge unsigned count and
+  ; crashes the uninstaller). $1 (suffixPtr) must stay live and unclobbered
+  ; all the way to the final RtlMoveMemory call below — an earlier version
+  ; of this file reused $1 as the throwaway output register for the
+  ; separator write two steps later, which silently corrupted every removal
+  ; except when the removed entry was last; $5 is the correct throwaway
+  ; there instead, since matchPtr is never read again after this point.
+  StrLen $0 ";$INSTDIR;"
+  IntOp $0 $0 * 2                  ; $0 = needleBytes
+
+  IntOp $6 $5 - $4                 ; raw offset of the match from padBuf's start
+  ${If} $6 > 0
+    IntOp $6 $6 - 2                ; drop the leading pad ';' -> prefixLen
+  ${EndIf}                          ; ($6 stays 0 when our entry is first)
+
+  IntOp $1 $5 + $0                 ; $1 = suffixPtr
+  IntOp $9 $4 + $3                 ; original NUL position (= end of real content)
+  IntOp $7 $9 - $1                 ; raw suffixLen
+  ${If} $7 < 0
+    StrCpy $7 0                    ; our entry was last: nothing legitimate follows
   ${EndIf}
 
-  StrLen $4 ";$INSTDIR;"
-  IntOp $4 $6 + $4
-  StrCpy $3 $5 "" $4 ; everything after the match, still ';'-suffixed (or empty)
-  ${If} $3 != ""
-    StrCpy $3 $3 -1 ; drop the trailing ';' that isn't ours to keep
+  IntOp $9 $6 + $7
+  ${If} $6 > 0
+  ${AndIf} $7 > 0
+    IntOp $9 $9 + 2                 ; a separator is only needed between two real neighbours
+  ${EndIf}
+  IntOp $9 $9 + 2                   ; NUL terminator
+
+  System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r9) i .r8'
+
+  IntOp $0 $4 + 2
+  System::Call 'Kernel32::RtlMoveMemory(i r8, i r0, i r6)'
+  IntOp $0 $8 + $6
+
+  ${If} $6 > 0
+  ${AndIf} $7 > 0
+    System::Call 'Kernel32::lstrcpyW(i r0, w ";") i .r5'
+    IntOp $0 $0 + 2
   ${EndIf}
 
-  ${If} $7 == ""
-    StrCpy $5 $3
-  ${ElseIf} $3 == ""
-    StrCpy $5 $7
-  ${Else}
-    StrCpy $5 "$7;$3"
-  ${EndIf}
+  System::Call 'Kernel32::RtlMoveMemory(i r0, i r1, i r7)'
 
   ClearErrors
-  ${If} $2 == ${AJH_REG_EXPAND_SZ}
-    WriteRegExpandStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
-  ${Else}
-    WriteRegStr HKCU "${AJH_PATH_REGKEY}" "${AJH_PATH_REGVALUE}" $5
+  System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_SET_VALUE}, *i .r0) i .r1'
+  ${If} $1 == 0
+    System::Call 'Advapi32::RegSetValueExW(i r0, w "${AJH_PATH_REGVALUE}", i 0, i r2, i r8, i r9) i .r1'
+    System::Call 'Advapi32::RegCloseKey(i r0)'
   ${EndIf}
-  ${IfNot} ${Errors}
+  ${If} $1 == 0
     DetailPrint "ajh: removed the agent CLI directory from the per-user PATH"
     !insertmacro AJH_BroadcastEnvironmentChange
   ${Else}
     DetailPrint "ajh: failed to update the per-user PATH; leaving it untouched"
   ${EndIf}
 
+  System::Call 'Kernel32::GlobalFree(i r8)'
+  System::Call 'Kernel32::GlobalFree(i r4)'
+
   ajh_rmpath_done:
+  Pop $9
+  Pop $8
   Pop $7
   Pop $6
   Pop $5

--- a/apps/desktop/src-tauri/windows/hooks.nsh
+++ b/apps/desktop/src-tauri/windows/hooks.nsh
@@ -40,13 +40,44 @@
 ; empty string — so that failure mode was never the risk. The real problem
 ; is narrower but unavoidable: our own working copy of the value (padded,
 ; searched, and rebuilt with the new entry) would itself be truncated the
-; moment it has to live in a $var, corrupting whatever didn't fit the moment
-; it gets written back. So neither the read nor the write ever puts the
-; PATH value in an NSIS variable: both go through `System::Call` against
+; moment it has to live in a $var, corrupting whatever did not fit the
+; moment it gets written back. So neither the read nor the write ever puts
+; the PATH value in an NSIS variable: both go through `System::Call` against
 ; raw, `GlobalAlloc`-backed memory (`Advapi32::RegQueryValueExW` /
 ; `RegSetValueExW`, with `Shlwapi::StrStrW` for the substring search), which
 ; has no such cap. Only short, fixed-size things ($INSTDIR, the literal
 ; separator) ever pass through a plain NSIS string.
+;
+; BUFFER SAFETY GATE — read this before touching either macro below.
+; Every length or pointer that reaches `RtlMoveMemory`/`lstrcpyW` is a
+; potential crash (0xC0000005) if it is wrong, because those Win32 calls
+; take no bounds and a bad value is either a huge unsigned copy count or a
+; null pointer dereference. Three independent things can produce a bad
+; value here, and both macros guard all three the same way, at the same
+; points, rather than patching each as a one-off:
+;   1. `$3` (the value's byte size from RegQueryValueExW) must be large
+;      enough that `$3 - 2` cannot go negative. A Win32 value can legally
+;      have `cbData == 0` (no data at all, not even a NUL) via a stock
+;      `RegSetValueExW` call, and NSIS's `IntOp` has no notion of this
+;      being invalid — it just produces a negative number that, handed to
+;      `RtlMoveMemory`'s length parameter, gets reinterpreted as ~4 billion
+;      bytes. Guarded once, immediately after the type check, before any
+;      arithmetic on `$3` begins.
+;   2. `GlobalAlloc` can return NULL (0) under real memory pressure, and a
+;      null pointer handed to `lstrcpyW`/`RtlMoveMemory` as the destination
+;      or source crashes immediately. Guarded after every `GlobalAlloc`
+;      call (four call sites, two per macro) — the second one in each macro
+;      also frees the first buffer before bailing, since it has already
+;      been allocated.
+;   3. `System::Call` writes the literal string `"error"` (not a number)
+;      into an output register when it cannot resolve the export it was
+;      asked for. Comparing such a register with `==`/`!=` (LogicLib's
+;      string comparison) can silently treat "error" as if it were a valid
+;      pointer or "not found" sentinel, depending on which side of the
+;      comparison it lands on. Every register that participates in pointer
+;      arithmetic below is compared with a numeric operator (`>`/`<=`),
+;      under which `IntCmp` parses a non-numeric string as 0 — landing it
+;      in whichever branch treats "nothing was found here" as safe.
 ; ---------------------------------------------------------------------------
 
 !ifndef AJH_PATH_HOOKS_INCLUDED
@@ -82,6 +113,13 @@
 ; plus a NUL, and relies on that final NUL already being zero rather than
 ; writing it explicitly.
 !define AJH_GPTR 0x0040
+
+; The smallest legal RegQueryValueExW size for a value we are willing to
+; edit: a lone NUL is 2 bytes (an empty existing PATH), so 4 bytes is
+; already one full character above that floor. See the BUFFER SAFETY GATE
+; note above — this exists specifically to keep `$3 - 2` non-negative
+; everywhere below.
+!define AJH_MIN_VALUE_BYTES 4
 
 ; ---------------------------------------------------------------------------
 ; Shared: query the current value's type and byte size (including its
@@ -159,6 +197,14 @@
     Goto ajh_addpath_done
   ${EndIf}
 
+  ; Buffer safety gate, step 1 (see the file-level note above): a value
+  ; this small cannot survive the "$3 - 2" arithmetic further down without
+  ; going negative.
+  ${If} $3 < ${AJH_MIN_VALUE_BYTES}
+    DetailPrint "ajh: per-user PATH value has an unexpected size; leaving it untouched"
+    Goto ajh_addpath_done
+  ${EndIf}
+
   ; From here: the value exists, type is SZ/EXPAND_SZ ($2), size is $3 bytes
   ; (including its NUL). Build padBuf ($4) = ';' + <value> + ';' + NUL in
   ; raw memory, so a single substring search proves *whole-segment*
@@ -168,6 +214,12 @@
   ; ';' added on each side, reusing the space the original NUL occupied).
   IntOp $0 $3 + 4
   System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r0) i .r4'
+  ${If} $4 == 0
+    ; Buffer safety gate, step 2: out of memory or similar — bail rather
+    ; than hand a null pointer to lstrcpyW.
+    DetailPrint "ajh: could not allocate memory to edit the per-user PATH; leaving it untouched"
+    Goto ajh_addpath_done
+  ${EndIf}
   System::Call 'Kernel32::lstrcpyW(i r4, w ";") i .r1'
 
   IntOp $0 $4 + 2
@@ -180,33 +232,65 @@
     Goto ajh_addpath_done
   ${EndIf}
 
+  ; Does the existing value already end with ';'? Read just the last real
+  ; character: it is still followed by the value's OWN (not yet
+  ; overwritten) NUL at this point, so lstrcpyW stops after exactly one
+  ; character. $9 is unused everywhere else in this macro, so the flag
+  ; survives untouched all the way to the append below. This must happen
+  ; before the next step overwrites that NUL.
+  IntOp $0 $4 + $3
+  IntOp $0 $0 - 2
+  System::Call 'Kernel32::lstrcpyW(t .r6, i r0) i .r1'
+  StrCpy $9 0
+  ${If} $6 == ";"
+    StrCpy $9 1
+  ${EndIf}
+
   ; Overwrite the value's own NUL (now sitting at padBuf+$3) with the
   ; trailing pad ';', then a fresh NUL right after — both fit in the extra
   ; 4 bytes allocated above.
   IntOp $0 $4 + $3
   System::Call 'Kernel32::lstrcpyW(i r0, w ";") i .r5'
 
-  ; Whole-segment membership check (idempotency).
+  ; Whole-segment membership check (idempotency). `>` is numeric (IntCmp),
+  ; so a "error" resolution-failure sentinel parses as 0 here and takes the
+  ; same branch as "not found" — see the BUFFER SAFETY GATE note, point 3.
   System::Call 'Shlwapi::StrStrW(i r4, w ";$INSTDIR;") i .r5'
-  ${If} $5 != 0
+  ${If} $5 > 0
     DetailPrint "ajh: agent CLI directory is already on the per-user PATH"
     System::Call 'Kernel32::GlobalFree(i r4)'
     Goto ajh_addpath_done
   ${EndIf}
 
-  ; Not present: build newBuf ($7) = <original value> + ';' + $INSTDIR + NUL.
-  StrLen $6 ";$INSTDIR"
-  IntOp $6 $6 + 1
+  ; Not present: build newBuf ($7) = <original value> [+ ';'] + $INSTDIR +
+  ; NUL — the separator is skipped when the value already ends with ';'
+  ; ($9, computed above), so a value that already ends in ';' does not gain
+  ; a doubled one.
+  StrLen $6 "$INSTDIR"
+  ${If} $9 == 1
+    IntOp $6 $6 + 1                ; INSTDIR + NUL only
+  ${Else}
+    IntOp $6 $6 + 2                ; ';' + INSTDIR + NUL
+  ${EndIf}
   IntOp $6 $6 * 2
   IntOp $0 $3 - 2
   IntOp $6 $6 + $0                ; $6 = newBytes
 
   System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r6) i .r7'
+  ${If} $7 == 0
+    DetailPrint "ajh: could not allocate memory to edit the per-user PATH; leaving it untouched"
+    System::Call 'Kernel32::GlobalFree(i r4)'
+    Goto ajh_addpath_done
+  ${EndIf}
   IntOp $0 $4 + 2                 ; original value starts right after the leading pad
   IntOp $8 $3 - 2                 ; its length in bytes, excluding its own NUL
   System::Call 'Kernel32::RtlMoveMemory(i r7, i r0, i r8)'
   IntOp $0 $7 + $8
-  System::Call 'Kernel32::lstrcpyW(i r0, w ";$INSTDIR") i .r5'
+  ${If} $9 == 1
+    System::Call 'Kernel32::lstrcpyW(i r0, w "$INSTDIR") i .r5'
+  ${Else}
+    System::Call 'Kernel32::lstrcpyW(i r0, w ";$INSTDIR") i .r5'
+  ${EndIf}
 
   ClearErrors
   System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_SET_VALUE}, *i .r0) i .r1'
@@ -265,10 +349,23 @@
     Goto ajh_rmpath_done
   ${EndIf}
 
+  ; Buffer safety gate, step 1 — see NSIS_HOOK_POSTINSTALL and the
+  ; file-level BUFFER SAFETY GATE note for why this is needed before any
+  ; arithmetic on $3 begins.
+  ${If} $3 < ${AJH_MIN_VALUE_BYTES}
+    DetailPrint "ajh: per-user PATH value has an unexpected size; leaving it untouched"
+    Goto ajh_rmpath_done
+  ${EndIf}
+
   ; padBuf ($4), built the same way as install — see NSIS_HOOK_POSTINSTALL
   ; for the full rationale on why this goes through raw memory.
   IntOp $0 $3 + 4
   System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r0) i .r4'
+  ${If} $4 == 0
+    ; Buffer safety gate, step 2 — see NSIS_HOOK_POSTINSTALL.
+    DetailPrint "ajh: could not allocate memory to edit the per-user PATH; leaving it untouched"
+    Goto ajh_rmpath_done
+  ${EndIf}
   System::Call 'Kernel32::lstrcpyW(i r4, w ";") i .r1'
   IntOp $0 $4 + 2
   System::Call 'Advapi32::RegOpenKeyExW(i ${HKEY_CURRENT_USER}, w "${AJH_PATH_REGKEY}", i 0, i ${AJH_KEY_QUERY_VALUE}, *i .r5) i .r1'
@@ -282,8 +379,13 @@
   IntOp $0 $4 + $3
   System::Call 'Kernel32::lstrcpyW(i r0, w ";") i .r5'
 
+  ; `<=` is numeric (IntCmp), so a "error" resolution-failure sentinel
+  ; parses as 0 and takes this same "nothing to do" branch as a genuine
+  ; not-found — see the BUFFER SAFETY GATE note, point 3. A string `== 0`
+  ; check here would let "error" fall through into the splice arithmetic
+  ; below with $5 read as a null pointer.
   System::Call 'Shlwapi::StrStrW(i r4, w ";$INSTDIR;") i .r5'
-  ${If} $5 == 0
+  ${If} $5 <= 0
     DetailPrint "ajh: agent CLI directory is not on the per-user PATH; nothing to remove"
     System::Call 'Kernel32::GlobalFree(i r4)'
     Goto ajh_rmpath_done
@@ -323,6 +425,11 @@
   IntOp $9 $9 + 2                   ; NUL terminator
 
   System::Call 'Kernel32::GlobalAlloc(i ${AJH_GPTR}, i r9) i .r8'
+  ${If} $8 == 0
+    DetailPrint "ajh: could not allocate memory to edit the per-user PATH; leaving it untouched"
+    System::Call 'Kernel32::GlobalFree(i r4)'
+    Goto ajh_rmpath_done
+  ${EndIf}
 
   IntOp $0 $4 + 2
   System::Call 'Kernel32::RtlMoveMemory(i r8, i r0, i r6)'

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -38,6 +38,7 @@ Read the minimum; **stop at ~90% confidence**.
 | [event-system.md](event-system.md)                               | Centralized one-way Tauri push-event channels (`app.emit`), colon-namespaced wire names, and the `IPC_CHANNELS` complement |
 | [notification-center.md](notification-center.md)                 | Persisted notification store, `AppNotification` type, Titlebar bell inbox, and route-intent dispatch                       |
 | [ui-theming-accent.md](ui-theming-accent.md)                     | Runtime theme engine and customizable accent-color system (CSS vars, ThemeId, accent tokens)                               |
+| [agent-cli.md](agent-cli.md)                                     | CLI mode of the shipped binary (`ajh-tauri agent <verb>`): invocation, exit codes, error sentinels, binary locations       |
 | [decision-records/](decision-records/)                           | ADRs (maintained by `project-steward`) — see table below                                                                   |
 
 ## Decision records index

--- a/docs/knowledge/agent-cli.md
+++ b/docs/knowledge/agent-cli.md
@@ -1,0 +1,61 @@
+# Agent CLI (`ajh-tauri agent <verb>`)
+
+Last updated: 2026-09-01
+
+A headless CLI mode of the shipped `ajh-tauri` binary, invoked alongside the running desktop app. Enables external programs (shell scripts, LLM agents, CI pipelines) to query job data, profile fields, and trigger commands without a GUI. The same binary, no separate install.
+
+## Invocation
+
+```bash
+ajh-tauri agent <verb> [args]
+```
+
+Run `ajh-tauri agent --help` to see the full verb list, argument patterns, and exit codes. `--help` works even if the app is not running.
+
+All verbs except `--help` require **the desktop app to be running**. Replies are always JSON on stdout, whether success or failure.
+
+## Exit codes
+
+Exit codes distinguish four outcomes (see `ajh-tauri agent --help` for the full contract):
+
+- **0** — Success; `{"ok":true,...}` returned
+- **1** — App refused the command (rate-limited, validation error, autofill off, etc.); error details in JSON on stdout
+- **2** — Round trip failed (app not running, bad CLI usage, connection error) or protocol issue
+- **4** — `call` verb only: an `Effect::Irreversible` command needs `--confirm '<value>'`; reply's `detail` field names which **other read command** to call first for the proof value (ADR-038 §4)
+
+The `error` field in exit-code-2 replies carries a fixed sentinel (not a path, URL, or echoed input). A `detail` field may also be present with additional context (e.g., the specific validation error). Full sentinel list in `ajh-tauri agent --help`.
+
+## Binary locations (v0.145.0+)
+
+| Platform                     | Path                                                                                      | On `PATH` by default?            |
+| ---------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------- |
+| **Linux** (deb/rpm)          | `/usr/bin/ajh-tauri`                                                                      | Yes                              |
+| **macOS Homebrew**           | Symlinked via `brew install --cask ai-job-hunter`                                         | Yes                              |
+| **macOS dmg drag-install**   | `/Applications/AI Job Hunter.app/Contents/MacOS/ajh-tauri`                                | No; add to `$PATH` if needed     |
+| **Windows** (nsis, per-user) | User's local install directory (use `~/.ajh-agent/agent.json` to locate programmatically) | Not on PATH; invoke by full path |
+
+## Discovery
+
+A program can locate the app's binary and data directory via the pointer file:
+
+```json
+~/.ajh-agent/agent.json
+{ "exePath": "/path/to/ajh-tauri", "dataDir": "/path/to/app-data" }
+```
+
+Written by the app on every launch (idempotent). This is the supported mechanism for automated discovery.
+
+## Design & constraints
+
+- **Mode, not binary**: The CLI is an argv mode of the shipped `ajh-tauri` executable, detected by the first post-binary token being exactly `agent`. It short-circuits before the GUI or single-instance plugin, and exits cleanly.
+- **Authentication**: Uses the same loopback WebSocket bridge as the browser extension, with mutual HMAC challenge-response. The pairing token is used only as an HMAC key and is never sent on the wire; both clients reuse the same OS-stored credential.
+- **Policy table**: The `call` verb is a generic tier that respects per-command `Effect` classification (Read, Reversible, Irreversible). Irreversible commands require a `--confirm` proof value read from a separate command first (ADR-038 §4). The curated verbs are a separate, simpler tier that predates it.
+- **Timeout discipline**: Per-step budgets (handshake, query) + an outer invocation deadline prevent hung/squatting ports from stalling the entire call.
+- **Privacy**: The `error` field is always a fixed sentinel from a closed set; paths and pairing tokens never appear in any reply. A `detail` field may be present with human-readable context (e.g., validation errors). Safe for use in LLM agent transcripts.
+
+## See also
+
+- [ADR-037](decision-records/adr-037-agent-cli-as-binary-mode-thin-client.md) — Design rationale (binary mode, loopback bridge, authentication)
+- [ADR-038](decision-records/adr-038-agent-cli-full-parity-two-tier.md) — Full policy table and command-dispatch tiers (curated vs. generic)
+- `apps/desktop/src-tauri/src/extension_bridge/agent_cli.rs` — Client implementation (verb parsing, exit codes, error sentinels)
+- `apps/desktop/src-tauri/src/extension_bridge/agent_call.rs` — Server-side dispatch and policy lookup

--- a/docs/knowledge/agent-cli.md
+++ b/docs/knowledge/agent-cli.md
@@ -27,12 +27,12 @@ The `error` field in exit-code-2 replies carries a fixed sentinel (not a path, U
 
 ## Binary locations (v0.145.0+)
 
-| Platform                     | Path                                                                                      | On `PATH` by default?            |
-| ---------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------- |
-| **Linux** (deb/rpm)          | `/usr/bin/ajh-tauri`                                                                      | Yes                              |
-| **macOS Homebrew**           | Symlinked via `brew install --cask ai-job-hunter`                                         | Yes                              |
-| **macOS dmg drag-install**   | `/Applications/AI Job Hunter.app/Contents/MacOS/ajh-tauri`                                | No; add to `$PATH` if needed     |
-| **Windows** (nsis, per-user) | User's local install directory (use `~/.ajh-agent/agent.json` to locate programmatically) | Not on PATH; invoke by full path |
+| Platform                     | Path                                                                                      | On `PATH` by default?                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Linux** (deb/rpm)          | `/usr/bin/ajh-tauri`                                                                      | Yes                                                                                |
+| **macOS Homebrew**           | Symlinked via `brew install --cask ai-job-hunter`                                         | Yes                                                                                |
+| **macOS dmg drag-install**   | `/Applications/AI Job Hunter.app/Contents/MacOS/ajh-tauri`                                | No; add to `$PATH` if needed                                                       |
+| **Windows** (nsis, per-user) | User's local install directory (use `~/.ajh-agent/agent.json` to locate programmatically) | Yes, from the release after v0.145.0 (NSIS hook); before that, invoke by full path |
 
 ## Discovery
 


### PR DESCRIPTION
## Why

ADR-037/ADR-038 shipped a 164-command, effect-classified agent CLI — and no user could invoke it. `ajh-tauri agent` returns "command not found" on a machine where the app is installed, because the binary is only reachable through the `~/.ajh-agent/agent.json` pointer file the app writes for *programs*. There was no human path, and the CLI appeared nowhere in the README, nowhere under `docs/` except `CONTEXT.md`, and nowhere on the landing site. The only landing mention is the `.claude/` development fleet, which a reader will conflate with it.

Same failure shape as a feature shipping dead: built, tested, reviewed, unreachable.

## What

Every platform row below was checked against a **downloaded v0.145.0 artifact**, not inferred — an earlier draft of this work contained two guesses, one of which would have shipped a broken symlink.

| Platform | Before | After |
| --- | --- | --- |
| Linux `.deb` / `.rpm` | already `/usr/bin/ajh-tauri` | unchanged — **no code needed** |
| macOS via Homebrew | not on PATH | `binary` stanza in the cask |
| macOS via dmg drag-install | not on PATH | documented; unchanged |
| Windows `.exe` (nsis) | not on PATH | NSIS `POSTINSTALL`/`POSTUNINSTALL` hook |
| Windows `.msi` | not on PATH | **deliberately unchanged** — see below |
| AppImage | n/a by design | documented |

Plus a README section and `docs/knowledge/agent-cli.md`, which states shape and points at `--help` and the owning symbols rather than copying the verb table, the sentinel list or `max 50` (AGENTS.md rule 17).

### Why the MSI is deliberately untouched

It genuinely lacks a PATH feature (`PathEnvVar` occurs 0 times in the shipped MSI while `INSTALLDIR`/`PATH` strings are readable), and WiX would actually be the *safer* implementation — `<Environment>` handles append and uninstall removal natively with no length ceiling. It is still not worth a second installer surface: floor-adjusted downloads across 73 releases are **122 for the `.exe` against 5 for the `.msi`**, the `.exe` is the primary download button, and it is the only one the updater signs. Revisit if MSI usage grows.

## The Windows hook is the risk-bearing part

PATH is a value whose corruption breaks the user's shell, so every branch is defensive: the value's content never enters an NSIS string variable (`RegQueryValueExW`/`RegSetValueExW` against allocated memory, so there is no 1024-char ceiling), whole-segment `;`-padded matching makes a sibling-prefix directory structurally unable to match, the registry value type is preserved, uninstall splices out exactly our segment and the one delimiter it owns, and every failure path leaves PATH untouched rather than aborting the install. A compile-time guard refuses to build under any `installMode` other than `currentUser`, since the hook hardcodes `HKCU`.

## What review caught

Two rounds of security review, both with the findings *measured* rather than reasoned about — none of these were visible by reading:

- **The uninstaller did not compile.** `${StrLoc}` expands to `Call StrLoc`, and NSIS forbids calling a non-`un.` function from an uninstall section. **PR CI structurally cannot catch this** — it runs `cargo check` and never bundles, so it would have surfaced first in the release job.
- **A failed probe destroyed PATH.** `System::Call` writes the literal string `"error"` into its output register on a resolution failure; `${If} $1 != 0` treated that as "no PATH exists" and replaced the whole value with one entry, then reported success.
- **The feature was a no-op on an ordinary machine.** The original 1016-byte budget refused any PATH longer than that; a developer machine with a 988-char PATH was already over it, so the installer would have silently done nothing while the docs promised otherwise.
- A crash class where a length reached `RtlMoveMemory` without a precondition (zero-length registry value, `GlobalAlloc` returning NULL, an unresolvable `StrStrW`). Data-safe in every case — PATH was untouched in 100% of injected failures — but a crashing installer is still a defect.

The final review re-attacked the splice across 22 shapes including 8 KB values, traced allocation discipline (8 frees against 4 allocations is correct multi-exit cleanup — no double-free, no leak on any `Goto`), and re-derived the offset arithmetic independently rather than trusting the clamps.

## Test plan

Verified locally: both macros compile clean under makensis 3.11 with the install macro in a real `Section Install` **and** the uninstall macro in a real `Section Uninstall`; the `installMode` guard aborts the build when flipped to `perMachine`; the hook was executed against a scratch `HKCU\Software\...` key across absent / `REG_SZ` / `REG_EXPAND_SZ` / `REG_DWORD` values, sibling-prefix directories, re-runs, >1024-char values up to 8 KB, and removal from first/middle/last/only position. The real `HKCU\Environment` was never written.

**Not verified:** no Windows release bundle was produced and installed end-to-end. Before release, on a real install:

1. Fresh install, open a **new** shell, run `ajh-tauri agent --help`.
2. Check `HKCU\Environment\Path` — exactly one entry for the install dir.
3. Re-run the installer (the update path) — still exactly one entry, not two.
4. Uninstall — the entry is gone and the rest of PATH is byte-identical.

macOS: `brew install --cask ai-job-hunter` then `ajh-tauri agent --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
