### PR TITLE
fix(release): create the xdg data dir before msstore runs; surface the snap store listing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1480,7 +1480,9 @@ jobs:
           # "SellerId is not set". Fix: create the dir first so both writes
           # land in the same place. Upstream fix: SpecialFolderOption.Create
           # in ConfigurationManager.cs.
-          mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}"
+          # 0700: this dir will hold settings.json (tenant/client/seller ids)
+          # and the keyring unlocked with a throwaway password.
+          mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}" && chmod 700 "${XDG_DATA_HOME:-$HOME/.local/share}"
 
           # reconfigure (writes the secret) and publish (reads it back) both
           # go through libsecret, so they must share the same live D-Bus
@@ -1870,6 +1872,10 @@ jobs:
           # Strip any prior block (idempotent) then re-append a fresh one.
           BODY="$(gh release view "$VERSION" --json body -q .body)"
           BODY="$(printf '%s' "$BODY" | sed '/<!-- downloads:start -->/,/<!-- downloads:end -->/d')"
+          # UNQUOTED heredoc on purpose so $URL and ${RAW} expand — which also
+          # means a backtick or $( in the prose below becomes a command
+          # substitution whose failure the outer $( ) swallows (set -e will
+          # NOT catch it). Never put shell metacharacters in this table.
           TABLE="$(cat <<EOF
           <!-- downloads:start -->
           ## 📥 Downloads
@@ -1882,7 +1888,7 @@ jobs:
           | 🐧 Linux | [Snap Store](https://snapcraft.io/ai-job-hunter) · [AppImage]($URL/linux-AI-Job-Hunter_${RAW}_amd64.AppImage) · [.deb]($URL/linux-AI-Job-Hunter_${RAW}_amd64.deb) · [.rpm]($URL/linux-AI-Job-Hunter-${RAW}-1.x86_64.rpm) |
           | 🧩 Browser extension | [Chrome (.zip)]($URL/ai-job-hunter-extension-chrome-${RAW}.zip) · [Firefox (.zip)]($URL/ai-job-hunter-extension-firefox-${RAW}.zip) |
 
-          _The Microsoft Store build is signed, so it installs without the SmartScreen warning the direct .exe/.msi downloads trigger; it may lag this tag by a day or two while Store certification runs. Installed apps auto-update — no need to re-download for new versions. The browser extension installs from its .zip (load unpacked / store upload). The Snap Store build lands in the edge channel first (sudo snap install ai-job-hunter --edge) and is promoted to stable by hand once it has been checked._
+          _The Microsoft Store build is signed, so it installs without the SmartScreen warning the direct .exe/.msi downloads trigger; it may lag this tag by a day or two while Store certification runs. Installed apps auto-update — no need to re-download for new versions. The browser extension installs from its .zip (load unpacked / store upload). The Snap Store build lands in the edge channel first and is promoted to stable by hand once it has been checked; the listing page shows the install command for whichever channel is live._
           <!-- downloads:end -->
           EOF
           )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1469,19 +1469,18 @@ jobs:
           MSIX="$(readlink -f "$MSIX")"
           export MSIX
 
-          # KNOWN UPSTREAM BUG, tracked at
-          # https://github.com/microsoft/msstore-cli/issues/181 — msstore
-          # reconfigure writes a complete, correct settings.json (verified
-          # directly: read the file right after reconfigure, before the next
-          # invocation — valid JSON, SellerId/TenantId/ClientId all
-          # populated), but ANY subsequent msstore invocation in the same
-          # environment (not just publish — msstore info fails identically)
-          # reports "SellerId is not set" regardless. Ruled out directly,
-          # not assumed: XDG_DATA_HOME, the working directory (both the
-          # nested GitHub Actions workspace path and a short flat one), and
-          # any exception in the load path (none is ever logged). This job
-          # will keep failing here until that issue is resolved upstream —
-          # check it before re-investigating from scratch.
+          # ROOT CAUSE (not our config — upstream tracker:
+          # https://github.com/microsoft/msstore-cli/issues/181): .NET's
+          # GetFolderPath(LocalApplicationData) returns "" on Unix if
+          # $XDG_DATA_HOME/$HOME/.local/share doesn't exist yet, so
+          # `reconfigure` writes settings.json CWD-relative. Its libsecret
+          # store then creates ~/.local/share/keyrings/ as a side effect,
+          # so the NEXT msstore call resolves the real dir, finds no
+          # settings.json, and silently creates an empty one — hence
+          # "SellerId is not set". Fix: create the dir first so both writes
+          # land in the same place. Upstream fix: SpecialFolderOption.Create
+          # in ConfigurationManager.cs.
+          mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}"
 
           # reconfigure (writes the secret) and publish (reads it back) both
           # go through libsecret, so they must share the same live D-Bus
@@ -1880,10 +1879,10 @@ jobs:
           | 🪟 Windows | [Microsoft Store](https://apps.microsoft.com/detail/9nc5kdjv0btm) · [Installer (.exe)]($URL/windows-AI-Job-Hunter_${RAW}_x64-setup.exe) · [MSI]($URL/windows-AI-Job-Hunter_${RAW}_x64_en-US.msi) |
           | 🍎 macOS (Apple Silicon) | [.dmg]($URL/macos-AI-Job-Hunter_${RAW}_aarch64-apple-silicon.dmg) |
           | 🍎 macOS (Intel) | [.dmg]($URL/macos-AI-Job-Hunter_${RAW}_x64-intel.dmg) |
-          | 🐧 Linux | [AppImage]($URL/linux-AI-Job-Hunter_${RAW}_amd64.AppImage) · [.deb]($URL/linux-AI-Job-Hunter_${RAW}_amd64.deb) · [.rpm]($URL/linux-AI-Job-Hunter-${RAW}-1.x86_64.rpm) |
+          | 🐧 Linux | [Snap Store](https://snapcraft.io/ai-job-hunter) · [AppImage]($URL/linux-AI-Job-Hunter_${RAW}_amd64.AppImage) · [.deb]($URL/linux-AI-Job-Hunter_${RAW}_amd64.deb) · [.rpm]($URL/linux-AI-Job-Hunter-${RAW}-1.x86_64.rpm) |
           | 🧩 Browser extension | [Chrome (.zip)]($URL/ai-job-hunter-extension-chrome-${RAW}.zip) · [Firefox (.zip)]($URL/ai-job-hunter-extension-firefox-${RAW}.zip) |
 
-          _The Microsoft Store build is signed, so it installs without the SmartScreen warning the direct .exe/.msi downloads trigger; it may lag this tag by a day or two while Store certification runs. Installed apps auto-update — no need to re-download for new versions. The browser extension installs from its .zip (load unpacked / store upload)._
+          _The Microsoft Store build is signed, so it installs without the SmartScreen warning the direct .exe/.msi downloads trigger; it may lag this tag by a day or two while Store certification runs. Installed apps auto-update — no need to re-download for new versions. The browser extension installs from its .zip (load unpacked / store upload). The Snap Store build lands in the edge channel first (sudo snap install ai-job-hunter --edge) and is promoted to stable by hand once it has been checked._
           <!-- downloads:end -->
           EOF
           )"

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ Grab the latest installer for your OS from the **<a href="https://github.com/sae
 <a href="https://apps.microsoft.com/detail/9nc5kdjv0btm" target="_blank" rel="noopener noreferrer">
   <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" alt="Download from the Microsoft Store" />
 </a>
+<a href="https://snapcraft.io/ai-job-hunter" target="_blank" rel="noopener noreferrer">
+  <img src="https://snapcraft.io/en/dark/install.svg" width="182" alt="Get it from the Snap Store" />
+</a>
 
 **macOS**: open the `.dmg` and drag the app into Applications. Because the app isn't notarized by Apple, Gatekeeper may refuse to open it the first time ("app is damaged and can't be opened"). Clear the quarantine attribute once:
 

--- a/apps/landing/src/components/download/DownloadBody.test.tsx
+++ b/apps/landing/src/components/download/DownloadBody.test.tsx
@@ -2,7 +2,15 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 
-import { CHROME_EXT, FIREFOX_EXT, KOFI, MS_STORE, PAYPAL, SPONSOR } from '@/lib/site-links';
+import {
+  CHROME_EXT,
+  FIREFOX_EXT,
+  KOFI,
+  MS_STORE,
+  PAYPAL,
+  SNAP_STORE,
+  SPONSOR,
+} from '@/lib/site-links';
 import { buildInstallers } from '@/lib/version';
 
 import { DownloadBody } from './DownloadBody';
@@ -95,15 +103,21 @@ describe('DownloadBody', () => {
     expect(back?.getAttribute('href')).toBe('/');
   });
 
-  it('renders the Microsoft Store link as a non-dl-btn anchor to MS_STORE', () => {
+  it('renders both store links as non-dl-btn anchors, MS_STORE then SNAP_STORE', () => {
     const { container } = render(<DownloadBody version={VERSION} installers={installers} />);
-    const storeBtn = container.querySelector('a.store-btn');
-    expect(storeBtn).not.toBeNull();
-    expect(storeBtn?.getAttribute('href')).toBe(MS_STORE);
-    expect(storeBtn?.classList.contains('dl-btn')).toBe(false);
-    expect(storeBtn?.hasAttribute('data-platform')).toBe(false);
-    expect(storeBtn?.getAttribute('target')).toBe('_blank');
-    expect(storeBtn?.getAttribute('rel')).toBe('noopener noreferrer');
+    const storeBtns = Array.from(container.querySelectorAll('a.store-btn'));
+    expect(storeBtns).toHaveLength(2);
+    expect(storeBtns.map((a) => a.getAttribute('href'))).toEqual([MS_STORE, SNAP_STORE]);
+
+    for (const storeBtn of storeBtns) {
+      expect(storeBtn.classList.contains('dl-btn')).toBe(false);
+      expect(storeBtn.hasAttribute('data-platform')).toBe(false);
+      expect(storeBtn.getAttribute('target')).toBe('_blank');
+      expect(storeBtn.getAttribute('rel')).toBe('noopener noreferrer');
+    }
+
+    // Guards the positional invariant DownloadFreshness relies on.
+    expect(container.querySelectorAll('a.dl-btn')).toHaveLength(7);
   });
 
   it('renders the ext-grid with 2 ext-btn anchors to the Chrome and Firefox store urls', () => {

--- a/apps/landing/src/components/download/DownloadCards.tsx
+++ b/apps/landing/src/components/download/DownloadCards.tsx
@@ -1,4 +1,4 @@
-import { MS_STORE } from '@/lib/site-links';
+import { MS_STORE, SNAP_STORE } from '@/lib/site-links';
 import type { Installers } from '@/lib/version';
 
 // Reproduces the old buildDownloadsHtml() markup (the release-pipeline-stamped
@@ -125,9 +125,15 @@ export function DownloadCards({
           <a className="dl-btn alt" data-platform="linuxRpm" href={installers.linuxRpm}>
             .rpm
           </a>
+          {/* Same rationale as the Windows card's store-btn: no dl-btn, no
+              data-platform — this links straight to the Store listing. */}
+          <a className="store-btn" href={SNAP_STORE} target="_blank" rel="noopener noreferrer">
+            Snap Store
+          </a>
         </div>
         <p className="dl-note">
-          <code>chmod +x</code> the AppImage, then run it.
+          <code>chmod +x</code> the AppImage, then run it. Or install it from the Snap Store (edge
+          channel for now).
         </p>
       </div>
     </div>

--- a/apps/landing/src/lib/site-links.ts
+++ b/apps/landing/src/lib/site-links.ts
@@ -11,6 +11,10 @@ export const FIREFOX_EXT = 'https://addons.mozilla.org/en-US/firefox/addon/ai-jo
 // Neither belongs in a link served to a global audience, so both are
 // stripped; this is the canonical, query-param-free listing URL.
 export const MS_STORE = 'https://apps.microsoft.com/detail/9nc5kdjv0btm';
+// Only the `edge` channel is published so far — the store page itself shows
+// the channel-correct install command, so DownloadCards links here rather
+// than printing `snap install` directly.
+export const SNAP_STORE = 'https://snapcraft.io/ai-job-hunter';
 export const SPONSOR = 'https://github.com/sponsors/saeedkolivand';
 export const KOFI = 'https://ko-fi.com/saeedkolivand';
 export const PAYPAL = 'https://paypal.me/saeedkolivand';

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -328,6 +328,10 @@ Which container is running is a **runtime** question: `platform::snap::is_packag
 
 The `publish-snap` job in `release.yml` publishes to the Snap Store's **`edge` channel only** — never auto-promoted to `stable`. Approval and promotion to `stable` remain manual, as the Store's own review process and versioning strategy require. The job is wired as a standalone dispatch option (the same model as `publish-chrome`/`publish-firefox` for store-specific re-runs); see the job's own comment and implementation in `.github/workflows/release.yml` for the full details. Before the job runs, `scripts/sync-snapcraft.cjs` (mirrors `sync-cask.cjs`'s job) bumps the Snap manifest's `version` field to match the release version.
 
+Listing: https://snapcraft.io/ai-job-hunter
+
+When the snap is promoted to `stable`, three places still say "edge" and need the same edit: the `SNAP_STORE` comment in `apps/landing/src/lib/site-links.ts`, the Linux card note in `apps/landing/src/components/download/DownloadCards.tsx`, and the Downloads-table footnote in `release.yml`'s `create-release` job (that one self-corrects on the next tag; the landing copy is a static export and does not).
+
 ### Local test loop
 
 The Snap build requires snapcraft and a real `$SNAP` environment; it cannot be tested on the primary Windows dev machine. Testing must occur on Linux/WSL:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -330,7 +330,7 @@ The `publish-snap` job in `release.yml` publishes to the Snap Store's **`edge` c
 
 Listing: https://snapcraft.io/ai-job-hunter
 
-When the snap is promoted to `stable`, three places still say "edge" and need the same edit: the `SNAP_STORE` comment in `apps/landing/src/lib/site-links.ts`, the Linux card note in `apps/landing/src/components/download/DownloadCards.tsx`, and the Downloads-table footnote in `release.yml`'s `create-release` job (that one self-corrects on the next tag; the landing copy is a static export and does not).
+When the snap is promoted to `stable`, three places still say "edge" and need the same edit: the `SNAP_STORE` comment in `apps/landing/src/lib/site-links.ts`, the Linux card note in `apps/landing/src/components/download/DownloadCards.tsx`, and the Downloads-table footnote in `release.yml`'s `generate-update-manifest` job (that one self-corrects on the next tag; the landing copy is a static export and does not).
 
 ### Local test loop
 


### PR DESCRIPTION
## Microsoft Store auto-submit: root cause found and fixed

`publish-msstore` failed on every run at the `reconfigure` → `publish` handoff with `SellerId is not set` (filed upstream as microsoft/msstore-cli#181). It is not a CLI file-handling bug. Reproduced locally with the real v0.4.2 Linux binary and no credentials:

1. msstore-cli builds its settings dir from .NET's `Environment.GetFolderPath(LocalApplicationData)`.
2. On Unix that call returns an **empty string** when the resolved directory (`$XDG_DATA_HOME` or `~/.local/share`) does not exist yet (`SpecialFolderOption.None` semantics), so the settings dir becomes the **cwd-relative** `Microsoft/MSStore.CLI/`. That is exactly where earlier runs found `settings.json`.
3. `reconfigure` writes there, then stores the client secret through libsecret. gnome-keyring creates `~/.local/share/keyrings/` on that first store, so `reconfigure` itself brings `~/.local/share` into existence.
4. The next `msstore` process resolves `~/.local/share/Microsoft/MSStore.CLI/`, finds nothing, silently starts from an empty config, and reports `SellerId is not set`.

Fix: create the directory (0700) before the first `msstore` call. Verified in WSL: same binary writes cwd-relative with the dir absent and to `~/.local/share/…` with it present; the keyring dir appears only after the first secret store. An Opus refutation pass could not break the claim and found matching evidence in the earlier runner logs (a valid `./Microsoft/MSStore.CLI/settings.json` present in publish's own cwd, yet `File.Exists` false with no exception logged).

Also in this PR: a guard comment on the unquoted release-notes heredoc, and the copy-pasteable `--edge` command removed from release notes so the manual stable-promotion gate is not inverted by the notes.

## Snap Store listing surfaced

First snap went live today (`ai-job-hunter`, revision 2, `edge`). Linked from the README badge row, the release-notes downloads table (Linux row, store-first like Windows), the landing Linux card (a `store-btn`, not a `dl-btn`, so the positional installer-URL contract stays at 7), and `docs/DEPLOYMENT.md`, which now also lists the three places that must change when the snap is promoted to stable.

## Review

Sonnet author → Opus pr-reviewer (APPROVE, 1 MEDIUM + 1 LOW, both folded) + Opus root-cause refuter (not refuted, confidence 88) → Opus security critic (APPROVE; its advisories folded). Landing typecheck, tests, parity and drift checks pass locally and in the pre-push gate.

Follow-up filed: #1197 (msstore-cli is installed from `releases/latest` with a same-origin checksum; pin it now that the job actually runs with credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)