### PR TITLE
test: keep import-time mock history under vitest 5

### DIFF
--- a/apps/extension/src/background.test.ts
+++ b/apps/extension/src/background.test.ts
@@ -124,6 +124,18 @@ vi.mock('./lib/bridge', () => ({
   }),
 }));
 
+// `background.ts` has no exports: every listener under test — `onMessage`,
+// `onInstalled`, `tabs.onUpdated`, `contextMenus.onClicked` — is recorded on
+// these mocks by the import BELOW, once, before any test body runs. Vitest 5
+// turned `clearMocks` on by default (a `vi.clearAllMocks()` before every test),
+// which wipes exactly that history — the migration guide names module-load
+// recording as the most affected pattern
+// (https://vitest.dev/guide/migration#clearmocks-is-enabled-by-default). Opt
+// this file out; the runner restores the config after the file, so no other test
+// file is affected, and per-test isolation stays explicit in the `beforeEach`
+// below.
+vi.setConfig({ clearMocks: false });
+
 // Dynamic import AFTER the mocks are in place — background.ts registers its
 // onMessage listener + kicks an initial ensureConnected() probe at module load.
 const backgroundModule = await import('./background');

--- a/apps/extension/src/sidepanel/sidepanel.test.ts
+++ b/apps/extension/src/sidepanel/sidepanel.test.ts
@@ -60,6 +60,18 @@ document.body.innerHTML =
   '<div id="job-tools-host"></div><div id="answer-tools-host"></div>' +
   '<div id="connection-pill-host"></div><div id="connection-views-host"></div>';
 
+// `sidepanel.ts` has no exports: everything under test — the `tabs.onActivated`
+// listener, the `mountJobTools`/`mountConnectionStatus` calls and the deps they
+// were handed — is recorded on these mocks by the import BELOW, once, before any
+// test body runs. Vitest 5 turned `clearMocks` on by default (a
+// `vi.clearAllMocks()` before every test), which wipes exactly that history —
+// the migration guide names module-load recording as the most affected pattern
+// (https://vitest.dev/guide/migration#clearmocks-is-enabled-by-default). Opt
+// this file out; the runner restores the config after the file, so no other test
+// file is affected, and the tests below still clear per-test history explicitly
+// where they depend on it (`mockClear()`).
+vi.setConfig({ clearMocks: false });
+
 const { subscribeAnswerState } = await import('../lib/answer-state');
 const { mountJobTools } = await import('../job-tools/job-tools');
 const { mountConnectionStatus } = await import('../connection-status/connection-status');

--- a/apps/landing/src/data/tech-radar.ts
+++ b/apps/landing/src/data/tech-radar.ts
@@ -432,7 +432,7 @@ export const RADAR: readonly TechRadarEntry[] = [
   },
   {
     id: 'vitest',
-    name: 'Vitest 4',
+    name: 'Vitest 5',
     ring: 'adopt',
     quadrant: 'build-ship-trust',
     subjectKind: 'dependency',
@@ -440,7 +440,7 @@ export const RADAR: readonly TechRadarEntry[] = [
     summary: 'The one test runner, in every workspace.',
     rationale:
       'A root vitest workspace config aggregates every package + app project — plus a dedicated node-env project for build/release scripts — into one coverage report, so `pnpm test` is a single command regardless of which package changed.',
-    lastReviewed: '2026-08-05',
+    lastReviewed: '2026-09-07',
   },
   {
     id: 'playwright',


### PR DESCRIPTION
## Why

Since #1127 moved the workspace to vitest 5, the root `pnpm test` fails on `main`: 21 tests in `apps/extension/src/background.test.ts` and `apps/extension/src/sidepanel/sidepanel.test.ts`. Vitest 5 enables `clearMocks` by default, which wipes every mock's recorded calls before each test. Those two files test entry-point modules with no exports: the listeners and mount calls under test are recorded once, at import time, so the history the assertions read back was already cleared. Every other project already runs on the new default without issue.

The pre-push hook runs the root suite, so this has been blocking every branch's push. Process side filed as #1147 (#1127 merged with its Tests check failing).

## What changed

Test-only. Each of the two files opts out for itself with `vi.setConfig({ clearMocks: false })` above its top-level dynamic import, with a comment citing the migration guide. The runner resets the config after each file, so no other project's mock semantics change; both files keep their explicit per-test resets, which is the vitest 4 behaviour they were written against. No assertion weakened, nothing skipped, extension runtime untouched.

Also carried here because the same bump broke it on `main`: the landing tech radar entry named "Vitest 4", which `check:tech-radar` (part of the Lint & Format job) now rejects against the workspace's `vitest ^5.0.0`. The entry is renamed to Vitest 5 with a fresh review date.

## Verification

- The two files: 96 passed. Whole extension suite: 22 files, 701 passed. Typecheck, eslint (`--max-warnings 0`) and prettier clean.
- Repo sweep: no other test file records module-load history at top level; the two `beforeAll` recorders elsewhere assert inside the test body and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
