### PR TITLE
test(settings): pin the agent-cli generic mcp hint against silent regression

### DIFF
--- a/apps/desktop/src/renderer/features/settings/components/preferences/AgentCliSection/AgentCliSection.test.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/preferences/AgentCliSection/AgentCliSection.test.tsx
@@ -88,6 +88,12 @@ describe('AgentCliSection', () => {
         2
       )
     );
+    // The generic block's hint is the only sentence telling the user the
+    // snippet above is already the whole `mcpServers` wrapper, not a section
+    // to nest inside one — a round-2 finding on this exact wording. Nothing
+    // else in this suite renders `hint`, so a dropped prop or a reworded
+    // string is invisible without this assertion.
+    expect(screen.getByText(/add just the inner entry/i)).toBeInTheDocument();
   });
 
   it('shows a skeleton, not an empty command, while the path is still being read', () => {

--- a/apps/desktop/src/renderer/features/support/support-data.test.ts
+++ b/apps/desktop/src/renderer/features/support/support-data.test.ts
@@ -167,7 +167,18 @@ describe('support corpus / translations parity', () => {
     // render the English string silently via `fallbackLng: 'en'` with no
     // gate to catch it.
     const KEY = 'settings.developer.agentCli.stayOpenNote';
-    expect(unresolved([KEY, 'settings.developer.agentCli.transcriptNote'])).toEqual([]);
+    expect(
+      unresolved([
+        KEY,
+        'settings.developer.agentCli.transcriptNote',
+        // The generic MCP block (added later, same card): its hint is the
+        // only sentence saying the copied snippet is already the whole
+        // `mcpServers` wrapper, not a section to nest inside one.
+        'settings.developer.agentCli.genericLabel',
+        'settings.developer.agentCli.genericHint',
+        'settings.developer.agentCli.copyGeneric',
+      ])
+    ).toEqual([]);
     const HEDGE_BY_LOCALE = {
       en: /most agent calls .*fail while it is closed/i,
       de: /die meisten Agentenaufrufe .*schlagen fehl, während sie geschlossen ist/i,


### PR DESCRIPTION
## Summary

Resolves review finding D1-r2-D2-FE-1 (issue #1156 follow-up round). The generic-client snippet's `hint` sentence on the Agent CLI settings card (`settings.developer.agentCli.genericHint`, added in #1175 and reworded there) had zero test coverage — deleting its render or dropping the `hint` prop left every suite green.

- `apps/desktop/src/renderer/features/settings/components/preferences/AgentCliSection/AgentCliSection.test.tsx` — asserts the hint text renders in the existing three-snippet card test.
- `apps/desktop/src/renderer/features/support/support-data.test.ts` — folds `genericLabel`/`genericHint`/`copyGeneric` into the existing en/de parity check alongside `stayOpenNote`/`transcriptNote`.

Note on branch/scope: the finding referenced `AgentCliSection/index.tsx:260`, which only exists after #1175/#1176 landed on `main`. The branch named for this task (`ui/settings-agent-card-copy`) was PR #1174, already merged before those two PRs and containing none of that code, so this fix branches off current `main` instead.

## Verification

- Mutation check: replaced the hint's `<p>` render with `{null}` — `AgentCliSection.test.tsx` failed (1 test) as expected; reverted, suite green again.
- `npx vitest run src/renderer/features/settings/components/preferences/AgentCliSection src/renderer/features/support/support-data.test.ts` — 2 files, 22 tests passed.
- `pnpm -F @ajh/desktop typecheck` — passed.
- `npx eslint` on both changed files — clean.

## Test plan

- [x] Unit tests pass (`AgentCliSection.test.tsx`, `support-data.test.ts`)
- [x] Typecheck passes
- [x] Lint clean
- [x] Mutation-verified the new assertion actually catches the regression

Refs #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnPnL9VTrHnv4syNEC4wVn