### PR TITLE
fix(prefs): merge and write under one lock, and clear the country with its location

### DIFF
--- a/apps/desktop/src-tauri/src/commands/job_preferences.rs
+++ b/apps/desktop/src-tauri/src/commands/job_preferences.rs
@@ -30,6 +30,9 @@ const LEGACY_WIRE_NAMES: &[(&str, &str)] = &[("tech_stack", "techStack")];
 /// [`JobPreferences`](crate::job_preferences::JobPreferences) field is
 /// `skip_serializing_if = "Option::is_none"`, so an unset column contributes no
 /// key and behaves exactly as it does today.
+///
+/// One pair of fields is coupled rather than independent — see the
+/// `location`/`countryCode` rule at the end of the body.
 fn merge_over_stored(
     stored: &crate::job_preferences::JobPreferences,
     mut incoming: serde_json::Map<String, Value>,
@@ -56,6 +59,19 @@ fn merge_over_stored(
         } else {
             merged.remove(*canonical);
         }
+    }
+    // `countryCode` is not an independent field: it is captured with `location`
+    // from ONE picked geocode suggestion and is meaningless without it. So a
+    // body that CLEARS the location clears the country with it — otherwise the
+    // orphaned code keeps steering scrapes (the aggregator board seeds its
+    // country from this row) for a location the user has removed. Narrow on
+    // purpose: only an explicit `location: null` triggers it, and only when the
+    // body does not address `countryCode` itself — a caller that sends both
+    // (the renderer's clear sends two nulls; a geocode pick sends a new
+    // location AND its country) keeps exactly what it sent, and setting the
+    // location to a new string never touches a stored country.
+    if incoming.get("location").is_some_and(Value::is_null) {
+        incoming.entry("countryCode").or_insert(Value::Null);
     }
     merged.extend(incoming);
     merged
@@ -132,10 +148,23 @@ fn parse_job_preferences(
 ///   the agent CLI policy table, so no confirmation step stands between a
 ///   caller and a wipe.
 ///
-/// Read-modify-write on the store's single settings row: the read and the write
-/// take the connection lock separately, so two concurrent `set`s can interleave
-/// (last writer wins per column). That is the pre-existing shape of every
-/// setter here and is unreachable in practice — one desktop user, one row.
+/// `location` and `countryCode` clear TOGETHER: a body whose `location` is an
+/// explicit `null` and that does not name `countryCode` clears the country too
+/// (see [`merge_over_stored`]). They come from one geocode pick, so a country
+/// left behind by a cleared location would keep steering scrapes. This is the
+/// rule `JobPreferencesContract.set` (packages/shared) points at.
+///
+/// Read-merge-write on the store's single settings row runs as ONE critical
+/// section — [`JobPreferencesStore::update`](crate::job_preferences::JobPreferencesStore::update)
+/// holds the connection lock across the read, the merge and the write. Taking
+/// the lock twice (`get()` … `set()`) would let two concurrent partial updates
+/// merge from the same snapshot, so the later write erases the earlier one's
+/// field — reachable from the agent/MCP tier, where several partial bodies can
+/// be in flight at once. Nothing is `.await`ed inside, so no lock is ever held
+/// across a yield point.
+///
+/// [`parse_job_preferences`] stays pure and runs INSIDE that critical section:
+/// it must not touch the store (the mutex is not reentrant).
 ///
 /// The `{"error": …}` reply exists for the agent/MCP tier. The renderer cannot
 /// produce it: its `set()` is typed to the shared `JobPreferences` contract, so
@@ -145,11 +174,7 @@ fn parse_job_preferences(
 /// object, so a renderer `onError`/`.catch` would never run. That is tolerable
 /// here only because the renderer has no reachable path to the error branch.
 fn set_job_preferences(store: &crate::job_preferences::JobPreferencesStore, prefs: Value) -> Value {
-    let job_prefs = match parse_job_preferences(&store.get(), prefs) {
-        Ok(job_prefs) => job_prefs,
-        Err(e) => return json!({ "error": e.to_string() }),
-    };
-    match store.set(&job_prefs) {
+    match store.update(|stored| parse_job_preferences(stored, prefs)) {
         Ok(()) => json!({ "success": true }),
         Err(e) => json!({ "error": e.to_string() }),
     }
@@ -394,6 +419,69 @@ mod test {
         assert_eq!(after.country_code.as_deref(), Some("DE"));
         assert_eq!(after.salary_expectation.as_deref(), Some("€75,000"));
         assert_eq!(after.extra_agency_companies, Some(vec!["Hays".to_string()]));
+    }
+
+    /// The one coupled pair: `countryCode` is captured with `location` from a
+    /// single geocode pick, so clearing the location must clear the country
+    /// with it. A body that names only `location: null` used to leave the
+    /// stored `DE` behind — and the aggregator board seeds its country from
+    /// this row, so that orphan kept steering scrapes to a country the user
+    /// had just removed. Delete the `countryCode` insertion in
+    /// `merge_over_stored` and this fails.
+    #[test]
+    fn clearing_the_location_clears_the_country_code_with_it() {
+        let (_dir, store) = store_with_saved_preferences();
+
+        let reply = set_job_preferences(&store, json!({ "location": null }));
+
+        assert_eq!(reply, json!({ "success": true }));
+        let after = store.get();
+        assert_eq!(after.location, None);
+        assert_eq!(
+            after.country_code, None,
+            "a country left behind by a cleared location keeps steering scrapes"
+        );
+        assert_eq!(
+            after.tech_stack.as_ref().map(|ts| ts[0].name.as_str()),
+            Some("Rust"),
+            "…and only that pair clears: the unnamed columns still survive"
+        );
+        assert_eq!(after.salary_expectation.as_deref(), Some("€75,000"));
+        assert_eq!(after.extra_agency_companies, Some(vec!["Hays".to_string()]));
+    }
+
+    /// The renderer's real clear sends BOTH nulls, so the same pair must land
+    /// through the explicit shape too — the insertion above must not turn a
+    /// caller-supplied key into a duplicate or otherwise disturb the merge.
+    #[test]
+    fn an_explicit_location_and_country_pair_of_nulls_clears_both() {
+        let (_dir, store) = store_with_saved_preferences();
+
+        let reply = set_job_preferences(&store, json!({ "location": null, "countryCode": null }));
+
+        assert_eq!(reply, json!({ "success": true }));
+        let after = store.get();
+        assert_eq!(after.location, None);
+        assert_eq!(after.country_code, None);
+        assert_eq!(after.salary_expectation.as_deref(), Some("€75,000"));
+    }
+
+    /// The other direction — the geocode pick: a body SETTING the location to a
+    /// new string carries its own country, and both must be written. The
+    /// clearing rule is scoped to an explicit `location: null`, so it can never
+    /// fire here; a broader "location present → clear the country" would write
+    /// a location with no country at all.
+    #[test]
+    fn a_new_location_writes_the_country_code_sent_with_it() {
+        let (_dir, store) = store_with_saved_preferences();
+
+        let reply =
+            set_job_preferences(&store, json!({ "location": "Lisbon", "countryCode": "PT" }));
+
+        assert_eq!(reply, json!({ "success": true }));
+        let after = store.get();
+        assert_eq!(after.location.as_deref(), Some("Lisbon"));
+        assert_eq!(after.country_code.as_deref(), Some("PT"));
     }
 
     /// The renderer's own shape — a full-row spread — must still overwrite

--- a/apps/desktop/src-tauri/src/job_preferences/mod.rs
+++ b/apps/desktop/src-tauri/src/job_preferences/mod.rs
@@ -226,6 +226,14 @@ impl JobPreferencesStore {
 
     pub fn get(&self) -> JobPreferences {
         let conn = self.conn.lock();
+        Self::read_row(&conn)
+    }
+
+    /// The row read behind [`get`](Self::get), taking the connection instead of
+    /// the lock so [`update`](Self::update) can reuse it while already holding
+    /// it (`parking_lot::Mutex` is NOT reentrant — calling `get()` from inside
+    /// the critical section would deadlock).
+    fn read_row(conn: &Connection) -> JobPreferences {
         conn.query_row(
             "SELECT location, tech_stack, country_code, salary_expectation, extra_agency_companies
              FROM job_preferences WHERE id = 1",
@@ -308,6 +316,38 @@ impl JobPreferencesStore {
 
     pub fn set(&self, prefs: &JobPreferences) -> AppResult<()> {
         let conn = self.conn.lock();
+        Self::write_row(&conn, prefs)
+    }
+
+    /// Read-merge-write of the settings row **under one lock acquisition** — the
+    /// atomic form of `get()` … merge … `set()`, which is what
+    /// `commands::job_preferences::set_job_preferences` needs now that a body
+    /// merges over the stored row rather than replacing it. Done with two
+    /// acquisitions, two concurrent partial updates both merge from the same
+    /// snapshot and the later write erases the earlier one's field (the agent /
+    /// MCP tier can drive several partial `job_preferences_set` calls at once,
+    /// and each of them re-writes every column via [`set`](Self::set)'s
+    /// full-row `UPDATE`).
+    ///
+    /// `merge` runs **while the connection mutex is held**, so it must be pure
+    /// and cheap: it must not call back into this store (`parking_lot::Mutex`
+    /// is not reentrant — that deadlocks), must not block, and must not be
+    /// `.await`ed inside (the async command calls this synchronously). It gets
+    /// the stored row and returns the row to write; returning `Err` writes
+    /// NOTHING, so a refused body leaves every saved column intact.
+    pub fn update(
+        &self,
+        merge: impl FnOnce(&JobPreferences) -> AppResult<JobPreferences>,
+    ) -> AppResult<()> {
+        let conn = self.conn.lock();
+        let merged = merge(&Self::read_row(&conn))?;
+        Self::write_row(&conn, &merged)
+    }
+
+    /// The full-row write behind [`set`](Self::set) — same lock-free shape (and
+    /// same reason) as [`read_row`](Self::read_row), so [`update`](Self::update)
+    /// can pair the two inside one critical section.
+    fn write_row(conn: &Connection, prefs: &JobPreferences) -> AppResult<()> {
         let tech_stack_json = prefs
             .tech_stack
             .as_ref()

--- a/apps/desktop/src-tauri/src/job_preferences/test.rs
+++ b/apps/desktop/src-tauri/src/job_preferences/test.rs
@@ -735,3 +735,163 @@ fn a_version_5_database_gains_the_semantic_scoring_column_on_open() {
         "…and the upgrade is an ADD COLUMN, so the user's existing row survives it"
     );
 }
+
+// ── Atomic read-merge-write (`update`) ────────────────────────────────────────
+
+/// `job_preferences_set` merges its body over the stored row, and `set()` is a
+/// full-row `UPDATE`, so that read and that write must be ONE critical section.
+/// With two lock acquisitions, two concurrent partial updates both merge from
+/// the same snapshot and the later write erases the earlier one's field.
+///
+/// Only this thread writes `location` and only the other writes
+/// `salary_expectation`, so ANY value other than the one this thread last wrote
+/// is a lost update — and it is checked on EVERY iteration, not just at the end:
+/// a final-state assertion alone passes even on the racy version, because
+/// whichever thread writes last happens to carry a fresh copy of the other's
+/// field.
+#[test]
+fn two_concurrent_updates_never_lose_each_others_field() {
+    const ITERATIONS: usize = 200;
+    let temp_dir = TempDir::new().unwrap();
+    let store = JobPreferencesStore::open(&temp_dir.path().to_path_buf()).unwrap();
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            let mut previous: Option<String> = None;
+            for i in 0..ITERATIONS {
+                let mine = format!("location-{i}");
+                store
+                    .update(|stored| {
+                        assert_eq!(
+                            stored.location, previous,
+                            "the other thread's merge overwrote this thread's location: \
+                             read + write is not atomic"
+                        );
+                        Ok(JobPreferences {
+                            location: Some(mine.clone()),
+                            ..stored.clone()
+                        })
+                    })
+                    .unwrap();
+                previous = Some(mine);
+            }
+        });
+        scope.spawn(|| {
+            let mut previous: Option<String> = None;
+            for i in 0..ITERATIONS {
+                let mine = format!("€{i}");
+                store
+                    .update(|stored| {
+                        assert_eq!(
+                            stored.salary_expectation, previous,
+                            "the other thread's merge overwrote this thread's salary: \
+                             read + write is not atomic"
+                        );
+                        Ok(JobPreferences {
+                            salary_expectation: Some(mine.clone()),
+                            ..stored.clone()
+                        })
+                    })
+                    .unwrap();
+                previous = Some(mine);
+            }
+        });
+    });
+
+    let after = store.get();
+    assert_eq!(
+        after.location,
+        Some(format!("location-{}", ITERATIONS - 1)),
+        "the final row must hold BOTH threads' last values"
+    );
+    assert_eq!(
+        after.salary_expectation,
+        Some(format!("€{}", ITERATIONS - 1))
+    );
+}
+
+/// The structural half of the guarantee above, deterministic where the racing
+/// loop is statistical: a second update must not be able to COMPLETE while the
+/// first one's merge is still in flight. Re-implement `update` as `get()` then
+/// `set()` (two acquisitions) and this fails on every run — the merge would run
+/// with no lock held, so the other thread's whole read-merge-write slips through
+/// the sleep below.
+#[test]
+fn a_second_update_cannot_complete_while_a_merge_is_in_flight() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let temp_dir = TempDir::new().unwrap();
+    let store = JobPreferencesStore::open(&temp_dir.path().to_path_buf()).unwrap();
+    let merging = AtomicBool::new(false);
+    let other_finished = AtomicBool::new(false);
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            store
+                .update(|stored| {
+                    merging.store(true, Ordering::SeqCst);
+                    // A window far wider than the other thread's whole update
+                    // needs, so "it did not finish" means it was BLOCKED.
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                    assert!(
+                        !other_finished.load(Ordering::SeqCst),
+                        "another update completed while this merge was still in flight: \
+                         the read, the merge and the write are not one critical section"
+                    );
+                    Ok(JobPreferences {
+                        location: Some("Berlin".to_string()),
+                        ..stored.clone()
+                    })
+                })
+                .unwrap();
+        });
+        scope.spawn(|| {
+            while !merging.load(Ordering::SeqCst) {
+                std::thread::yield_now();
+            }
+            store
+                .update(|stored| {
+                    Ok(JobPreferences {
+                        salary_expectation: Some("€75,000".to_string()),
+                        ..stored.clone()
+                    })
+                })
+                .unwrap();
+            other_finished.store(true, Ordering::SeqCst);
+        });
+    });
+
+    let after = store.get();
+    assert_eq!(after.location.as_deref(), Some("Berlin"));
+    assert_eq!(
+        after.salary_expectation.as_deref(),
+        Some("€75,000"),
+        "the blocked update must still land once the lock is released"
+    );
+}
+
+/// A merge that REFUSES the body writes nothing — the store-level half of the
+/// command's "nothing may be written when the body is refused" test, pinned
+/// here because `update` is where the write is now skipped.
+#[test]
+fn a_failing_merge_leaves_the_stored_row_untouched() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = JobPreferencesStore::open(&temp_dir.path().to_path_buf()).unwrap();
+    store
+        .set(&JobPreferences {
+            location: Some("Berlin".to_string()),
+            country_code: Some("DE".to_string()),
+            tech_stack: None,
+            salary_expectation: None,
+            extra_agency_companies: None,
+        })
+        .unwrap();
+
+    let err = store
+        .update(|_| Err(crate::error::AppError::Validation("nope".to_string())))
+        .unwrap_err();
+
+    assert_eq!(err.to_string(), "nope");
+    assert_eq!(store.get().location, Some("Berlin".to_string()));
+    assert_eq!(store.get().country_code, Some("DE".to_string()));
+}


### PR DESCRIPTION
## Why

The last commit of #1152 was still in the pre-push gate when that PR was merged, so `main` has the preference merge semantics without two review fixes that its resolved threads describe. This PR carries that one commit.

## What changed

- `JobPreferencesStore::update(merge)` reads, merges and writes inside one critical section, so two partial updates from the renderer or an agent can no longer merge from the same snapshot and erase each other's field; `job_preferences_set` runs its pure parse inside it. Concurrency tests: two threads merging different fields 200 times each never lose a write; a second update cannot complete while a merge is in flight; a failing merge leaves the row untouched. Reverting to the two-lock version fails both.
- A body that clears `location` alone now clears `countryCode` with it, matching the contract; a body that names `countryCode` keeps what it sent, and a new location never touches the stored country. Tests cover the lone-null, two-null and new-location shapes.

## Verification

Whole Rust lib suite (5389), `job_preferences` (40), `commands::job_preferences` (12), `architecture`, clippy `-D warnings`, fmt: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
