### PR TITLE
fix: move the nsis installMode guard inside the hook macros

### DIFF
--- a/apps/desktop/src-tauri/windows/hooks.nsh
+++ b/apps/desktop/src-tauri/windows/hooks.nsh
@@ -22,9 +22,15 @@
 ; the installer itself is per-user; under perMachine/both an elevated
 ; installer would run as a different (admin) principal and this would
 ; silently edit *that* account's PATH instead of the real user's.
-!if "${INSTALLMODE}" != "currentUser"
-  !error "windows/hooks.nsh hardcodes HKCU for the per-user PATH and is only safe for bundle.windows.nsis.installMode == currentUser; wire a per-machine (HKLM) path or drop this hook before changing installMode."
-!endif
+; The guard that enforces this lives INSIDE both macros below, NOT here at
+; file scope, and that placement is load-bearing. Tauri's generated
+; installer.nsi does `!include "<this file>"` about ten lines BEFORE it does
+; `!define INSTALLMODE "<mode>"`, so at file-scope include time the symbol is
+; still undefined. NSIS leaves an undefined ${SYMBOL} as literal text, so a
+; file-scope `!if "${INSTALLMODE}" != "currentUser"` is ALWAYS true and aborts
+; every build. The macros expand at their insertion points inside the install
+; and uninstall sections, far below the define, where the value is real.
+; This cost one broken release build -- do not move it back to file scope.
 ;
 ; Tauri's bundled NSIS toolchain does not ship the third-party EnVar plugin,
 ; and the one bundled utility plugin (nsis_tauri_utils) has no PATH-related
@@ -154,6 +160,12 @@
 !macroend
 
 !macro NSIS_HOOK_POSTINSTALL
+  ; See the INSTALLMODE note at the top of this file: this check must live
+  ; inside the macro, because at file-scope include time the symbol is not
+  ; yet defined.
+  !if "${INSTALLMODE}" != "currentUser"
+    !error "windows/hooks.nsh hardcodes HKCU for the per-user PATH and is only safe for bundle.windows.nsis.installMode == currentUser; wire a per-machine (HKLM) path or drop this hook before changing installMode."
+  !endif
   Push $0
   Push $1
   Push $2
@@ -321,6 +333,12 @@
 !macroend
 
 !macro NSIS_HOOK_POSTUNINSTALL
+  ; See the INSTALLMODE note at the top of this file: this check must live
+  ; inside the macro, because at file-scope include time the symbol is not
+  ; yet defined.
+  !if "${INSTALLMODE}" != "currentUser"
+    !error "windows/hooks.nsh hardcodes HKCU for the per-user PATH and is only safe for bundle.windows.nsis.installMode == currentUser; wire a per-machine (HKLM) path or drop this hook before changing installMode."
+  !endif
   Push $0
   Push $1
   Push $2


### PR DESCRIPTION
## The break

The Release workflow failed on `main`: **every Windows bundle aborts**.

```
!error: windows/hooks.nsh hardcodes HKCU for the per-user PATH ...
Error in script installer.nsi -- aborting creation process
failed to bundle project: `Failed to bundle app with makensis`
```

The `installMode` guard added in #1088 is at fault, and it fires unconditionally. Tauri's generated `installer.nsi` does `!include "<hooks file>"` roughly **ten lines before** `!define INSTALLMODE "<mode>"`. At file-scope include time the symbol is therefore undefined, and NSIS leaves an undefined `${SYMBOL}` as literal text — which is never equal to `"currentUser"`, so the `!error` always fires.

## Why it wasn't caught

Both the local verification and the security review compiled against a *reconstruction* of Tauri's template, and both reconstructions defined `INSTALLMODE` **before** including the hook file — the reverse of the real ordering. The guard was the one part of #1088 never exercised against the real generated script, and it is the part that broke. #1088 explicitly listed "no real release bundle was built" as its unverified gap; this is that gap.

Worth noting what this says about the gate: PR CI runs `cargo check` and never bundles, so no PR check can catch an NSIS regression. The Release workflow is the first place it appears — the same structural blind spot the #1088 review flagged for a different defect.

## The fix

Move the check inside both macros. Macros expand at their insertion points inside the install and uninstall sections, far below the define, where the value is real. The reason is recorded at the top of the file so nobody moves it back.

The guard is kept rather than deleted: it is the only thing stopping a future `installMode` change from silently writing an elevating admin's hive instead of the user's.

## Verification

A harness with the **real** ordering — hook included *before* `INSTALLMODE` is defined.

The control matters more than the fix:

| | Result |
| --- | --- |
| Pre-fix file under this harness | **reproduces the exact CI error** — harness is faithful |
| Fixed file | compiles, RC=0 |
| Fixed file, harness flipped to `perMachine` | still aborts — the guard kept its purpose |

Without that first row the harness would prove nothing, which is exactly how the original defect slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
