### PR TITLE
feat(landing): link the microsoft store from the download page and release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1435,13 +1435,13 @@ jobs:
 
           | Platform | Get it |
           |----------|--------|
-          | 🪟 Windows | [Installer (.exe)]($URL/windows-AI-Job-Hunter_${RAW}_x64-setup.exe) · [MSI]($URL/windows-AI-Job-Hunter_${RAW}_x64_en-US.msi) |
+          | 🪟 Windows | [Microsoft Store](https://apps.microsoft.com/detail/9nc5kdjv0btm) · [Installer (.exe)]($URL/windows-AI-Job-Hunter_${RAW}_x64-setup.exe) · [MSI]($URL/windows-AI-Job-Hunter_${RAW}_x64_en-US.msi) |
           | 🍎 macOS (Apple Silicon) | [.dmg]($URL/macos-AI-Job-Hunter_${RAW}_aarch64-apple-silicon.dmg) |
           | 🍎 macOS (Intel) | [.dmg]($URL/macos-AI-Job-Hunter_${RAW}_x64-intel.dmg) |
           | 🐧 Linux | [AppImage]($URL/linux-AI-Job-Hunter_${RAW}_amd64.AppImage) · [.deb]($URL/linux-AI-Job-Hunter_${RAW}_amd64.deb) · [.rpm]($URL/linux-AI-Job-Hunter-${RAW}-1.x86_64.rpm) |
           | 🧩 Browser extension | [Chrome (.zip)]($URL/ai-job-hunter-extension-chrome-${RAW}.zip) · [Firefox (.zip)]($URL/ai-job-hunter-extension-firefox-${RAW}.zip) |
 
-          _Installed apps auto-update — no need to re-download for new versions. The browser extension installs from its .zip (load unpacked / store upload)._
+          _The Microsoft Store build is signed, so it installs without the SmartScreen warning the direct .exe/.msi downloads trigger; it may lag this tag by a day or two while Store certification runs. Installed apps auto-update — no need to re-download for new versions. The browser extension installs from its .zip (load unpacked / store upload)._
           <!-- downloads:end -->
           EOF
           )"

--- a/apps/landing/src/components/download/DownloadBody.test.tsx
+++ b/apps/landing/src/components/download/DownloadBody.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 
-import { CHROME_EXT, FIREFOX_EXT, KOFI, PAYPAL, SPONSOR } from '@/lib/site-links';
+import { CHROME_EXT, FIREFOX_EXT, KOFI, MS_STORE, PAYPAL, SPONSOR } from '@/lib/site-links';
 import { buildInstallers } from '@/lib/version';
 
 import { DownloadBody } from './DownloadBody';
@@ -93,6 +93,17 @@ describe('DownloadBody', () => {
 
     const back = container.querySelector('a.top-back');
     expect(back?.getAttribute('href')).toBe('/');
+  });
+
+  it('renders the Microsoft Store link as a non-dl-btn anchor to MS_STORE', () => {
+    const { container } = render(<DownloadBody version={VERSION} installers={installers} />);
+    const storeBtn = container.querySelector('a.store-btn');
+    expect(storeBtn).not.toBeNull();
+    expect(storeBtn?.getAttribute('href')).toBe(MS_STORE);
+    expect(storeBtn?.classList.contains('dl-btn')).toBe(false);
+    expect(storeBtn?.hasAttribute('data-platform')).toBe(false);
+    expect(storeBtn?.getAttribute('target')).toBe('_blank');
+    expect(storeBtn?.getAttribute('rel')).toBe('noopener noreferrer');
   });
 
   it('renders the ext-grid with 2 ext-btn anchors to the Chrome and Firefox store urls', () => {

--- a/apps/landing/src/components/download/DownloadCards.tsx
+++ b/apps/landing/src/components/download/DownloadCards.tsx
@@ -1,3 +1,4 @@
+import { MS_STORE } from '@/lib/site-links';
 import type { Installers } from '@/lib/version';
 
 // Reproduces the old buildDownloadsHtml() markup (the release-pipeline-stamped
@@ -94,9 +95,18 @@ export function DownloadCards({
           <a className="dl-btn alt" data-platform="winMsi" href={installers.winMsi}>
             .msi
           </a>
+          {/* Not a `.dl-btn`: DownloadFreshness swaps installer hrefs by
+              `.dl-btn` positional index and DownloadCounts keys pills off
+              `.dl-btn[data-platform]` — an 8th `.dl-btn` here would shift
+              every installer URL over by one. This links straight to the
+              Store listing, nothing to swap or count. */}
+          <a className="store-btn" href={MS_STORE} target="_blank" rel="noopener noreferrer">
+            Microsoft Store
+          </a>
         </div>
         <p className="dl-note">
-          SmartScreen may warn (unsigned). Click &quot;More info&quot; → &quot;Run anyway&quot;.
+          SmartScreen may warn (unsigned). Click &quot;More info&quot; → &quot;Run anyway&quot; — or
+          skip the warning entirely and get it from the Microsoft Store, which is signed.
         </p>
       </div>
 

--- a/apps/landing/src/lib/site-links.ts
+++ b/apps/landing/src/lib/site-links.ts
@@ -6,6 +6,11 @@ export const GITHUB_REPO = 'https://github.com/saeedkolivand/ai-job-hunter-app';
 export const CHROME_EXT =
   'https://chromewebstore.google.com/detail/ai-job-hunter-%E2%80%94-job-impor/oaoekkgkhmgdfnpmfkpphgiikliaicll';
 export const FIREFOX_EXT = 'https://addons.mozilla.org/en-US/firefox/addon/ai-job-hunter/';
+// The owner's share link carries `?hl=en-us&gl=DE&ocid=pdpshare` — `gl=DE`
+// pins every visitor to the German storefront and `ocid` is share-tracking.
+// Neither belongs in a link served to a global audience, so both are
+// stripped; this is the canonical, query-param-free listing URL.
+export const MS_STORE = 'https://apps.microsoft.com/detail/9nc5kdjv0btm';
 export const SPONSOR = 'https://github.com/sponsors/saeedkolivand';
 export const KOFI = 'https://ko-fi.com/saeedkolivand';
 export const PAYPAL = 'https://paypal.me/saeedkolivand';

--- a/apps/landing/src/styles/download.css
+++ b/apps/landing/src/styles/download.css
@@ -177,6 +177,33 @@ h2 {
   outline-offset: 3px;
   border-radius: 12px;
 }
+/* Store link — deliberately not `.dl-btn` (see the comment at its anchor in
+   DownloadCards.tsx); reuses .dl-btn.alt's look so it still reads as a sibling
+   button rather than a new visual language. */
+.store-btn {
+  font-family: var(--hand);
+  font-size: 15px;
+  background: transparent;
+  color: var(--ink);
+  border: 2.6px solid var(--ink);
+  border-radius: 12px 9px 13px 8px;
+  padding: 7px 16px;
+  box-shadow: 2px 3px 0 rgba(0, 0, 0, 0.14);
+  text-align: center;
+  text-decoration: none;
+  transition: transform 0.14s;
+}
+.store-btn:hover {
+  transform: translateY(-2px);
+}
+/* store-btn on light pcard bg: ink ring (high contrast), same standard as
+   .dl-btn.alt:focus-visible above */
+.store-btn:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+  border-radius: 12px;
+}
+
 /* Download-count pill, appended into each .dl-btn by DownloadCounts.tsx once
    the static /downloads-by-platform.json lands. It is absent on first paint and
    absent entirely when the fetch fails, so nothing here may change the button's
@@ -290,11 +317,13 @@ h2 {
 /* reduced motion — disable transitions/transforms but keep focus-visible rings */
 @media (prefers-reduced-motion: reduce) {
   .dl-btn,
+  .store-btn,
   .ext-btn,
   .copy-cmd {
     transition: none;
   }
   .dl-btn:hover,
+  .store-btn:hover,
   .ext-btn:hover {
     transform: none;
   }


### PR DESCRIPTION
Closes #1188

The desktop app is live on the Microsoft Store: https://apps.microsoft.com/detail/9nc5kdjv0btm — and that build is signed, so it installs without the SmartScreen warning the direct `.exe`/`.msi` downloads trigger. Nothing linked to it.

## What changed

**`/download` Windows card** — a `Microsoft Store` button after `.msi`, and the SmartScreen note now offers the Store as the way to skip the warning it describes:

> SmartScreen may warn (unsigned). Click "More info" → "Run anyway" — or skip the warning entirely and get it from the Microsoft Store, which is signed.

**Release-notes Downloads table** (`.github/workflows/release.yml`) — the Windows row leads with the Store link, and the footnote explains why it may lag the tag by a day or two while Store certification runs.

**`site-links.ts`** — one `MS_STORE` constant.

## The trap this had to avoid

The new anchor deliberately carries **neither** the `dl-btn` class **nor** `data-platform`. `DownloadFreshness` swaps installer hrefs by `querySelectorAll('.dl-btn')` **positional index**, and `DownloadCounts` keys its download pills off `.dl-btn[data-platform]` — an eighth `.dl-btn` in that block would have shifted every installer URL by one, silently. `DownloadBody.test.tsx` already asserted exactly seven in a fixed order; that assertion is untouched and a new test pins the Store anchor as a non-`dl-btn`.

`.store-btn` reuses `.dl-btn.alt`'s look rather than inventing a visual language, and joins the existing `prefers-reduced-motion` suppression block.

## Link hygiene

The share URL carried `?hl=en-us&gl=DE&ocid=pdpshare`. `gl=DE` pins every visitor to the German storefront and `ocid` is share tracking, so the constant is the canonical param-free listing URL.

## Verification

- `pnpm --filter @ajh/landing test` → 39 files, 361 tests passed
- `pnpm --filter @ajh/landing typecheck` → clean
- `pnpm --filter @ajh/landing build` → static export OK
- `check:parity` → 27 phrases, 13 legacy links, 7 installer URLs present
- `check:a11y` → 14 pages, 0 WCAG A/AA violations
- Rendered the built page and screenshotted the Windows card — the Store button sits alongside `.msi` at matching weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)