### PR TITLE
feat: persistent next-step tile on the dashboard

### DIFF
--- a/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
@@ -313,6 +313,14 @@ export function useCanUseAI(): { canUse: boolean; reason?: string } {
   if (isPending) return { canUse: false };
 
   if (kind === 'cloud') {
+    // Same "still checking" convention as the cold-boot branch above, for the
+    // same reason: while the key query is in flight its `data` is `undefined`,
+    // and `?? false` below reads that as a settled "there is no key" — naming
+    // `addApiKey` as the blocker for a question nobody has answered yet.
+    // `ModelSelector` itself already has to work around this with a separate
+    // `activeKeyLoading` (see the comment above it); consumers of this hook
+    // could not, because a reason is indistinguishable from a real answer.
+    if (providerKeyQuery.isPending) return { canUse: false };
     if (!(providerKeyQuery.data?.has ?? false)) return { canUse: false, reason: 'addApiKey' };
     if (!activeProviderModel) return { canUse: false, reason: 'selectModel' };
     return { canUse: true };

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/index.tsx
@@ -321,6 +321,10 @@ export function useCanUseAI(): { canUse: boolean; reason?: string } {
     // `activeKeyLoading` (see the comment above it); consumers of this hook
     // could not, because a reason is indistinguishable from a real answer.
     if (providerKeyQuery.isPending) return { canUse: false };
+    // A REJECTED key query is a failed keyring read, not a settled "no key" — and
+    // `healthUnavailable` ("Couldn't check AI status…") already says exactly that, so
+    // no new reason or translation is needed. Mirrors `healthIsError` below.
+    if (providerKeyQuery.isError) return { canUse: false, reason: 'healthUnavailable' };
     if (!(providerKeyQuery.data?.has ?? false)) return { canUse: false, reason: 'addApiKey' };
     if (!activeProviderModel) return { canUse: false, reason: 'selectModel' };
     return { canUse: true };

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/useCanUseAI.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/useCanUseAI.test.tsx
@@ -197,6 +197,31 @@ describe('useCanUseAI — cloud', () => {
     });
   });
 
+  it('key query REJECTS → "health unavailable", never a false "add an API key"', async () => {
+    // The failure twin of the in-flight case above. A rejected keyring read is
+    // not an answer either: `data` stays `undefined` forever (retries are off),
+    // so `?? false` read the FAILURE as a settled "there is no key" and told a
+    // user who has one to go add one. `healthUnavailable`'s copy ("Couldn't
+    // check AI status. Try again in a moment.") already says exactly this, so
+    // the fix needs no new reason — both consumers already map it.
+    const client = createMockClient({
+      ai: {
+        activeConfig: async () => ({
+          activeProvider: 'openai',
+          providers: { openai: { model: 'gpt-4o' } },
+        }),
+        // Rejects rather than hanging: a model IS configured, so without the
+        // `isError` guard this lands on `addApiKey`, not on a "checking" state.
+        hasProviderKey: () => Promise.reject(new Error('keyring read failed')),
+      },
+      system: { health: async () => readyHealth() },
+    });
+    const { result } = renderHookWithClient(() => useCanUseAI(), { client });
+    await waitFor(() =>
+      expect(result.current).toEqual({ canUse: false, reason: 'healthUnavailable' })
+    );
+  });
+
   it('key stored but no model chosen → blocked with "select a model"', async () => {
     const client = createMockClient({
       ai: {

--- a/apps/desktop/src/renderer/components/ui/ModelSelector/useCanUseAI.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/ModelSelector/useCanUseAI.test.tsx
@@ -167,6 +167,36 @@ describe('useCanUseAI — cloud', () => {
     await waitFor(() => expect(result.current).toEqual({ canUse: false, reason: 'addApiKey' }));
   });
 
+  it('key query still in flight → "checking" (no reason), never a premature "add an API key"', async () => {
+    // The cloud mirror of the local-server "health probe in flight" case
+    // above, and the same class of bug: `providerKeyQuery.data?.has ?? false`
+    // read a not-yet-loaded `undefined` as a settled "there is no key", so
+    // every consumer was handed `addApiKey` — a concrete instruction — for a
+    // question nobody had answered yet. `ModelSelector` had to work around it
+    // locally (`activeKeyLoading`); consumers of the hook could not.
+    const client = createMockClient({
+      ai: {
+        activeConfig: async () => ({
+          activeProvider: 'openai',
+          providers: { openai: { model: 'gpt-4o' } },
+        }),
+        // Never resolves, isolating the window where `useActiveConfig` has
+        // settled and the key status has not.
+        hasProviderKey: () => new Promise<{ has: boolean }>(() => {}),
+      },
+      system: { health: async () => readyHealth() },
+    });
+    const { result, queryClient } = renderHookWithClient(() => useCanUseAI(), { client });
+    // `{ canUse: false }` with no reason is ALSO the first synchronous
+    // render's value (`useActiveConfig`'s own cold-boot branch), so require
+    // that query to have SETTLED in the same assertion — this can only pass
+    // from inside the cloud branch, past the branch that returns it for free.
+    await waitFor(() => {
+      expect(queryClient.getQueryState(['ai', 'activeConfig'])?.status).toBe('success');
+      expect(result.current).toEqual({ canUse: false });
+    });
+  });
+
   it('key stored but no model chosen → blocked with "select a model"', async () => {
     const client = createMockClient({
       ai: {

--- a/apps/desktop/src/renderer/features/dashboard/components/AISystemStatus/AISystemStatus.test.tsx
+++ b/apps/desktop/src/renderer/features/dashboard/components/AISystemStatus/AISystemStatus.test.tsx
@@ -80,9 +80,17 @@ describe('AISystemStatus — AI-model row reads useCanUseAI, not the Ollama-only
     expect(aiDetailText()).toBe(expectedKey);
   });
 
-  it('shows "checking" (not an error) while useActiveConfig is still cold-booting', () => {
+  it('shows "checking" (not an error) while useCanUseAI is still resolving', () => {
     // useCanUseAI's own convention: canUse=false with NO reason means
     // "still resolving" — not "blocked". See its source doc comment.
+    //
+    // Reached by more than the cold-boot config read: a cloud provider whose
+    // KEY query is still in flight also answers reason-less now, so this row
+    // must not print "add an API key" for it. That upstream half is pinned in
+    // `components/ui/ModelSelector/useCanUseAI.test.tsx` (the real hook,
+    // mock-client-backed) — it cannot be pinned here, because this file mocks
+    // `@/components/ui/ModelSelector` wholesale and so no case in it can fail
+    // from a change inside the hook.
     mockCanUseAI = { canUse: false, reason: undefined };
     mockSelectedModel = '';
     render(<AISystemStatus />);

--- a/apps/desktop/src/renderer/features/dashboard/components/Dashboard/index.tsx
+++ b/apps/desktop/src/renderer/features/dashboard/components/Dashboard/index.tsx
@@ -6,6 +6,7 @@ import { ActionTile } from '@ajh/ui';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { AISystemStatus } from '@/features/dashboard/components/AISystemStatus';
 import { JobPipelineOverview } from '@/features/dashboard/components/JobPipelineOverview';
+import { NextStepTile } from '@/features/dashboard/components/NextStepTile';
 import { QUICK_ACTIONS } from '@/features/dashboard/constants';
 import { useUserName } from '@/store/preferences-store';
 
@@ -24,6 +25,10 @@ function Dashboard() {
           title={userName ? `${t('dashboard.welcome')}, ${userName}` : t('dashboard.welcome')}
           subtitle={t('dashboard.subtitle')}
         />
+
+        {/* The one thing to do next — full width, not a fifth quick action:
+            the grid below is 4-up and its stagger classes only go to 4. */}
+        <NextStepTile />
 
         {/* Quick Actions */}
         <div className="mb-8 grid grid-cols-2 gap-4 @2xl:grid-cols-4">

--- a/apps/desktop/src/renderer/features/dashboard/components/JobPipelineOverview/JobPipelineOverview.test.tsx
+++ b/apps/desktop/src/renderer/features/dashboard/components/JobPipelineOverview/JobPipelineOverview.test.tsx
@@ -17,7 +17,12 @@ vi.mock('@ajh/ui', () => ({
   GlassCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
-vi.mock('lucide-react', () => ({
+// Spread the real module rather than listing icons: the allowlist this
+// component filters with now lives in the shared `features/dashboard/constants`
+// module, which also holds the quick-action icons — an exhaustive stub breaks
+// on an icon this component never renders.
+vi.mock('lucide-react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   Bookmark: () => null,
   Briefcase: () => null,
   CheckCircle: () => null,

--- a/apps/desktop/src/renderer/features/dashboard/components/JobPipelineOverview/index.tsx
+++ b/apps/desktop/src/renderer/features/dashboard/components/JobPipelineOverview/index.tsx
@@ -3,16 +3,8 @@ import { Bookmark, Briefcase, CheckCircle, Eye, TrendingUp } from 'lucide-react'
 import { useTranslation } from '@ajh/translations';
 import { GlassCard } from '@ajh/ui';
 
+import { TRACKED_INTERACTION_TYPES } from '@/features/dashboard/constants';
 import { useInteractions } from '@/services';
-
-/**
- * Interaction types that count toward "tracked" in the pipeline overview.
- * An explicit allowlist — not "every type except `dismissed`" — so a future
- * SIXTH interaction type must be deliberately added here before it can
- * silently inflate this headline number. `dismissed` is excluded on purpose:
- * a job the user explicitly rejected was never "tracked".
- */
-const TRACKED_INTERACTION_TYPES = new Set(['viewed', 'opened', 'applied', 'bookmarked']);
 
 export function JobPipelineOverview() {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/features/dashboard/components/NextStepTile/NextStepTile.test.tsx
+++ b/apps/desktop/src/renderer/features/dashboard/components/NextStepTile/NextStepTile.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * The tile's own half of the derivation: turning three service-hook reads into
+ * the three signals, and turning the chosen step into a destination.
+ *
+ * `next-step.test.ts` covers the ordering and counting; what lives HERE is the
+ * mapping the lib can't see — above all the cold-boot rule, that a query with
+ * no data yet is `'pending'` and not "unmet", so a returning user never gets a
+ * flash of "Add your résumé", and its counterpart, that a REJECTED query is
+ * `'unavailable'` and not a silent hidden row.
+ *
+ * Nothing between this component and the backend is stubbed: the real service
+ * hooks and the real `useCanUseAI` run against a mock `AppClient` + a real
+ * `QueryClient` (the `useCanUseAI.test.tsx` pattern). The previous version of
+ * this file mocked `@/services` to `{ data }` literals and `useCanUseAI` to a
+ * fixed object, which made two shipped defects unobservable here: the hook
+ * naming `addApiKey` before its key query had answered, and a `dismissed`
+ * interaction counting as a tracked job.
+ *
+ * `@ajh/ui` and `lucide-react` are deliberately NOT mocked (same as
+ * `AISystemStatus.test.tsx`): the tile's whole output is an `ActionTile`, and a
+ * stub would assert against the stub.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TEST_IDS } from '@ajh/test-ids';
+
+import { createMockClient } from '@/lib/mock-client';
+import { useSessionStore } from '@/store/session-store';
+import { withProviders } from '@/test-support';
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+// Both mocks spread the real module: the un-stubbed service graph below pulls
+// in plenty of other consumers of these packages, and replacing them wholesale
+// would break modules that have nothing to do with this test.
+vi.mock('@ajh/translations', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+  }),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useRouter: () => ({ navigate }),
+}));
+
+import { NextStepTile } from './index';
+
+type ClientOverrides = NonNullable<Parameters<typeof createMockClient>[0]>;
+
+const embeddingStatus = (total: number) => ({
+  active: { provider: 'ollama', model: 'nomic-embed-text' },
+  spaces: [],
+  documents: { total, indexedInActiveSpace: total, stale: 0 },
+  indexing: false,
+});
+
+/** A full interaction row — the contract's eight fields, not just the one. */
+const interaction = (interactionType: string) => ({
+  jobId: `job-${interactionType}`,
+  interactionType,
+  timestamp: 1_700_000_000_000,
+  title: 'Senior Engineer',
+  company: 'ACME',
+  url: 'https://example.test/job',
+  source: 'test',
+  location: 'Remote',
+});
+
+/**
+ * A client where every signal is answered AND met: a cloud provider with a
+ * stored key and a model, one document, one `applied` interaction. Each test
+ * overrides only the namespace it is about.
+ */
+function makeClient(overrides: ClientOverrides = {}) {
+  return createMockClient({
+    ...overrides,
+    ai: {
+      activeConfig: async () => ({
+        activeProvider: 'openai',
+        providers: { openai: { model: 'gpt-4o' } },
+      }),
+      hasProviderKey: async () => ({ has: true }),
+      embeddingStatus: async () => embeddingStatus(1),
+      ...overrides.ai,
+    },
+    scrape: {
+      listInteractions: async () => [interaction('applied')],
+      ...overrides.scrape,
+    },
+  });
+}
+
+function renderTile(overrides: ClientOverrides = {}) {
+  return render(<NextStepTile />, { wrapper: withProviders(makeClient(overrides)) });
+}
+
+/**
+ * Flush everything that CAN settle. After this, a query with no data is one
+ * the test deliberately left unresolved — which is what makes "renders
+ * nothing" an assertion about pending-handling rather than about being early.
+ */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  navigate.mockClear();
+});
+
+describe('NextStepTile', () => {
+  it('renders nothing while a signal query is still unanswered', async () => {
+    const embeddingStatusQuery = vi.fn(() => new Promise<never>(() => {}));
+    const { container } = renderTile({ ai: { embeddingStatus: embeddingStatusQuery } });
+
+    await waitFor(() => expect(embeddingStatusQuery).toHaveBeenCalled());
+    await settle();
+
+    // Cold boot: the documents count never arrives, so the tile must not
+    // advise a returning user to add the résumé they already have.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing while the AI key check is in flight, then the done row once it answers — never the AI step', async () => {
+    // The defect this pins: `useCanUseAI` used to read its not-yet-loaded key
+    // query as a settled "no key" and answer `addApiKey`, so a fully
+    // configured cloud user got a "Connect an AI model" tile on every cold
+    // Dashboard mount, for as long as the key check took.
+    let resolveKey: ((value: { has: boolean }) => void) | undefined;
+    const hasProviderKey = vi.fn(
+      () =>
+        new Promise<{ has: boolean }>((resolve) => {
+          resolveKey = resolve;
+        })
+    );
+    const { container } = renderTile({ ai: { hasProviderKey } });
+
+    // The key query only STARTS once `activeConfig` has resolved (before that
+    // the active provider reads as `ollama`, for which the query is
+    // disabled) — so this also proves the config read is already settled.
+    await waitFor(() => expect(hasProviderKey).toHaveBeenCalled());
+    await settle();
+    expect(container).toBeEmptyDOMElement();
+
+    expect(resolveKey).toBeDefined();
+    await act(async () => {
+      resolveKey?.({ has: true });
+    });
+
+    expect(await screen.findByTestId(TEST_IDS.dashboard.nextStepDone)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.dashboard.nextStepTile)).not.toBeInTheDocument();
+  });
+
+  it('shows a neutral, permanent help row when a signal query REJECTS — never "setup complete", never nothing', async () => {
+    // A rejected query leaves `data` undefined for good. Read as "still
+    // loading" it hid the tile — the app's one always-present route to help —
+    // for the rest of the session.
+    renderTile({
+      scrape: { listInteractions: () => Promise.reject(new Error('interactions unavailable')) },
+    });
+
+    expect(await screen.findByTestId(TEST_IDS.dashboard.nextStepUnavailable)).toBeInTheDocument();
+    expect(screen.getByText('dashboard.nextStep.unavailableTitle')).toBeInTheDocument();
+    // Neither of the two claims the tile is not entitled to make.
+    expect(screen.queryByTestId(TEST_IDS.dashboard.nextStepDone)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.dashboard.nextStepTile)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('dashboard.nextStep.help'));
+    expect(navigate).toHaveBeenCalledWith({ to: '/support' });
+  });
+
+  it('does not count a dismissed posting as a tracked job', async () => {
+    // `useInteractions()` unfiltered includes `dismissed` — the opposite of
+    // tracking, and excluded from the "total tracked" stat rendered inches
+    // away on the same page. A user who has only ever dismissed a posting has
+    // not started their pipeline.
+    renderTile({ scrape: { listInteractions: async () => [interaction('dismissed')] } });
+
+    expect(await screen.findByTestId(TEST_IDS.dashboard.nextStepTile)).toBeInTheDocument();
+    expect(screen.getByText('dashboard.nextStep.job.title')).toBeInTheDocument();
+    expect(screen.getByText(/"done":2.*"total":3/)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.dashboard.nextStepDone)).not.toBeInTheDocument();
+  });
+
+  it('asks for a résumé first, counting the steps already met', async () => {
+    renderTile({ ai: { embeddingStatus: async () => embeddingStatus(0) } });
+
+    expect(await screen.findByTestId(TEST_IDS.dashboard.nextStepTile)).toBeInTheDocument();
+    expect(screen.getByText('dashboard.nextStep.resume.title')).toBeInTheDocument();
+    expect(screen.getByText(/"done":2.*"total":3/)).toBeInTheDocument();
+  });
+
+  it('deep-links the résumé step to the résumé section of Settings', async () => {
+    useSessionStore.getState().setSettings({ activeSection: 'general' });
+    renderTile({ ai: { embeddingStatus: async () => embeddingStatus(0) } });
+
+    await userEvent.click(await screen.findByText('dashboard.nextStep.resume.title'));
+
+    // Navigating alone lands on whatever section was last active, so the store
+    // write is half the destination — assert both.
+    expect(useSessionStore.getState().settings.activeSection).toBe('resume');
+    expect(navigate).toHaveBeenCalledWith({ to: '/settings' });
+  });
+
+  it('describes the AI step with the real block reason, not a generic nudge', async () => {
+    // A cloud provider whose key check ANSWERED "no key" — the settled
+    // counterpart of the in-flight case above.
+    renderTile({ ai: { hasProviderKey: async () => ({ has: false }) } });
+
+    expect(await screen.findByText('dashboard.nextStep.ai.title')).toBeInTheDocument();
+    expect(screen.getByText('aiSetup.addApiKey')).toBeInTheDocument();
+  });
+
+  it('sends the job step to the job board', async () => {
+    renderTile({ scrape: { listInteractions: async () => [] } });
+
+    await userEvent.click(await screen.findByText('dashboard.nextStep.job.title'));
+    expect(navigate).toHaveBeenCalledWith({ to: '/jobs' });
+  });
+
+  it('collapses to a persistent done row — never disappears — with a route to help', async () => {
+    renderTile();
+
+    expect(await screen.findByTestId(TEST_IDS.dashboard.nextStepDone)).toBeInTheDocument();
+    expect(screen.queryByTestId(TEST_IDS.dashboard.nextStepTile)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('dashboard.nextStep.help'));
+    expect(navigate).toHaveBeenCalledWith({ to: '/support' });
+  });
+});

--- a/apps/desktop/src/renderer/features/dashboard/components/NextStepTile/index.tsx
+++ b/apps/desktop/src/renderer/features/dashboard/components/NextStepTile/index.tsx
@@ -1,0 +1,168 @@
+import { Briefcase, CheckCircle2, Cpu, FileText, Info, type LucideIcon } from 'lucide-react';
+import { useRouter } from '@tanstack/react-router';
+
+import { TEST_IDS } from '@ajh/test-ids';
+import { useTranslation } from '@ajh/translations';
+import { ActionTile, Button } from '@ajh/ui';
+
+import { useCanUseAI } from '@/components/ui/ModelSelector';
+import { ROUTES } from '@/constants/routes/routes';
+import { TRACKED_INTERACTION_TYPES } from '@/features/dashboard/constants';
+import {
+  deriveNextStep,
+  type NextStepId,
+  type StepSignal,
+} from '@/features/dashboard/lib/next-step';
+import { useEmbeddingStatus, useInteractions } from '@/services';
+import { useSessionStore } from '@/store/session-store';
+
+const STEP_ICON: Record<NextStepId, LucideIcon> = {
+  resume: FileText,
+  ai: Cpu,
+  job: Briefcase,
+};
+
+/** Mirrors `AiSetupHint`'s `MESSAGE_KEY` — the copy for each `useCanUseAI`
+ *  block reason, reused here so the AI step says which part of setup is
+ *  missing instead of a generic nudge. Duplicated rather than imported: every
+ *  gating call site in the app inlines its own copy of this tiny reason→key
+ *  map (see the same note on `AISystemStatus`). */
+const AI_REASON_KEY: Record<string, string> = {
+  addApiKey: 'aiSetup.addApiKey',
+  selectModel: 'aiSetup.selectModel',
+  installCli: 'aiSetup.installCli',
+  startOllama: 'aiSetup.startOllama',
+  healthUnavailable: 'aiSetup.healthUnavailable',
+};
+
+/**
+ * The one thing to do next, above the quick actions.
+ *
+ * Permanent by design: it collapses to a single line — "setup complete", or a
+ * neutral "can't tell right now" when a signal query failed — rather than
+ * disappearing, so the row never becomes a mystery gap and there is always a
+ * route to help. Nothing is persisted; the three signals are re-derived from
+ * their queries on every mount.
+ */
+export function NextStepTile() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const setSettings = useSessionStore((s) => s.setSettings);
+
+  const { data: embedding, isError: embeddingFailed } = useEmbeddingStatus();
+  const { canUse: aiCanUse, reason: aiReason } = useCanUseAI();
+  const { data: interactions, isError: interactionsFailed } = useInteractions();
+
+  // Three states per signal, never two. `data === undefined` is `'pending'`
+  // (cold boot — the tile stays hidden rather than advising a user to redo
+  // something they already did), a REJECTED query is `'unavailable'` — its
+  // `data` is `undefined` for good, so reading it as "still loading" hid this
+  // row for the rest of the session.
+
+  // Deliberate proxy: a document row carries no `kind`, so "any document
+  // exists" has to stand for "a résumé exists". `documents.total` is the same
+  // count `documents.list()` returns, from a query the root layout already
+  // mounts — without shipping every document's full text in to ask.
+  const hasResume: StepSignal = embeddingFailed
+    ? 'unavailable'
+    : embedding === undefined
+      ? 'pending'
+      : embedding.documents.total > 0;
+
+  // `useCanUseAI` blocks with NO reason while it is still checking (its
+  // documented cold-boot convention); a reason means it has really answered.
+  // It has no `isError` to read and needs none: it turns its own failed reads
+  // into concrete reasons (`healthUnavailable`, `addApiKey`), so unlike a raw
+  // query it can never sit reason-less forever.
+  const aiUsable: StepSignal = aiCanUse ? true : aiReason == null ? 'pending' : false;
+
+  // Interactions ONLY, filtered by the same allowlist the pipeline card counts
+  // with — a `dismissed` posting is the opposite of a tracked one, and the two
+  // surfaces sit inches apart. Applications are deliberately NOT consulted:
+  // `useApplications()` ships every application's full job description onto the
+  // home route to answer one boolean, and the app-global `applications:changed`
+  // listener would re-fetch all of it while the user just sits on the
+  // Dashboard. The cost of leaving it out is that a job tracked by hand or by
+  // the extension, with no interaction row, does not satisfy the step — which
+  // is why the step's copy asks the user to FIND a job (search a board, open a
+  // posting: that is what writes an interaction) and never claims "track".
+  const hasJob: StepSignal = interactionsFailed
+    ? 'unavailable'
+    : interactions === undefined
+      ? 'pending'
+      : (interactions as { interactionType?: string }[]).some((i) =>
+          TRACKED_INTERACTION_TYPES.has(i.interactionType ?? '')
+        );
+
+  const next = deriveNextStep({ resume: hasResume, ai: aiUsable, job: hasJob });
+
+  if (next.kind === 'pending') return null;
+
+  if (next.kind === 'done' || next.kind === 'unavailable') {
+    const settled = next.kind === 'done';
+    return (
+      <div
+        data-testid={
+          settled ? TEST_IDS.dashboard.nextStepDone : TEST_IDS.dashboard.nextStepUnavailable
+        }
+        className="mb-8 flex items-center gap-2 rounded-xl border border-[var(--border-clear)] bg-card px-4 py-2"
+      >
+        {settled ? (
+          <CheckCircle2 size={15} className="shrink-0 text-emerald-400" />
+        ) : (
+          // Neutral, not an alarm: a failed status read is not the user's
+          // problem to fix, and claiming "setup complete" on a question we
+          // could not answer would be worse than either.
+          <Info size={15} className="shrink-0 text-muted-foreground" />
+        )}
+        <span className="min-w-0 flex-1 text-sm text-foreground/70">
+          {t(settled ? 'dashboard.nextStep.doneTitle' : 'dashboard.nextStep.unavailableTitle')}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => void router.navigate({ to: ROUTES.SUPPORT })}
+        >
+          {t('dashboard.nextStep.help')}
+        </Button>
+      </div>
+    );
+  }
+
+  const { step, done, total } = next;
+
+  const openStep = () => {
+    if (step === 'job') {
+      void router.navigate({ to: ROUTES.JOBS });
+      return;
+    }
+    // Exactly how `AiSetupHint` reaches a Settings section: select it in the
+    // session store first, then navigate — the page reads `activeSection` on
+    // mount, so navigating alone would land on `general`.
+    setSettings({ activeSection: step === 'ai' ? 'ai' : 'resume' });
+    void router.navigate({ to: ROUTES.SETTINGS });
+  };
+
+  const description =
+    step === 'ai'
+      ? t(AI_REASON_KEY[aiReason ?? ''] ?? 'dashboard.nextStep.ai.description')
+      : t(`dashboard.nextStep.${step}.description`);
+
+  return (
+    <div className="mb-8" data-testid={TEST_IDS.dashboard.nextStepTile}>
+      <ActionTile
+        icon={STEP_ICON[step]}
+        label={t(`dashboard.nextStep.${step}.title`)}
+        description={description}
+        badge={
+          <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+            {t('dashboard.nextStep.progress', { done, total })}
+          </span>
+        }
+        active
+        className="w-full"
+        onClick={openStep}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/dashboard/constants.ts
+++ b/apps/desktop/src/renderer/features/dashboard/constants.ts
@@ -6,3 +6,17 @@ export const QUICK_ACTIONS = [
   { icon: Briefcase, labelKey: 'nav.jobs', path: '/jobs' },
   { icon: FileText, labelKey: 'nav.documents', path: '/documents' },
 ] as const;
+
+/**
+ * Interaction types that count toward "tracked" on the Dashboard.
+ * An explicit allowlist — not "every type except `dismissed`" — so a future
+ * SIXTH interaction type must be deliberately added here before it can
+ * silently inflate a headline number. `dismissed` is excluded on purpose:
+ * a job the user explicitly rejected was never "tracked".
+ *
+ * Shared by `JobPipelineOverview` (the "total tracked" stat) and `NextStepTile`
+ * (whether the job step is met) so the two cannot disagree about what tracking
+ * means — the tile counted dismissals as progress while the card next to it
+ * said zero.
+ */
+export const TRACKED_INTERACTION_TYPES = new Set(['viewed', 'opened', 'applied', 'bookmarked']);

--- a/apps/desktop/src/renderer/features/dashboard/lib/next-step.test.ts
+++ b/apps/desktop/src/renderer/features/dashboard/lib/next-step.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The Dashboard next-step derivation, and the copy it renders.
+ *
+ * Two halves:
+ *   1. `deriveNextStep` — pending beats everything, the suggestion order, and
+ *      the "done" count being positional-free.
+ *   2. Locale parity — every key the tile passes to `t()` resolves to a
+ *      non-empty string in BOTH bundles. The JSON is imported directly rather
+ *      than through `@ajh/translations`, which initializes i18next with
+ *      `fallbackLng: 'en'` and would answer a missing `de` key with the
+ *      English string (same reasoning as `features/support/support-data.test.ts`).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveNextStep,
+  NEXT_STEP_TEXT_KEYS,
+  type NextStepSignals,
+} from '@/features/dashboard/lib/next-step';
+
+import de from '../../../../../../../packages/translations/src/locales/de/translation.json';
+import en from '../../../../../../../packages/translations/src/locales/en/translation.json';
+
+const BUNDLES: Record<string, unknown> = { en, de };
+
+/**
+ * Written out by hand, not derived from `NEXT_STEP_TEXT_KEYS` — a test that
+ * loops over the constant it guards can only catch ADDITIONS, so deleting a
+ * key from the export (and the copy with it) would otherwise stay green.
+ */
+const EXPECTED_KEYS = [
+  'dashboard.nextStep.resume.title',
+  'dashboard.nextStep.resume.description',
+  'dashboard.nextStep.ai.title',
+  'dashboard.nextStep.ai.description',
+  'dashboard.nextStep.job.title',
+  'dashboard.nextStep.job.description',
+  'dashboard.nextStep.progress',
+  'dashboard.nextStep.doneTitle',
+  'dashboard.nextStep.unavailableTitle',
+  'dashboard.nextStep.help',
+];
+
+/** Reason copy the AI step borrows from `AiSetupHint` instead of restating. */
+const AI_REASON_KEYS = [
+  'aiSetup.addApiKey',
+  'aiSetup.selectModel',
+  'aiSetup.installCli',
+  'aiSetup.startOllama',
+  'aiSetup.healthUnavailable',
+];
+
+/** Walks a dotted key through a bundle; `undefined` when a segment is missing. */
+function lookup(bundle: unknown, key: string): unknown {
+  return key
+    .split('.')
+    .reduce<unknown>(
+      (node, segment) =>
+        typeof node === 'object' && node !== null
+          ? (node as Record<string, unknown>)[segment]
+          : undefined,
+      bundle
+    );
+}
+
+/** `"<locale>: <key>"` for every key that is missing or blank. */
+function unresolved(keys: readonly string[]): string[] {
+  const missing: string[] = [];
+  for (const [locale, bundle] of Object.entries(BUNDLES)) {
+    for (const key of keys) {
+      const value = lookup(bundle, key);
+      if (typeof value !== 'string' || value.trim() === '') missing.push(`${locale}: ${key}`);
+    }
+  }
+  return missing;
+}
+
+const signals = (patch: Partial<NextStepSignals> = {}): NextStepSignals => ({
+  resume: true,
+  ai: true,
+  job: true,
+  ...patch,
+});
+
+describe('deriveNextStep', () => {
+  it('reports pending when any signal is still unanswered', () => {
+    // Even with two steps already unmet — a cold boot must render nothing
+    // rather than flash "add your résumé" at a user who has one.
+    expect(deriveNextStep({ resume: 'pending', ai: false, job: false })).toEqual({
+      kind: 'pending',
+    });
+    expect(deriveNextStep(signals({ ai: 'pending' }))).toEqual({ kind: 'pending' });
+    expect(deriveNextStep(signals({ job: 'pending' }))).toEqual({ kind: 'pending' });
+  });
+
+  it('reports unavailable — not silence — when a signal query rejected', () => {
+    // The signal that failed is `job`, which is met in every other respect
+    // here: a hole anywhere makes both answers ("which step is first unmet"
+    // and "how many are done") unknowable, so the tile owes the user a
+    // neutral row instead of the permanent nothing a rejected query used to
+    // produce.
+    expect(deriveNextStep(signals({ job: 'unavailable' }))).toEqual({ kind: 'unavailable' });
+    expect(deriveNextStep({ resume: 'unavailable', ai: false, job: false })).toEqual({
+      kind: 'unavailable',
+    });
+  });
+
+  it('still renders nothing while another signal is loading alongside a failed one', () => {
+    // Pending is checked first: during a cold boot where one query has
+    // already failed, showing nothing is better than a status row that
+    // appears a moment before the rest of the page settles.
+    expect(deriveNextStep({ resume: 'unavailable', ai: 'pending', job: true })).toEqual({
+      kind: 'pending',
+    });
+  });
+
+  it('suggests the first unmet step in the order résumé → ai → job', () => {
+    // Each case leaves everything earlier in the order met, so the step it
+    // returns can only come from the order itself.
+    expect(deriveNextStep({ resume: false, ai: false, job: false })).toMatchObject({
+      step: 'resume',
+    });
+    expect(deriveNextStep({ resume: true, ai: false, job: false })).toMatchObject({ step: 'ai' });
+    expect(deriveNextStep({ resume: true, ai: true, job: false })).toMatchObject({ step: 'job' });
+  });
+
+  it('counts met steps regardless of position, not how far along the order it is', () => {
+    // The trap this pins: a user who finished setup and then deleted their
+    // résumé is back on step one but is NOT 0-of-3 done.
+    expect(deriveNextStep({ resume: false, ai: true, job: true })).toEqual({
+      kind: 'step',
+      step: 'resume',
+      done: 2,
+      total: 3,
+    });
+    expect(deriveNextStep({ resume: false, ai: false, job: false })).toEqual({
+      kind: 'step',
+      step: 'resume',
+      done: 0,
+      total: 3,
+    });
+  });
+
+  it('reports done once every step is met', () => {
+    expect(deriveNextStep(signals())).toEqual({ kind: 'done' });
+  });
+});
+
+describe('next-step copy / translations parity', () => {
+  it('exports exactly the keys the tile renders', () => {
+    expect([...NEXT_STEP_TEXT_KEYS]).toEqual(EXPECTED_KEYS);
+  });
+
+  it('resolves every next-step key to a non-empty string in en AND de', () => {
+    expect(unresolved(NEXT_STEP_TEXT_KEYS)).toEqual([]);
+  });
+
+  it('resolves the AI reason copy the step borrows in en AND de', () => {
+    expect(unresolved(AI_REASON_KEYS)).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/features/dashboard/lib/next-step.ts
+++ b/apps/desktop/src/renderer/features/dashboard/lib/next-step.ts
@@ -1,0 +1,100 @@
+/**
+ * Which single setup step the Dashboard should nudge next.
+ *
+ * Pure derivation on purpose: the tile reads its three signals from service
+ * hooks and passes plain values in here, so every branch below is testable
+ * without React Query, IPC or a router.
+ */
+
+/**
+ * One input to the derivation.
+ *
+ * Two non-boolean states, because "no answer" arrives in two shapes that have
+ * opposite right responses:
+ *
+ * - `'pending'` — the query has no data YET. It is NOT `false`: telling a
+ *   returning user to add a résumé they already have, for the half-second
+ *   before the cache answers, is worse than showing nothing.
+ * - `'unavailable'` — the query REJECTED. Its `data` stays `undefined` for
+ *   good, so folding this into `'pending'` hid the row permanently — the one
+ *   outcome the tile is not allowed to have, being the app's only always-there
+ *   route to help.
+ */
+export type StepSignal = boolean | 'pending' | 'unavailable';
+
+/** The three things that have to be true before the app can do its job. */
+export type NextStepId = 'resume' | 'ai' | 'job';
+
+/**
+ * Whether each step is met.
+ *
+ * - `resume` — a document exists to tailor from.
+ * - `ai` — an AI provider is configured and reachable.
+ * - `job` — at least one posting carries a tracked interaction (see
+ *   `TRACKED_INTERACTION_TYPES`; a dismissal is not one).
+ */
+export type NextStepSignals = Record<NextStepId, StepSignal>;
+
+/** What the tile should render. */
+export type NextStep =
+  | { kind: 'pending' }
+  | { kind: 'unavailable' }
+  | { kind: 'step'; step: NextStepId; done: number; total: number }
+  | { kind: 'done' };
+
+/**
+ * The order the first unmet step is picked in.
+ *
+ * Not a sequence the user must follow — any step can be done first, which is
+ * why the badge counts met steps ("2 of 3 done") instead of claiming "Step 1
+ * of 3". The order is only a preference for what to suggest when several are
+ * unmet: a résumé is the input everything else consumes, AI is what turns it
+ * into output, and a job is what both are pointed at.
+ */
+const STEP_ORDER: readonly NextStepId[] = ['resume', 'ai', 'job'];
+
+/**
+ * The first unmet step, or `done` / `unavailable` / `pending`.
+ *
+ * `done` counts met steps regardless of position, so a user who deletes their
+ * résumé after finishing sees the résumé step with "2 of 3 done" — true, where
+ * a positional counter would lie.
+ */
+export function deriveNextStep(signals: NextStepSignals): NextStep {
+  if (STEP_ORDER.some((step) => signals[step] === 'pending')) return { kind: 'pending' };
+
+  // Checked AFTER `'pending'`, which only delays this row and never replaces
+  // it (a rejected query does not recover on its own): during a cold boot
+  // where one signal has already failed and the rest are still in flight, the
+  // tile stays empty instead of flashing a status row a moment before the
+  // steady state. Never merged into `'pending'` — that is the bug this state
+  // exists for, a failed read hiding the row for the whole session.
+  if (STEP_ORDER.some((step) => signals[step] === 'unavailable')) return { kind: 'unavailable' };
+
+  const done = STEP_ORDER.filter((step) => signals[step] === true).length;
+  const next = STEP_ORDER.find((step) => signals[step] !== true);
+
+  return next === undefined
+    ? { kind: 'done' }
+    : { kind: 'step', step: next, done, total: STEP_ORDER.length };
+}
+
+/**
+ * Every `dashboard.nextStep.*` key the tile can render, so the locale-parity
+ * test asserts the same set the component asks `t()` for.
+ *
+ * Not every string the tile can show: the AI step's description is borrowed
+ * from `AiSetupHint`'s `aiSetup.*` reason copy (`AI_REASON_KEY` in the tile),
+ * which lives in a different namespace and is walked by its own list in
+ * `next-step.test.ts`.
+ */
+export const NEXT_STEP_TEXT_KEYS: readonly string[] = [
+  ...STEP_ORDER.flatMap((step) => [
+    `dashboard.nextStep.${step}.title`,
+    `dashboard.nextStep.${step}.description`,
+  ]),
+  'dashboard.nextStep.progress',
+  'dashboard.nextStep.doneTitle',
+  'dashboard.nextStep.unavailableTitle',
+  'dashboard.nextStep.help',
+];

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -87,6 +87,7 @@ Read the minimum; **stop at ~90% confidence**.
 | [ADR-039](decision-records/adr-039-hybrid-postings-search-lexical-dense-rerank.md)           | Hybrid postings search: lexical FTS5 + dense cosine + RRF fusion + optional LLM rerank                                                                                                                |
 | [ADR-040](decision-records/adr-040-mcp-server-as-agent-cli-mode.md)                          | MCP stdio server as a mode of the agent CLI: legacy 2025-11-25 wire on purpose, tools along the `Effect` boundary, confirm passed through verbatim, `call-irreversible` behind `--allow-irreversible` |
 | [ADR-041](decision-records/adr-041-searchable-help-page-over-compiled-in-entries.md)         | Searchable help page over compiled-in, localized entries; client-side matching, no model or IPC; partly supersedes ADR-0006 (FAQ-only)                                                                |
+| [ADR-042](decision-records/adr-042-dashboard-next-step-tile-derived-not-stored.md)           | Dashboard next-step tile derived from live state, not stored; collapses to one line when setup is complete, never dismissible; extension and autopilot deliberately not steps                         |
 
 ### The `NNNN-` series (closed)
 

--- a/docs/knowledge/decision-records/adr-041-searchable-help-page-over-compiled-in-entries.md
+++ b/docs/knowledge/decision-records/adr-041-searchable-help-page-over-compiled-in-entries.md
@@ -42,7 +42,7 @@ Both proposals assumed complexity was necessary; the gap is discoverability, whi
 
 3. **An external docs site** (rejected): the app is local-first and offline-capable; the answer must be available inside the app at the moment of the question, not on a website.
 
-4. **A new onboarding flow** (rejected here): an onboarding wizard and spotlight tour already exist and are first-run-only; the "what should I do next" half is a separate, later decision about persistence on the Dashboard, not part of this record.
+4. **A new onboarding flow** (rejected here): an onboarding wizard and spotlight tour already exist and are first-run-only; the "what should I do next" half is a separate, later decision about persistence on the Dashboard, not part of this record (now [ADR-042](adr-042-dashboard-next-step-tile-derived-not-stored.md)).
 
 ## Consequences
 

--- a/docs/knowledge/decision-records/adr-042-dashboard-next-step-tile-derived-not-stored.md
+++ b/docs/knowledge/decision-records/adr-042-dashboard-next-step-tile-derived-not-stored.md
@@ -1,0 +1,76 @@
+# ADR-042 — Dashboard next-step tile derived from live state, not stored; collapses to one line when setup is complete
+
+**Status:** Accepted
+
+**Date:** 2026-09-02
+
+**Deciders:** owner (decision 2026-09-02, "go next"), main session
+
+## Context
+
+[ADR-041](adr-041-searchable-help-page-over-compiled-in-entries.md) deferred the "what should I do next" half of the discoverability gap as a separate decision about persistence on the Dashboard.
+
+The onboarding wizard and spotlight tour are first-run-only and gated on a single persisted boolean; both the tour's skip and finish actions write the same value. This design means nothing can tell a user who read the tour from one who dismissed it. The owner's demonstration of the app to another person failed precisely because the wizard had been dismissed on that machine, and a one-time tour cannot answer a question that arises three screens later.
+
+The Dashboard today renders a page header, four data-free quick-action tiles, and two cards with no getting-started surface. Eight orphaned `dashboard.*` translation keys show a richer dashboard was designed and never built.
+
+## Decision
+
+**1. One derived next-step row on the Dashboard**, placed between the page header and the quick-action grid, reusing the `ActionTile` primitive. Not a fifth quick-action tile — the grid is `@2xl:grid-cols-4` and the stagger class index is typed to the four existing stagger classes.
+
+**2. It derives from live state only**, through existing React Query service hooks: `hasDocument` (embedding status document count, app-global), `aiUsable` (the same predicate used by Analyzer and the AI status card), `hasJob` (any interaction-log row of a tracked type — the same allowlist the pipeline overview uses, so a dismissed suggestion does not count). No preference, no store field, no migration, nothing persisted; re-derived on every mount.
+
+**3. While any signal is still resolving, the row renders nothing**; the AI predicate's "no reason yet" state counts as resolving, and the predicate itself withholds a reason until its provider-key query has settled (it once answered "add an API key" mid-flight, which would have flashed the wrong step at every configured cloud user on every cold boot). If a signal query fails, the row falls back to a neutral line with the help link — it never disappears and never claims setup is complete. This accepts the small layout shift when signals arrive.
+
+**4. Three steps only**: résumé, AI, job. Extension pairing is not a step — the bridge's connected flag is a live socket count, not a pairing record, and reading it would add an app-wide poll. Autopilot is not a step — its list query deliberately has `staleTime: 0` and would refetch on every visit home.
+
+**5. Once every step is met, the row collapses to a single line** with a check icon, a title, and a link to Help & Support. It never disappears and is never dismissible. A surface that disappears is invisible to the user who is set up and still lost — the exact failure the plan set out to fix.
+
+**6. The progress badge counts met steps**, not sequence position, because steps can become unmet again out of order (a user who deletes a document after finishing shows step résumé with "2 of 3 done").
+
+**7. Applications are deliberately not a signal**: the applications list ships every row's job description and summary, and its app-global change listener would re-fetch it while the user sits on the home route, all for one boolean. A job tracked by hand or through the extension with no interaction row therefore does not satisfy the step, which is why the step says "find", never "track": opening any posting satisfies it.
+
+**8. The résumé step uses the document count as a proxy**: documents carry no `kind` field, so a user with only an imported cover letter reads as ready. This is accepted to avoid adding `kind` to the document schema.
+
+**9. `ActionTile` becomes keyboard-reachable**: `role="button"`, `tabIndex={0}`, and `onKeyDown` firing `onClick` on Enter and Space, only when `onClick` is provided. Fixes the same gap for existing quick-action tiles.
+
+## Considered options
+
+1. **A stored dismissal flag** (rejected): introduces a new persisted field with factory-reset and e2e-seed consequences, for a surface cheaper to derive on every mount.
+
+2. **Disappearing on completion** (rejected by the owner): a surface that disappears is invisible to the user who is still lost after setup, which is the failure the plan set out to fix.
+
+3. **A "continue working" mode** (deferred): suggests the next action from application data (requires per-application generation status the Dashboard does not load, and a rule set of its own).
+
+4. **A fifth quick-action tile** (impossible): would require changing the grid definition and its stagger class index typing.
+
+5. **Reviving the orphaned `dashboard.continueWorking` / `dashboard.insights.*` keys** (rejected): they carry fabricated numbers; ADR-041 § 6 forbids copy not verified against the UI.
+
+## Consequences
+
+### Positive
+
+- **Persistent, state-aware pointer** at the next action and at help, visible on every home visit.
+
+- **No persistence cost**: nothing new to migrate or reset; re-derived on mount.
+
+- **No added query** on the home route: every signal dedupes onto a query the root layout or the pipeline overview already mounts.
+
+### Tradeoffs and costs
+
+- **Brief layout shift**: the row appears after signals resolve. Mitigated by rendering nothing while pending.
+
+- **Document-count proxy**: a user with only an imported cover letter reads as having a résumé. Accepted to avoid adding schema fields.
+
+- **Interaction log under-reports**: a viewed row is only written after a dwell in the detail pane, and applications are not consulted (decision 7), so a user who tracked a job by hand still sees the "find a job" step until they open a posting.
+
+- **Extractor CI step is advisory**: translation keys are pinned by a renderer test, as in ADR-041, rather than failing the build.
+
+## References
+
+- Prior decision: [ADR-041](adr-041-searchable-help-page-over-compiled-in-entries.md) — the help page decision; the onboarding and tour context
+- Persistence boundary: `docs/knowledge/persistence.md`
+- Dashboard component: `apps/desktop/src/renderer/features/dashboard/components/Dashboard/index.tsx`
+- NextStepTile component: `apps/desktop/src/renderer/features/dashboard/components/NextStepTile/index.tsx`
+- Derivation logic: `apps/desktop/src/renderer/features/dashboard/lib/next-step.ts`
+- ActionTile primitive: `packages/ui/src/components/ActionTile/ActionTile.tsx`

--- a/packages/test-ids/src/test-ids.test.ts
+++ b/packages/test-ids/src/test-ids.test.ts
@@ -54,5 +54,6 @@ describe('TEST_IDS', () => {
     expect(keys).toContain('generation');
     expect(keys).toContain('onboarding');
     expect(keys).toContain('support');
+    expect(keys).toContain('dashboard');
   });
 });

--- a/packages/test-ids/src/test-ids.ts
+++ b/packages/test-ids/src/test-ids.ts
@@ -197,6 +197,18 @@ export const TEST_IDS = {
     tour: 'tour',
   },
 
+  /** Dashboard — the persistent next-step row above the quick actions */
+  dashboard: {
+    /** Wrapper around the ActionTile nudging the first unmet setup step. */
+    nextStepTile: 'dashboard-next-step-tile',
+    /** The slim "setup complete" row that replaces the tile once every step is met. */
+    nextStepDone: 'dashboard-next-step-done',
+    /** The same slim row, neutral copy, when a signal query failed and the tile
+     *  cannot say which step is next — distinct from `nextStepDone` so a test
+     *  can prove the "setup complete" claim is NOT what a failed read renders. */
+    nextStepUnavailable: 'dashboard-next-step-unavailable',
+  },
+
   /** Help & Support — the searchable help page (ADR-041) */
   support: {
     /** Search box above the sections; filters entries with a word-AND substring match. */

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -2279,6 +2279,24 @@
       "indexed": "Indiziert",
       "memory": "Speichernutzung",
       "refresh": "Aktualisieren"
+    },
+    "nextStep": {
+      "resume": {
+        "title": "Lebenslauf hinzufügen",
+        "description": "Laden Sie einen Lebenslauf hoch, damit die App ihn auf einen Job zuschneiden kann."
+      },
+      "ai": {
+        "title": "KI-Modell verbinden",
+        "description": "Wählen Sie einen Anbieter oder ein lokales Modell zum Generieren."
+      },
+      "job": {
+        "title": "Ersten Job finden",
+        "description": "Durchsuchen Sie ein Jobboard und öffnen Sie eine Anzeige, um Ihre Pipeline zu starten."
+      },
+      "progress": "{{done}} von {{total}} erledigt",
+      "doneTitle": "Einrichtung abgeschlossen — Sie können sich jetzt bewerben.",
+      "unavailableTitle": "Der Einrichtungsstatus ist gerade nicht verfügbar.",
+      "help": "Hilfe ansehen"
     }
   },
   "jobs": {

--- a/packages/translations/src/locales/de/translation.json
+++ b/packages/translations/src/locales/de/translation.json
@@ -898,7 +898,7 @@
       "exportDataDescription": "Speichern Sie Ihre beworbenen, angesehenen und gespeicherten Jobs in einer JSON-Datei.",
       "export": "Exportieren",
       "importData": "Daten importieren",
-      "importDataDescription": "Wiederherstellung aus einem vorherigen Export. Vorhandene Datensätze bleiben erhalten.",
+      "importDataDescription": "Wiederherstellung aus einem vorherigen Export. Ersetzt die vorhandenen Daten durch den Inhalt der Datei.",
       "import": "Importieren",
       "signOutAll": "Alle Konten abmelden",
       "signOutAllDescription": "Löscht alle Browser-Sitzungen. Verbinden Sie Boards über Kontoeinstellungen neu.",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -898,7 +898,7 @@
       "exportDataDescription": "Save your applied, viewed, and bookmarked jobs to a JSON file.",
       "export": "Export",
       "importData": "Import Data",
-      "importDataDescription": "Restore from a previous export. Existing records are preserved.",
+      "importDataDescription": "Restore from a previous export. Replaces the current data with the contents of the file.",
       "import": "Import",
       "signOutAll": "Sign Out All Accounts",
       "signOutAllDescription": "Wipes all browser sessions. Reconnect boards via Accounts settings.",

--- a/packages/translations/src/locales/en/translation.json
+++ b/packages/translations/src/locales/en/translation.json
@@ -2275,6 +2275,24 @@
       "indexed": "Indexed",
       "memory": "Memory usage",
       "refresh": "Refresh"
+    },
+    "nextStep": {
+      "resume": {
+        "title": "Add your résumé",
+        "description": "Upload a CV so the app can tailor it to a job."
+      },
+      "ai": {
+        "title": "Connect an AI model",
+        "description": "Pick a provider or a local model to generate with."
+      },
+      "job": {
+        "title": "Find your first job",
+        "description": "Search a board and open a posting to start your pipeline."
+      },
+      "progress": "{{done}} of {{total}} done",
+      "doneTitle": "Setup complete — you're ready to apply.",
+      "unavailableTitle": "Setup status is unavailable right now.",
+      "help": "Browse help"
     }
   },
   "jobs": {

--- a/packages/ui/src/components/ActionTile/ActionTile.test.tsx
+++ b/packages/ui/src/components/ActionTile/ActionTile.test.tsx
@@ -1,6 +1,6 @@
 import { Zap } from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ActionTile } from './ActionTile';
@@ -20,5 +20,57 @@ describe('ActionTile', () => {
     render(<ActionTile icon={Zap} label="Run" active onClick={onClick} />);
     await userEvent.click(screen.getByText('Run'));
     expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('is reachable by keyboard: tab to it, then Enter and Space fire onClick', async () => {
+    // The tile is a div, so without an explicit role/tabIndex/key handler it is
+    // mouse-only — `.tab()` would land on nothing and both keys would be inert.
+    const onClick = vi.fn();
+    render(<ActionTile icon={Zap} label="Run" onClick={onClick} />);
+
+    await userEvent.tab();
+    expect(screen.getByRole('button', { name: /Run/ })).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard(' ');
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows the default action on Space so the page does not scroll under the tile', () => {
+    // `userEvent.keyboard(' ')` above proves the handler RAN, not that it
+    // called `preventDefault` — and on a focused non-button div the browser
+    // default for Space is to scroll. Dispatch the event ourselves so the
+    // flag is observable: delete the `preventDefault` line and this fails.
+    render(<ActionTile icon={Zap} label="Run" onClick={vi.fn()} />);
+    const tile = screen.getByRole('button', { name: /Run/ });
+
+    const space = createEvent.keyDown(tile, { key: ' ' });
+    fireEvent(tile, space);
+    expect(space.defaultPrevented).toBe(true);
+
+    // Enter activates without a default worth suppressing — asserted so the
+    // fix stays a targeted one and not a blanket "prevent everything".
+    const enter = createEvent.keyDown(tile, { key: 'Enter' });
+    fireEvent(tile, enter);
+    expect(enter.defaultPrevented).toBe(false);
+  });
+
+  it('activates once per press: a held (auto-repeating) key does not re-fire onClick', () => {
+    const onClick = vi.fn();
+    render(<ActionTile icon={Zap} label="Run" onClick={onClick} />);
+    const tile = screen.getByRole('button', { name: /Run/ });
+
+    fireEvent.keyDown(tile, { key: 'Enter' });
+    // Every keydown the OS generates while the key is held carries `repeat`.
+    fireEvent.keyDown(tile, { key: 'Enter', repeat: true });
+    fireEvent.keyDown(tile, { key: ' ', repeat: true });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays out of the tab order and exposes no role when it has no onClick', () => {
+    render(<ActionTile icon={Zap} label="Static" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/ActionTile/ActionTile.test.tsx
+++ b/packages/ui/src/components/ActionTile/ActionTile.test.tsx
@@ -69,8 +69,30 @@ describe('ActionTile', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('stays out of the tab order and exposes no role when it has no onClick', () => {
-    render(<ActionTile icon={Zap} label="Static" />);
+  it('stays out of the tab order and exposes no role when it has no onClick', async () => {
+    // The missing-role assertion alone lets a silently-focusable tile through:
+    // `tabIndex={0}` with no role is a keyboard stop that announces nothing and
+    // does nothing. Pin the attribute itself, and prove a tab between two real
+    // controls lands past the tile rather than on it. (Links, not buttons, so
+    // the unqualified `queryByRole('button')` below stays as strict as it was.)
+    render(
+      <>
+        <a href="#before">before</a>
+        <ActionTile icon={Zap} label="Static" />
+        <a href="#after">after</a>
+      </>
+    );
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    // The label div is a direct child of the tile's card root.
+    const tile = screen.getByText('Static').parentElement;
+    if (!tile) throw new Error('tile root not found');
+    expect(tile).not.toHaveAttribute('tabindex');
+
+    await userEvent.tab();
+    expect(screen.getByText('before')).toHaveFocus();
+    await userEvent.tab();
+    expect(tile).not.toHaveFocus();
+    expect(screen.getByText('after')).toHaveFocus();
   });
 });

--- a/packages/ui/src/components/ActionTile/ActionTile.tsx
+++ b/packages/ui/src/components/ActionTile/ActionTile.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
 
 import { cn } from '../../lib/cn';
 import { GlassCard } from '../GlassCard';
@@ -17,6 +17,12 @@ interface ActionTileProps {
 /**
  * Clickable tile with icon, label, optional description and badge.
  * Used in quick-action grids, feature selection, and option pickers.
+ *
+ * The surface is a `div`, so when it is clickable it carries the button role,
+ * tab stop, focus ring and Enter/Space handling a `<button>` would give for
+ * free — without them the quick-action grids were mouse-only. A tile with no
+ * `onClick` stays inert: no role, no tab stop, nothing for a keyboard user to
+ * land on.
  */
 export function ActionTile({
   icon: Icon,
@@ -27,14 +33,34 @@ export function ActionTile({
   active = false,
   className,
 }: ActionTileProps) {
+  const handleKeyDown =
+    onClick &&
+    ((event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      // Space scrolls the page on a focused non-button element; Enter doesn't.
+      // Before the repeat guard below, deliberately: a HELD space must not
+      // start scrolling either, even though it activates only once.
+      if (event.key === ' ') event.preventDefault();
+      // Auto-repeat: holding the key fires this handler at the OS repeat rate,
+      // which on a tile that navigates means a burst of activations from a
+      // single press. One press, one `onClick`.
+      if (event.repeat) return;
+      onClick();
+    });
+
   return (
     <GlassCard
       className={cn(
         'group cursor-pointer transition-all duration-150 ease-out',
+        onClick &&
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
         active && 'ring-1 ring-brand/40',
         className
       )}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
     >
       <div className="mb-3 flex items-start justify-between">
         <Icon


### PR DESCRIPTION
## Why

The searchable help page (#1094) answered "how do I do X". The other half of the discoverability gap is "what should I do next", and the app only ever answered it once: the onboarding wizard and spotlight tour are first-run-only, gated on a single persisted boolean that cannot even tell a skipped tour from a finished one. The demonstration that started this work failed because that wizard had been dismissed on the machine in question. ADR-041 §4 deferred this half as a separate decision about persistence on the Dashboard; ADR-042 records it.

## What

**A derived next-step row on the Dashboard**, between the header and the quick-action grid, on the existing `ActionTile`. It shows the first unmet of three steps — add a résumé, set up AI, find a job — with a "N of 3 done" badge, and deep-links to the place that resolves it (the Settings section, or the Jobs page). Once all three are met it collapses to a single line with a link to Help & Support. It never disappears and cannot be dismissed, which the owner chose over disappearing: a surface that vanishes is invisible to the user who is set up and still lost.

**Nothing is stored.** Every signal comes from live queries the app already runs — the app-global embedding-status document count, the same AI-usable predicate the Analyzer and the AI status card use, and the interaction log filtered by the same tracked-type allowlist the pipeline card uses — so there is no preference, no schema field, no migration, and nothing for factory reset or the e2e seeds to know about. The row re-derives on every mount and comes back by itself when the data goes away. No new query lands on the home route: every signal dedupes onto a query the root layout or the pipeline card already mounts.

**Deliberately not a signal: applications.** The applications list ships every row's job description and summary, and its app-global change listener would re-fetch it while the user sits on the home route, all for one boolean. A job tracked by hand or through the extension with no interaction row therefore does not satisfy the step, which is why the step says "find", never "track": opening any posting satisfies it.

**Deliberately not steps.** Extension pairing: the bridge's `connected` flag is a live socket count, not a pairing record, and its status hook is not app-global despite its own doc comment, so a step keyed on it would re-suggest pairing on most cold starts and add an app-wide poll. Autopilot: its list query is intentionally never stale and would refetch on every visit home.

**While signals resolve the row renders nothing; if a signal query fails the row falls back to a neutral line with the help link**, never to nothing and never to a "setup complete" claim. The AI predicate returns "not usable" with no reason while it is still checking; treating that as "set up AI" would flash the wrong step on every cold boot, the same defect the neighbouring status card's tests exist to prevent.

**`ActionTile` becomes keyboard-reachable.** It rendered a `div` with an `onClick` and no role, focus or key handling, so every quick-action tile was mouse-only. It now has the button role, is focusable, and fires on Enter and Space; the existing tiles inherit the fix.

Also in this PR, one line: the Settings import description said "Existing records are preserved." while the `DataStore` contract clears and repopulates; the help corpus shipped in #1094 already said the truth, so the two disagreed.

## What review changed

The strict pre-PR gate rendered the tile against the real hooks with a deferred provider-key query and found what the spec, the ADR and the author's mocked tests all assumed away:

- **The AI predicate answered before its key query settled.** `useCanUseAI` returned "add an API key" while `hasProviderKey` was still crossing IPC, so a correctly configured cloud user would have seen a full-width "Connect an AI model" tile on every cold boot, then watched it vanish. The predicate now withholds its reason until the key query has settled, which fixes the neighbouring AI status card's identical row for free, and the test drives the real hook through a deferred query rather than a literal.
- **A dismissed suggestion counted as "tracked a job".** The unfiltered interaction list includes `dismissed`, which the pipeline card on the same page explicitly excludes; one dismissal on Best Matches would have collapsed the tile to "setup complete" above a card reading "Total tracked: 0". The allowlist now lives in the feature's constants and both components use it.
- **The applications query was dropped from the home route** (full job descriptions per row, re-fetched on every change event) and the job step's copy changed from "track" to "find" so it never claims something the signal cannot see.
- **A failed signal query hid the row for the rest of the visit**, contradicting the ADR's "never disappears"; it now falls back to a neutral help line.
- `ActionTile`'s Space `preventDefault` had no test pinning it (deleting the line left the suite green); it does now, and a held key no longer fires once per auto-repeat.

The external round added one more on the same predicate: a *rejected* provider-key query also read as "no key". A failed keyring read now reports the existing "Couldn't check AI status" reason, mirroring how the other two branches of the predicate already treat a failed health read, and the static-tile test now also asserts the absence of a tab stop.

## Test plan

- `next-step.test.ts`: pending wins over everything; order résumé → AI → job; the done count is independent of order (résumé unmet with the others met reports the résumé step and two done); all met → done. Mutation-checked by swapping the step order.
- Locale-parity test for every `dashboard.nextStep.*` key in both bundles, importing the JSON directly because the translations entrypoint falls back to English and would mask a missing German key. Mutation-checked by deleting one German value.
- `ActionTile` keyboard test in `@ajh/ui`.
- Tile tests through the real hooks and the mock client: a cloud provider with a deferred key query never shows the AI step; a rejecting query shows the neutral help row; a lone `dismissed` interaction still shows the job step.
- `pnpm lint:strict`, `pnpm typecheck`, the dashboard, ui and test-ids vitest suites, `pnpm check:event-subscriptions` (the tile subscribes to nothing), `pnpm check:adr-citations`.
- **Not done:** no screenshot (the renderer cannot run outside Tauri); the layout shift when the row appears after the signals resolve is accepted, not measured.

## Follow-ups (recorded, not done)

- A "continue working" mode after setup (suggest the next action from application data). Needs per-application generation data the Dashboard does not load and a rule set of its own.
- The a11y ESLint config covers only the renderer, so `packages/ui` primitives such as `ActionTile` get no jsx-a11y lint; a one-line glob addition, separately.
- Eight orphaned `dashboard.*` translation keys (`continueWorking`, `insights.*` with fabricated numbers, and others) with no consumer: a cleanup candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
