### PR TITLE
ci(release): pin msstore-cli to v0.4.2 and verify against a committed sha256

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1421,7 +1421,7 @@ jobs:
           set -euo pipefail
           echo "::group::Installing msstore CLI $MSSTORE_CLI_VERSION"
           cd "$RUNNER_TEMP"
-          curl -sSLO "https://github.com/microsoft/msstore-cli/releases/download/$MSSTORE_CLI_VERSION/MSStoreCLI-linux-x64.tar.gz"
+          curl -fsSLO "https://github.com/microsoft/msstore-cli/releases/download/$MSSTORE_CLI_VERSION/MSStoreCLI-linux-x64.tar.gz"
           echo "$MSSTORE_CLI_SHA256  MSStoreCLI-linux-x64.tar.gz" | sha256sum -c -
           mkdir -p "$HOME/.local/msstore-cli"
           tar -xzf MSStoreCLI-linux-x64.tar.gz -C "$HOME/.local/msstore-cli"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1407,22 +1407,22 @@ jobs:
 
       # msstore-cli is NOT a .NET global tool (no NuGet package exists) —
       # it ships as a self-contained tarball per-OS from its own GitHub
-      # releases. Verified against the sha256 the release publishes alongside it.
+      # releases. Pinned to a release tag and verified against the checksum
+      # committed HERE, not the .sha256.txt published next to the tarball:
+      # a same-origin checksum only proves the download survived transit,
+      # never that upstream is still the release that was reviewed (#1197).
+      # Bump both values together — the sha256 is that tag's
+      # MSStoreCLI-linux-x64.tar.gz, recomputed locally with sha256sum.
       - name: 📥 Install the Microsoft Store Developer CLI
+        env:
+          MSSTORE_CLI_VERSION: v0.4.2
+          MSSTORE_CLI_SHA256: 2810cb60c4688351136bbffa321d368153c003027aec60ae1346644fd6b392e2
         run: |
           set -euo pipefail
-          echo "::group::Installing msstore CLI"
+          echo "::group::Installing msstore CLI $MSSTORE_CLI_VERSION"
           cd "$RUNNER_TEMP"
-          curl -sSLO https://github.com/microsoft/msstore-cli/releases/latest/download/MSStoreCLI-linux-x64.tar.gz
-          curl -sSLO https://github.com/microsoft/msstore-cli/releases/latest/download/MSStoreCLI-linux-x64.tar.gz.sha256.txt
-          # The .sha256.txt Microsoft publishes is UTF-16LE with a BOM, not
-          # UTF-8 — sha256sum can't parse a checksum line with a null byte
-          # after every character, so it must be converted first. iconv's
-          # output still carries the BOM (now UTF-8-encoded), stripped by
-          # the sed pass. Verified directly against the real download, not
-          # assumed: sha256sum -c failed silently-wrong ("no properly
-          # formatted checksum lines found") without this conversion.
-          iconv -f UTF-16LE -t UTF-8 MSStoreCLI-linux-x64.tar.gz.sha256.txt | sed '1s/^\xEF\xBB\xBF//' | sha256sum -c -
+          curl -sSLO "https://github.com/microsoft/msstore-cli/releases/download/$MSSTORE_CLI_VERSION/MSStoreCLI-linux-x64.tar.gz"
+          echo "$MSSTORE_CLI_SHA256  MSStoreCLI-linux-x64.tar.gz" | sha256sum -c -
           mkdir -p "$HOME/.local/msstore-cli"
           tar -xzf MSStoreCLI-linux-x64.tar.gz -C "$HOME/.local/msstore-cli"
           chmod +x "$HOME/.local/msstore-cli/msstore"


### PR DESCRIPTION
Closes #1197.

`publish-msstore` installed the Microsoft Store Developer CLI from `releases/latest` and checked it against the `.sha256.txt` published next to the tarball. A same-origin checksum only proves the download survived transit; it cannot tell a reviewed release from a repointed one, and `latest` floats. Now that #1198 lets the job run to completion with real Store credentials, that gap is live.

This pins the tag and the tarball's sha256 as two step-level env values, verified against a plain `sha256sum -c` line (the UTF-16LE `.sha256.txt` dance is gone with it). `v0.4.2` is the current latest release, so the running binary does not change. `curl -f` makes a bad tag fail as an HTTP error rather than a misleading checksum mismatch.

Verified locally: the committed digest matches both a fresh download of the pinned URL and Microsoft's published checksum; a wrong digest aborts the step under `set -euo pipefail`. Opus pr-reviewer: APPROVE (its one LOW, the `-f`, is folded). zizmor and the workflow-catalog check pass.

Bumping: change both env values together; the digest is `sha256sum` of that tag's `MSStoreCLI-linux-x64.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)