### PR TITLE
ci: fix the chrome web store zip path and add per-store re-publish dispatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ name: 🚀 Release
 #       and commits the bump back to main. Does NOT build installers.
 #   - build-installers (default) → build Tauri apps + browser extension for a chosen
 #       tag, then run the cask/manifest/download-page fan-out.
+#   - publish-chrome / publish-firefox → re-run ONE store submission for a chosen
+#       tag (package-extension + that store's publish job, nothing else). For when
+#       one store's job failed and the other went through: a store rejects a
+#       version it already has, so re-running both would only redden the good one.
 # Jobs:
 #   - release: Determine version, sync version files + changelog, create the
 #       GitHub release, and commit the bump back to main (action: release only)
@@ -29,6 +33,8 @@ name: 🚀 Release
 #      semantic-release derives the bump from commit types (feat/fix/perf/BREAKING).
 #   2. Actions → "🚀 Release" → Run workflow → action: build-installers
 #      Leave the version blank for the latest tag, or pass one (e.g. 0.61.0).
+#   3. Only if one store submission failed: action: publish-chrome or
+#      publish-firefox with that same version.
 # ──────────────────────────────────────────────────────────────────────
 
 on:
@@ -40,9 +46,11 @@ on:
         options:
           - build-installers
           - release
+          - publish-chrome
+          - publish-firefox
         default: build-installers
       version:
-        description: 'Version to build installers for, e.g. 0.61.0 (blank = latest tag)'
+        description: 'Version to build installers / publish the extension for, e.g. 0.61.0 (blank = latest tag)'
         required: false
         type: string
 
@@ -699,8 +707,9 @@ jobs:
     name: 🧩 Package Extension
     # Manual-only: the browser extension is built + attached to the Release on
     # demand from the Actions tab ("Run workflow" → action: build-installers) —
-    # mirrors the installer `build` job philosophy.
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.action == 'build-installers' }}
+    # mirrors the installer `build` job philosophy. Also the producer for a
+    # single-store re-publish, which rebuilds the same tag's zips.
+    if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJSON('["build-installers", "publish-chrome", "publish-firefox"]'), inputs.action) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Uploads the zipped extension to the GitHub Release (softprops/action-gh-release).
@@ -835,7 +844,7 @@ jobs:
   publish-chrome:
     name: 🧩 Publish to Chrome Web Store
     needs: package-extension
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.action == 'build-installers' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.action == 'build-installers' || inputs.action == 'publish-chrome') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -974,8 +983,12 @@ jobs:
           # stream; $GITHUB_STEP_SUMMARY is a file this step writes and the
           # runner uploads as-is, so unbounded output from a third-party tool
           # does not go in it.
+          # Absolute path on purpose: `pnpm --filter … exec` runs the CLI from
+          # apps/extension/, while the existence check above ran from the
+          # workspace root — a relative path passes the check and then resolves
+          # one directory too deep inside the CLI.
           pnpm --filter @ajh/extension exec chrome-webstore-upload \
-            --source "$ZIP" \
+            --source "$GITHUB_WORKSPACE/$ZIP" \
             --extension-id "$CHROME_EXTENSION_ID" \
             --deploy-percentage 100
           echo "::endgroup::"
@@ -1003,7 +1016,7 @@ jobs:
   publish-firefox:
     name: 🦊 Publish to Firefox AMO
     needs: package-extension
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.action == 'build-installers' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.action == 'build-installers' || inputs.action == 'publish-firefox') }}
     runs-on: ubuntu-latest
     # The reproducibility gate below does a full workspace install + build of the
     # unpacked source archive, on top of this job's own install.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -216,7 +216,7 @@ Additional advisory layers:
 
 ## Browser extension store publishing
 
-The MV3 extension is already listed on both stores, so every release **submits a new version to an existing listing** — never creates one. Two jobs in `release.yml` do it automatically after `package-extension`, on the same `action: build-installers` dispatch:
+The MV3 extension is already listed on both stores, so every release **submits a new version to an existing listing** — never creates one. Two jobs in `release.yml` do it automatically after `package-extension`, on the same `action: build-installers` dispatch (and one at a time via `action: publish-chrome` / `publish-firefox` with the tag's version, for when a single store's submission failed):
 
 | Job               | Store            | What it submits                                                                                                 |
 | ----------------- | ---------------- | --------------------------------------------------------------------------------------------------------------- |
@@ -258,7 +258,7 @@ Generate a JWT issuer + secret on the AMO **Manage API Keys** page with the acco
 ### Known failure modes
 
 - **An open manual draft blocks Chrome.** The API refuses to act while an unsubmitted draft edit is pending in the dashboard. Submit or discard it, then re-run.
-- **The version must increase.** Chrome rejects an upload whose manifest version is not higher than the published one. The extension version is bumped for every app release by `scripts/sync-tauri-version.cjs`, so this only bites when re-running a release for an already-submitted tag.
+- **The version must increase.** Chrome rejects an upload whose manifest version is not higher than the published one. The extension version is bumped for every app release by `scripts/sync-tauri-version.cjs`, so this only bites when re-running a release for an already-submitted tag — which is why a failed single store is re-run with its own `publish-*` action rather than the whole `build-installers`.
 - **A Chrome refresh token expires after 6 months unused** (and after 7 days if the consent screen was left in Testing). Symptom: `invalid_grant`. Re-run the key generator.
 - **An AMO source-archive mismatch is a rejection**, and a repeat offence gets the add-on taken down. The reproducibility gate exists to catch it in CI instead.
 - **Missing secrets fail the job by design.** Until all six exist, every release run shows two red jobs and no submission happens. Nothing else in the release is affected.


### PR DESCRIPTION
## Summary

Release run #569 (v0.149.0) was the first to reach the automated store submissions. Firefox AMO went through; the Chrome Web Store job failed before uploading anything:

```
Error: Zipped extension not found: …/apps/extension/extension-zips/ai-job-hunter-extension-chrome-0.149.0.zip
```

The zip existence check ran at the workspace root and passed, but `pnpm --filter @ajh/extension exec` runs the store CLI from `apps/extension/`, so the relative `--source` path resolved one directory too deep. The CLI now receives the path under `$GITHUB_WORKSPACE`, with a comment on why it must stay absolute.

**Per-store re-publish.** `publish-chrome` and `publish-firefox` are new `action` choices on the workflow dispatch. Each runs `package-extension` plus that one store's job for the chosen tag and nothing else. Both stores reject a version they already have, so recovering one store by re-running `build-installers` would only turn the other store's job red. `docs/DEPLOYMENT.md` § Browser extension store publishing points at the new actions.

Verified with actionlint (clean) and a YAML parse of the resulting job conditions.

## After merge

Dispatch **🚀 Release → `action: publish-chrome`, `version: 0.149.0`** to submit the Chrome version that run #569 could not. Nothing else in #569 needs re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
