### PR TITLE
ci(charts): count store installs in the public installs badge

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -109,13 +109,15 @@ jobs:
           # It shipped missing exactly once, because repo-charts.yml builds the
           # badges tree from its own hardcoded file list: adding an output to
           # build-repo-charts.mjs publishes nothing until that list names it too.
-          if git show "FETCH_HEAD:downloads-by-platform.json" > apps/landing/public/downloads-by-platform.json 2>/dev/null \
-            && [ -s apps/landing/public/downloads-by-platform.json ]; then
-            echo "fetched downloads-by-platform.json ($(wc -c < apps/landing/public/downloads-by-platform.json) bytes)"
-          else
-            rm -f apps/landing/public/downloads-by-platform.json
-            echo "::warning::downloads-by-platform.json missing on the badges branch — /download ships without its count pills. Check the publish list in repo-charts.yml."
-          fi
+          for f in downloads-by-platform.json store-counts.json; do
+            if git show "FETCH_HEAD:$f" > "apps/landing/public/$f" 2>/dev/null \
+              && [ -s "apps/landing/public/$f" ]; then
+              echo "fetched $f ($(wc -c < "apps/landing/public/$f") bytes)"
+            else
+              rm -f "apps/landing/public/$f"
+              echo "::warning::$f missing on the badges branch — the page it feeds degrades quietly. Check the publish list in repo-charts.yml."
+            fi
+          done
 
       - name: 🏗️ Build landing (static export)
         run: pnpm --filter @ajh/landing build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -115,7 +115,7 @@ jobs:
               echo "fetched $f ($(wc -c < "apps/landing/public/$f") bytes)"
             else
               rm -f "apps/landing/public/$f"
-              echo "::warning::$f missing on the badges branch — the page it feeds degrades quietly. Check the publish list in repo-charts.yml."
+              echo "::warning::$f missing on the badges branch — /download ships without the figure $f feeds. Check the publish list in repo-charts.yml."
             fi
           done
 

--- a/.github/workflows/repo-charts.yml
+++ b/.github/workflows/repo-charts.yml
@@ -6,15 +6,18 @@ name: 📈 Repo Charts
 # Purpose: publish everything the README embeds about repo growth, generated
 #   in-repo so no third-party service sits in the README's critical path.
 #
-#   1. downloads.json         — Shields endpoint badge. The stock
-#        github/downloads/<repo>/total badge is updater-inflated (it sums
-#        latest.json polling, .sig fetches and Tauri update payloads);
-#        scripts/build-repo-charts.mjs keeps only OS installers.
-#   2. downloads-history.json — the daily series behind the chart. GitHub has NO
-#        historical download endpoint, so a time series exists only because this
-#        job appends one reading per day. Losing this file loses the past.
+#   1. downloads.json         — Shields endpoint badge, labeled "installs": GitHub
+#        installer downloads (the stock github/downloads/<repo>/total badge is
+#        updater-inflated — it sums latest.json polling, .sig fetches and Tauri
+#        update payloads; scripts/build-repo-charts.mjs keeps only OS installers)
+#        plus Microsoft Store, Snap Store, Chrome Web Store and Firefox AMO counts.
+#   2. downloads-history.json — the daily series behind the chart, GitHub-only.
+#        GitHub has NO historical download endpoint, so a time series exists only
+#        because this job appends one reading per day. Losing this file loses the past.
 #   3. downloads.svg          — that series, drawn.
 #   4. stars.svg              — star history, rebuilt from scratch each run.
+#   5. store-counts.json      — the store-side counters behind #1's sum, published
+#        for transparency (nulls preserved when a store is unreachable).
 #
 #   Charts are dark-only, matching apps/landing's body (#0a0c11 / #e7ecf3).
 #
@@ -89,9 +92,17 @@ jobs:
             echo "no prior history on the badges branch — seeding from the repo"
           fi
 
+      - name: 🧰 Install snapcraft (Snap Store metrics)
+        run: |
+          sudo snap install snapcraft --classic || echo "::warning::snapcraft install failed — the Snap Store installed base will be reported as unavailable"
+
       - name: 📊 Build badge and charts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
+          MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+          MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: node scripts/build-repo-charts.mjs --prev-history prev-history.json
 
       - name: 📤 Publish to the badges branch
@@ -118,7 +129,7 @@ jobs:
             # pages.yml's fetch loop. Adding an output to the script alone publishes
             # nothing — which is exactly how downloads-by-platform.json shipped
             # missing and broke the next Pages deploy.
-            for f in downloads.json downloads-by-platform.json downloads-history.json downloads.svg stars.svg; do
+            for f in downloads.json downloads-by-platform.json store-counts.json downloads-history.json downloads.svg stars.svg; do
               [ -f "badge-out/$f" ] || continue
               printf '100644 blob %s\t%s\n' "$(git hash-object -w "badge-out/$f")" "$f"
             done | git mktree

--- a/.github/workflows/repo-charts.yml
+++ b/.github/workflows/repo-charts.yml
@@ -93,8 +93,9 @@ jobs:
           fi
 
       - name: 🧰 Install snapcraft (Snap Store metrics)
+        timeout-minutes: 4
         run: |
-          sudo snap install snapcraft --classic || echo "::warning::snapcraft install failed — the Snap Store installed base will be reported as unavailable"
+          sudo snap install snapcraft --classic --channel=latest/stable || echo "::warning::snapcraft install failed — the Snap Store installed base will be reported as unavailable"
 
       - name: 📊 Build badge and charts
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -273,6 +273,7 @@ apps/landing/public/world/vid/
 apps/landing/public/stars.svg
 apps/landing/public/downloads.svg
 apps/landing/public/downloads-by-platform.json
+apps/landing/public/store-counts.json
 
 # ── Generated image sets ───────────────────────────────────────────────────────
 # All rendered output, not source: every file below is produced by a committed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 <p align="center">
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Release" src="https://img.shields.io/github/v/release/saeedkolivand/ai-job-hunter-app?color=e24b4a&label=release"></a>
-  <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Downloads" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/saeedkolivand/ai-job-hunter-app/badges/downloads.json"></a>
+  <a href="https://github.com/saeedkolivand/ai-job-hunter-app/releases"><img alt="Installs" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/saeedkolivand/ai-job-hunter-app/badges/downloads.json"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/actions/workflows/ci-pipeline.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/saeedkolivand/ai-job-hunter-app/ci-pipeline.yml?label=CI"></a>
   <a href="https://github.com/saeedkolivand/ai-job-hunter-app/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/saeedkolivand/ai-job-hunter-app"></a>
   <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>

--- a/apps/landing/src/components/DownloadCounts.test.tsx
+++ b/apps/landing/src/components/DownloadCounts.test.tsx
@@ -22,14 +22,19 @@ const COUNTS = {
   linuxRpm: 0,
 };
 
-function stubFetch(impl: () => unknown) {
+// Dispatches on the requested URL, so the by-platform pills and the installs
+// total (two independent fetches) can be stubbed differently in one test. A
+// stub that ignores the `url` argument — most of the existing tests below —
+// answers both endpoints identically, which is fine for cases that don't care.
+function stubFetch(impl: (url: string) => unknown) {
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.resolve(impl()))
+    vi.fn((url: string) => Promise.resolve(impl(url)))
   );
 }
 
 const ok = (body: unknown) => ({ ok: true, json: () => Promise.resolve(body) });
+const notOk = { ok: false, json: () => Promise.reject(new Error('nope')) };
 
 /** The real download page, so the pills are tested against the real buttons. */
 function renderPage() {
@@ -110,7 +115,7 @@ describe('DownloadCounts', () => {
   });
 
   it('stays silent when the counts file is missing, and never touches the buttons', async () => {
-    stubFetch(() => ({ ok: false, json: () => Promise.reject(new Error('nope')) }));
+    stubFetch(() => notOk);
     const { container } = renderPage();
 
     await waitFor(() => expect(container.querySelectorAll('a.dl-btn')).toHaveLength(7));
@@ -130,5 +135,34 @@ describe('DownloadCounts', () => {
     const { container } = renderPage();
     await waitFor(() => expect(container.querySelectorAll('a.dl-btn')).toHaveLength(7));
     expect(container.querySelectorAll('.dl-count')).toHaveLength(0);
+  });
+
+  it('renders the installs total and un-hides it, formatted', async () => {
+    stubFetch((url) =>
+      url.includes('store-counts')
+        ? ok({ total: 12345, github: 12000, msStore: 200, snap: 100, chrome: 40, firefox: 5 })
+        : ok(COUNTS)
+    );
+    const { container } = renderPage();
+
+    const el = () => container.querySelector<HTMLElement>('[data-installs-total]');
+    await waitFor(() => expect(el()?.hidden).toBe(false));
+    expect(el()?.textContent).toContain('12,345 installs so far');
+  });
+
+  it('keeps the installs total hidden when store-counts.json 404s, without touching the pills', async () => {
+    stubFetch((url) => (url.includes('store-counts') ? notOk : ok(COUNTS)));
+    const { container } = renderPage();
+
+    await waitFor(() => expect(container.querySelectorAll('.dl-count')).toHaveLength(7));
+    expect(container.querySelector<HTMLElement>('[data-installs-total]')?.hidden).toBe(true);
+  });
+
+  it('keeps the installs total hidden when `total` is malformed', async () => {
+    stubFetch((url) => (url.includes('store-counts') ? ok({ total: 'lots' }) : ok(COUNTS)));
+    const { container } = renderPage();
+
+    await waitFor(() => expect(container.querySelectorAll('.dl-count')).toHaveLength(7));
+    expect(container.querySelector<HTMLElement>('[data-installs-total]')?.hidden).toBe(true);
   });
 });

--- a/apps/landing/src/components/DownloadCounts.test.tsx
+++ b/apps/landing/src/components/DownloadCounts.test.tsx
@@ -158,6 +158,20 @@ describe('DownloadCounts', () => {
     expect(container.querySelector<HTMLElement>('[data-installs-total]')?.hidden).toBe(true);
   });
 
+  it('renders the installs total when downloads-by-platform.json 404s, without any pills', async () => {
+    stubFetch((url) =>
+      url.includes('store-counts')
+        ? ok({ total: 999, github: 900, msStore: 50, snap: 30, chrome: 15, firefox: 4 })
+        : notOk
+    );
+    const { container } = renderPage();
+
+    const el = () => container.querySelector<HTMLElement>('[data-installs-total]');
+    await waitFor(() => expect(el()?.hidden).toBe(false));
+    expect(el()?.textContent).toContain('999 installs so far');
+    expect(container.querySelectorAll('.dl-count')).toHaveLength(0);
+  });
+
   it('keeps the installs total hidden when `total` is malformed', async () => {
     stubFetch((url) => (url.includes('store-counts') ? ok({ total: 'lots' }) : ok(COUNTS)));
     const { container } = renderPage();

--- a/apps/landing/src/components/DownloadCounts.tsx
+++ b/apps/landing/src/components/DownloadCounts.tsx
@@ -20,6 +20,15 @@ import { useEffect } from 'react';
 // this follows the idiom that is already here rather than adding a second one.
 const COUNTS_URL = '/downloads-by-platform.json';
 
+// The second, independent figure this component fills in: one public
+// "installs" total (GitHub installer downloads plus the Microsoft, Snap,
+// Chrome and Firefox store counts — see scripts/lib/store-counts.mjs for the
+// unit caveat, since a store "user" or "acquisition" isn't literally a
+// download). It has its own fetch, its own try/catch and its own placeholder
+// element, so a failure or absence here never touches the per-platform pills
+// above and vice versa.
+const STORE_COUNTS_URL = '/store-counts.json';
+
 export function DownloadCounts() {
   useEffect(() => {
     let cancelled = false;
@@ -59,6 +68,37 @@ export function DownloadCounts() {
       } catch {
         // Silent, like DownloadFreshness: a missing count must never cost
         // someone the download button it sits on.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const res = await fetch(STORE_COUNTS_URL);
+        if (!res.ok || cancelled) return;
+        const data: unknown = await res.json();
+        if (cancelled || typeof data !== 'object' || data === null) return;
+
+        const total = (data as Record<string, unknown>).total;
+        if (typeof total !== 'number' || !Number.isFinite(total) || total < 0) return;
+
+        const el = document.querySelector<HTMLElement>('[data-installs-total]');
+        // StrictMode-safe: a second run must not re-fill an already-filled node.
+        if (!el || el.textContent) return;
+
+        const format = new Intl.NumberFormat('en-US');
+        el.textContent = `${format.format(total)} installs so far — GitHub downloads plus the Microsoft, Snap, Chrome and Firefox stores.`;
+        el.hidden = false;
+      } catch {
+        // Silent, same contract as the per-platform fetch above: a missing or
+        // malformed total must never break the page, just leave it hidden.
       }
     })();
 

--- a/apps/landing/src/components/DownloadCounts.tsx
+++ b/apps/landing/src/components/DownloadCounts.tsx
@@ -94,8 +94,11 @@ export function DownloadCounts() {
         if (!el || el.textContent) return;
 
         const format = new Intl.NumberFormat('en-US');
-        el.textContent = `${format.format(total)} installs so far — GitHub downloads plus the Microsoft, Snap, Chrome and Firefox stores.`;
+        // Un-hide BEFORE filling the text: aria-live only announces mutations
+        // of a region that is already rendered, so setting textContent first
+        // would speak to nobody.
         el.hidden = false;
+        el.textContent = `${format.format(total)} installs so far — GitHub downloads plus the app and extension stores.`;
       } catch {
         // Silent, same contract as the per-platform fetch above: a missing or
         // malformed total must never break the page, just leave it hidden.

--- a/apps/landing/src/components/download/DownloadBody.test.tsx
+++ b/apps/landing/src/components/download/DownloadBody.test.tsx
@@ -95,6 +95,15 @@ describe('DownloadBody', () => {
     }
   });
 
+  it('renders the installs-total placeholder hidden at SSR', () => {
+    const { container } = render(<DownloadBody version={VERSION} installers={installers} />);
+    const el = container.querySelector('[data-installs-total]');
+    expect(el).not.toBeNull();
+    expect(el?.classList.contains('installs-total')).toBe(true);
+    expect((el as HTMLElement | null)?.hidden).toBe(true);
+    expect(el?.textContent).toBe('');
+  });
+
   it('renders the h1 and the top back-link', () => {
     const { container } = render(<DownloadBody version={VERSION} installers={installers} />);
     expect(container.querySelector('h1')?.textContent).toBe('Take the app');

--- a/apps/landing/src/components/download/DownloadBody.tsx
+++ b/apps/landing/src/components/download/DownloadBody.tsx
@@ -25,6 +25,10 @@ export function DownloadBody({ version, installers }: { version: string; install
           reassure it.
         </p>
 
+        {/* Filled and un-hidden at runtime by DownloadCounts once /store-counts.json
+            lands (empty + hidden here so SSR never shows a stale or zero figure). */}
+        <p className="installs-total" data-installs-total hidden aria-live="polite" />
+
         <div className="platforms">
           <DownloadCards version={version} installers={installers} />
         </div>

--- a/apps/landing/src/styles/download.css
+++ b/apps/landing/src/styles/download.css
@@ -78,6 +78,16 @@ code {
   color: var(--ink);
 }
 
+/* Filled + un-hidden at runtime by DownloadCounts once /store-counts.json
+   lands (see DownloadBody.tsx); empty and hidden at SSR, so nothing here may
+   assume it is present. */
+.installs-total {
+  font-family: var(--hand);
+  font-size: 13px;
+  color: var(--muted);
+  margin: 6px 0 0;
+}
+
 h2 {
   font-family: var(--scrawl);
   font-size: clamp(18px, 4vw, 24px);

--- a/apps/landing/src/styles/download.css
+++ b/apps/landing/src/styles/download.css
@@ -83,7 +83,7 @@ code {
    assume it is present. */
 .installs-total {
   font-family: var(--hand);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--muted);
   margin: 6px 0 0;
 }

--- a/scripts/build-repo-charts.mjs
+++ b/scripts/build-repo-charts.mjs
@@ -18,7 +18,7 @@
 //     seeded once from git history (scripts/backfill-downloads-history.mjs) and
 //     appended to daily from here.
 //
-// Output: badge-out/{downloads.json,downloads-by-platform.json,
+// Output: badge-out/{downloads.json,downloads-by-platform.json,store-counts.json,
 //                    downloads-history.json,downloads.svg,stars.svg}
 // Run locally: GITHUB_TOKEN=$(gh auth token) node scripts/build-repo-charts.mjs
 
@@ -34,6 +34,7 @@ import {
   installerDownloads,
 } from './lib/github-releases.mjs';
 import { GOLD, RED, renderLineChart } from './lib/line-chart-svg.mjs';
+import { collectStoreCounts, totalInstalls } from './lib/store-counts.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const outDir = join(here, '..', 'badge-out');
@@ -69,6 +70,8 @@ function starSeries(stargazers) {
 
 const releases = await fetchAllReleases();
 const total = installerDownloads(releases);
+const stores = await collectStoreCounts();
+const installs = totalInstalls({ github: total, ...stores });
 
 // `--prev-history` is the copy the workflow fetched off the `badges` branch.
 // Absent on a first run, and absent locally — both degrade to seed-only.
@@ -76,6 +79,9 @@ const prevArg = process.argv.indexOf('--prev-history');
 const prevHistory =
   prevArg === -1 ? [] : readJsonArray(process.argv[prevArg + 1], 'prior downloads history');
 
+// History and both charts below stay GitHub-only (`total`, not `installs`):
+// their seed is GitHub-only, so mixing in store counts would draw a fake jump
+// on the day the stores were added rather than reflecting real growth.
 const history = mergePoints(readJsonArray(seedPath, 'downloads history seed'), prevHistory, [
   { date: today, value: total },
 ]);
@@ -84,9 +90,18 @@ mkdirSync(outDir, { recursive: true });
 
 writeFileSync(
   join(outDir, 'downloads.json'),
-  `${JSON.stringify({ schemaVersion: 1, label: 'downloads', message: humanize(total), color: RED.slice(1) }, null, 2)}\n`
+  `${JSON.stringify({ schemaVersion: 1, label: 'installs', message: humanize(installs), color: RED.slice(1) }, null, 2)}\n`
 );
 writeFileSync(join(outDir, 'downloads-history.json'), `${JSON.stringify(history, null, 2)}\n`);
+
+// One public number, everything an install by any reading: GitHub installer
+// downloads (floor-corrected) plus Microsoft Store acquisitions, Snap Store
+// installed base, Chrome Web Store users and Firefox AMO average daily users.
+// Nulls are preserved (not zeroed) so a store outage stays visible here.
+writeFileSync(
+  join(outDir, 'store-counts.json'),
+  `${JSON.stringify({ generatedAt: today, github: total, ...stores, total: installs }, null, 2)}\n`
+);
 
 // Per-platform split for the /download buttons. Published here rather than
 // fetched by the page: the honest number is cumulative across every release, so
@@ -132,5 +147,6 @@ if (stars.length) {
 
 process.stderr.write(
   `downloads: ${total} installers, ${history.length} daily points (${history[0]?.date} → ${history.at(-1)?.date})\n` +
-    `stars: ${stargazers.length} stargazers, ${stars.length} dated points\n`
+    `stars: ${stargazers.length} stargazers, ${stars.length} dated points\n` +
+    `installs: ${installs} (github ${total} + stores msStore ${stores.msStore} snap ${stores.snap} chrome ${stores.chrome} firefox ${stores.firefox})\n`
 );

--- a/scripts/lib/store-counts.mjs
+++ b/scripts/lib/store-counts.mjs
@@ -160,15 +160,26 @@ export async function fetchMsStoreAcquisitions(env = process.env) {
       `?applicationId=${MS_STORE_APP_ID}&startDate=${MS_STORE_START_DATE}&endDate=${today}` +
       '&aggregationLevel=day&top=10000';
     const pages = [];
-    while (url) {
+    // Hard cap: `top=10000` with no `groupby` returns rows disaggregated
+    // across date x market x deviceType x ..., so page count only grows over
+    // time. A runaway (or looping) @nextLink must not spin forever.
+    const MAX_PAGES = 50;
+    while (url && pages.length < MAX_PAGES) {
       const res = await fetch(url, {
         headers: { authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(20_000),
       });
-      if (!res.ok) break;
+      // Fail loud, not quiet: a non-2xx mid-pagination means the sum so far
+      // is partial. Returning it would silently publish a truncated count.
+      if (!res.ok) return null;
       const page = await res.json();
       pages.push(page);
-      url = page['@nextLink'] || null;
+      // `@nextLink` is documented as relative to the analytics base path, so
+      // resolve it against a base rather than fetching it as-is.
+      url = page['@nextLink']
+        ? new URL(page['@nextLink'], 'https://manage.devcenter.microsoft.com/v1.0/my/analytics/')
+            .href
+        : null;
     }
     return sumAcquisitions(pages);
   } catch {

--- a/scripts/lib/store-counts.mjs
+++ b/scripts/lib/store-counts.mjs
@@ -22,6 +22,8 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+// Must match MSSTORE_PRODUCT_ID in .github/workflows/release.yml — same app,
+// two separate pipelines (publish vs. read-only metrics).
 const MS_STORE_APP_ID = '9NC5KDJV0BTM';
 // The listing went live 2026-09-09; started a week early on purpose so a clock
 // skew or a late first read can never fall outside the window.
@@ -50,10 +52,12 @@ export function parseChromeUsers(html) {
   const m = /([\d,.]+)\s*([KM])?\+?\s*users/i.exec(html ?? '');
   if (!m) return null;
   const n = Number.parseFloat(m[1].replace(/,/g, ''));
-  if (!Number.isFinite(n)) return null;
+  if (!Number.isFinite(n) || n < 0) return null;
   const multiplier =
     m[2]?.toUpperCase() === 'K' ? 1_000 : m[2]?.toUpperCase() === 'M' ? 1_000_000 : 1;
-  return Math.round(n * multiplier);
+  const result = Math.round(n * multiplier);
+  // Sanity ceiling: guards against matching some other number on the page.
+  return result > 5_000_000 ? null : result;
 }
 
 /**
@@ -65,8 +69,21 @@ export function snapInstalledBase(json) {
   const metric = Array.isArray(json?.metrics) ? json.metrics[0] : json;
   if (!metric || !Array.isArray(metric.series) || !Array.isArray(metric.buckets)) return null;
   if (metric.buckets.length === 0) return null;
-  const last = metric.buckets.length - 1;
-  return metric.series.reduce((sum, s) => sum + (Number(s?.values?.[last]) || 0), 0);
+  if (typeof metric.status === 'string' && metric.status !== 'OK') return null;
+
+  const hasReading = (i) =>
+    metric.series.some((s) => {
+      const v = s?.values?.[i];
+      return typeof v === 'number' && Number.isFinite(v);
+    });
+  // An all-null latest day must read as "unavailable", not 0 — walk back to
+  // the most recent bucket that actually has a reading.
+  let last = metric.buckets.length - 1;
+  while (last >= 0 && !hasReading(last)) last -= 1;
+  if (last < 0) return null;
+
+  const total = metric.series.reduce((sum, s) => sum + (Number(s?.values?.[last]) || 0), 0);
+  return total < 0 ? null : total;
 }
 
 /** Sum of `acquisitionQuantity` across every paginated Microsoft Store response. */
@@ -78,7 +95,7 @@ export function sumAcquisitions(pages) {
     sawValueArray = true;
     for (const row of page.Value) {
       const q = row?.acquisitionQuantity;
-      if (typeof q === 'number' && Number.isFinite(q)) sum += q;
+      if (typeof q === 'number' && Number.isFinite(q) && q >= 0) sum += q;
     }
   }
   return sawValueArray ? sum : null;
@@ -125,14 +142,14 @@ export async function fetchChromeUsers(id = 'oaoekkgkhmgdfnpmfkpphgiikliaicll') 
 
 /**
  * Microsoft Store — OAuth2 client-credentials token, then a paginated
- * analytics GET. `null` (with a stderr note) when any of the three secrets is
- * missing, so an unconfigured store degrades exactly like an unreachable one.
- * Never logs the token, the secret, a URL that carries them, or a response body.
+ * analytics GET. `null` when any of the three secrets is missing (collectStoreCounts
+ * logs the one-line "unavailable" note), so an unconfigured store degrades
+ * exactly like an unreachable one. Never logs the token, the secret, a URL
+ * that carries them, or a response body.
  */
 export async function fetchMsStoreAcquisitions(env = process.env) {
   const { MSSTORE_TENANT_ID, MSSTORE_CLIENT_ID, MSSTORE_CLIENT_SECRET } = env;
   if (!MSSTORE_TENANT_ID || !MSSTORE_CLIENT_ID || !MSSTORE_CLIENT_SECRET) {
-    process.stderr.write('store-counts: msStore not configured\n');
     return null;
   }
   try {
@@ -147,6 +164,7 @@ export async function fetchMsStoreAcquisitions(env = process.env) {
           client_secret: MSSTORE_CLIENT_SECRET,
           resource: 'https://manage.devcenter.microsoft.com',
         }),
+        redirect: 'error',
         signal: AbortSignal.timeout(20_000),
       }
     );
@@ -164,24 +182,39 @@ export async function fetchMsStoreAcquisitions(env = process.env) {
     // across date x market x deviceType x ..., so page count only grows over
     // time. A runaway (or looping) @nextLink must not spin forever.
     const MAX_PAGES = 50;
+    // One shared deadline for the whole pagination walk (the token POST keeps
+    // its own 20s) — a slow upstream that keeps answering just under 20s per
+    // page could otherwise page for a very long time.
+    const deadline = AbortSignal.timeout(60_000);
     while (url && pages.length < MAX_PAGES) {
       const res = await fetch(url, {
         headers: { authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(20_000),
+        redirect: 'error',
+        signal: deadline,
       });
       // Fail loud, not quiet: a non-2xx mid-pagination means the sum so far
       // is partial. Returning it would silently publish a truncated count.
       if (!res.ok) return null;
       const page = await res.json();
       pages.push(page);
-      // `@nextLink` is documented as relative to the analytics base path, so
-      // resolve it against a base rather than fetching it as-is.
-      url = page['@nextLink']
-        ? new URL(page['@nextLink'], 'https://manage.devcenter.microsoft.com/v1.0/my/analytics/')
-            .href
-        : null;
+      if (page['@nextLink']) {
+        // `@nextLink` is documented as relative to the analytics base path,
+        // so resolve it against a base rather than fetching it as-is — and
+        // pin the result to the real host, so the bearer token can never be
+        // sent to another origin even if a response were ever compromised.
+        const next = new URL(
+          page['@nextLink'],
+          'https://manage.devcenter.microsoft.com/v1.0/my/analytics/'
+        );
+        if (next.origin !== 'https://manage.devcenter.microsoft.com') return null;
+        url = next.href;
+      } else {
+        url = null;
+      }
     }
-    return sumAcquisitions(pages);
+    // Hitting the page cap with a next link still pending means the sum is
+    // incomplete — publish null, never a truncated number.
+    return url ? null : sumAcquisitions(pages);
   } catch {
     return null;
   }
@@ -195,18 +228,25 @@ export async function fetchMsStoreAcquisitions(env = process.env) {
 export async function fetchSnapInstalledBase(name = 'ai-job-hunter', env = process.env) {
   if (!env.SNAPCRAFT_STORE_CREDENTIALS) return null;
   try {
+    // Minimal env only — never the whole process env, which on CI also
+    // carries GITHUB_TOKEN and the MS Store secrets this command has no
+    // business seeing.
+    const minimalEnv = {
+      PATH: env.PATH,
+      HOME: env.HOME,
+      SNAPCRAFT_STORE_CREDENTIALS: env.SNAPCRAFT_STORE_CREDENTIALS,
+    };
     const { stdout } = await execFileAsync(
       'snapcraft',
       ['metrics', name, '--name', 'installed_base_by_channel', '--format', 'json'],
-      { timeout: 60_000, env }
+      { timeout: 60_000, env: minimalEnv }
     );
     return snapInstalledBase(JSON.parse(stdout));
   } catch (err) {
-    // Only the exit code and a short stderr snippet — never the full output,
-    // which could echo back credentials on some failure paths.
+    // Only the exit code — never a stderr snippet, even truncated: a
+    // truncated prefix can still defeat GitHub's exact-match secret masking.
     const code = err?.code ?? 'unknown';
-    const stderrSnippet = String(err?.stderr ?? '').slice(0, 200);
-    process.stderr.write(`store-counts: snap metrics failed (exit ${code}): ${stderrSnippet}\n`);
+    process.stderr.write(`store-counts: snap metrics failed (exit ${code})\n`);
     return null;
   }
 }

--- a/scripts/lib/store-counts.mjs
+++ b/scripts/lib/store-counts.mjs
@@ -1,0 +1,232 @@
+// Store-side counters for the public "installs" number — everything besides
+// the GitHub installer downloads that scripts/lib/github-releases.mjs already
+// computes.
+//
+// UNIT CAVEAT: a Microsoft Store "acquisition", a Snap "installed device", a
+// Chrome Web Store "weekly active user" and a Firefox AMO "average daily user"
+// are four different metrics, not four downloads. None of them is directly
+// comparable to a GitHub asset download either. Summing them is still honest
+// under one reading — every term is an install by SOME definition, and the sum
+// undercounts if anything (an acquisition that never launches the app still
+// isn't double-counted anywhere else) — which is exactly why the public label
+// is "installs", never "downloads". See build-repo-charts.mjs for where the
+// sum happens.
+//
+// SOFT-FAIL CONTRACT: a store outage, a missing credential, or an upstream
+// markup change must never break the nightly badge build. Every fetcher below
+// catches everything and returns `null` on failure; `totalInstalls` treats
+// `null` as "no data", not zero; `collectStoreCounts` never rejects.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const MS_STORE_APP_ID = '9NC5KDJV0BTM';
+// The listing went live 2026-09-09; started a week early on purpose so a clock
+// skew or a late first read can never fall outside the window.
+const MS_STORE_START_DATE = '2026-09-01';
+
+const CHROME_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36';
+
+// ── Pure parsers ─────────────────────────────────────────────────────────────
+// Each returns an integer >= 0, or `null` when the input is unrecognized. No
+// network, no process spawning — safe to unit-test directly.
+
+/** AMO's `average_daily_users` field, if it is a usable number. */
+export function parseFirefoxUsers(json) {
+  const n = json?.average_daily_users;
+  return typeof n === 'number' && Number.isFinite(n) && n >= 0 ? Math.round(n) : null;
+}
+
+/**
+ * Scrapes a Chrome Web Store listing page for its "N users" figure — there is
+ * no public API, so the rendered HTML is the only source. Handles the K/M
+ * suffix larger listings render (`10K+ users`, `2.5M users`) alongside the
+ * plain form (`21 users`, `1,234 users`).
+ */
+export function parseChromeUsers(html) {
+  const m = /([\d,.]+)\s*([KM])?\+?\s*users/i.exec(html ?? '');
+  if (!m) return null;
+  const n = Number.parseFloat(m[1].replace(/,/g, ''));
+  if (!Number.isFinite(n)) return null;
+  const multiplier =
+    m[2]?.toUpperCase() === 'K' ? 1_000 : m[2]?.toUpperCase() === 'M' ? 1_000_000 : 1;
+  return Math.round(n * multiplier);
+}
+
+/**
+ * Snap Store metrics API response → installed devices on the latest day.
+ * Shape is `{ metrics: [M] }` or a bare `M`, where `M.series[*].values` aligns
+ * with `M.buckets` by index; sums every series' LAST bucket only (today).
+ */
+export function snapInstalledBase(json) {
+  const metric = Array.isArray(json?.metrics) ? json.metrics[0] : json;
+  if (!metric || !Array.isArray(metric.series) || !Array.isArray(metric.buckets)) return null;
+  if (metric.buckets.length === 0) return null;
+  const last = metric.buckets.length - 1;
+  return metric.series.reduce((sum, s) => sum + (Number(s?.values?.[last]) || 0), 0);
+}
+
+/** Sum of `acquisitionQuantity` across every paginated Microsoft Store response. */
+export function sumAcquisitions(pages) {
+  let sum = 0;
+  let sawValueArray = false;
+  for (const page of pages ?? []) {
+    if (!Array.isArray(page?.Value)) continue;
+    sawValueArray = true;
+    for (const row of page.Value) {
+      const q = row?.acquisitionQuantity;
+      if (typeof q === 'number' && Number.isFinite(q)) sum += q;
+    }
+  }
+  return sawValueArray ? sum : null;
+}
+
+/** Sum of the finite non-null values in `parts` — an all-null input is 0, not null. */
+export function totalInstalls(parts) {
+  return Object.values(parts).reduce(
+    (sum, v) => (typeof v === 'number' && Number.isFinite(v) ? sum + v : sum),
+    0
+  );
+}
+
+// ── Fetchers ─────────────────────────────────────────────────────────────────
+// Each is independently soft-failing: a timeout, a non-2xx, a markup change or
+// a missing credential all degrade to `null`, never a thrown error.
+
+/** Firefox AMO — no auth, public API. */
+export async function fetchFirefoxUsers(slug = 'ai-job-hunter') {
+  try {
+    const res = await fetch(`https://addons.mozilla.org/api/v5/addons/addon/${slug}/`, {
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!res.ok) return null;
+    return parseFirefoxUsers(await res.json());
+  } catch {
+    return null;
+  }
+}
+
+/** Chrome Web Store — no API; scrapes the public listing page. */
+export async function fetchChromeUsers(id = 'oaoekkgkhmgdfnpmfkpphgiikliaicll') {
+  try {
+    const res = await fetch(`https://chromewebstore.google.com/detail/${id}`, {
+      headers: { 'user-agent': CHROME_USER_AGENT, 'accept-language': 'en' },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!res.ok) return null;
+    return parseChromeUsers(await res.text());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Microsoft Store — OAuth2 client-credentials token, then a paginated
+ * analytics GET. `null` (with a stderr note) when any of the three secrets is
+ * missing, so an unconfigured store degrades exactly like an unreachable one.
+ * Never logs the token, the secret, a URL that carries them, or a response body.
+ */
+export async function fetchMsStoreAcquisitions(env = process.env) {
+  const { MSSTORE_TENANT_ID, MSSTORE_CLIENT_ID, MSSTORE_CLIENT_SECRET } = env;
+  if (!MSSTORE_TENANT_ID || !MSSTORE_CLIENT_ID || !MSSTORE_CLIENT_SECRET) {
+    process.stderr.write('store-counts: msStore not configured\n');
+    return null;
+  }
+  try {
+    const tokenRes = await fetch(
+      `https://login.microsoftonline.com/${MSSTORE_TENANT_ID}/oauth2/token`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'client_credentials',
+          client_id: MSSTORE_CLIENT_ID,
+          client_secret: MSSTORE_CLIENT_SECRET,
+          resource: 'https://manage.devcenter.microsoft.com',
+        }),
+        signal: AbortSignal.timeout(20_000),
+      }
+    );
+    if (!tokenRes.ok) return null;
+    const token = (await tokenRes.json())?.access_token;
+    if (!token) return null;
+
+    const today = new Date().toISOString().slice(0, 10);
+    let url =
+      'https://manage.devcenter.microsoft.com/v1.0/my/analytics/appacquisitions' +
+      `?applicationId=${MS_STORE_APP_ID}&startDate=${MS_STORE_START_DATE}&endDate=${today}` +
+      '&aggregationLevel=day&top=10000';
+    const pages = [];
+    while (url) {
+      const res = await fetch(url, {
+        headers: { authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(20_000),
+      });
+      if (!res.ok) break;
+      const page = await res.json();
+      pages.push(page);
+      url = page['@nextLink'] || null;
+    }
+    return sumAcquisitions(pages);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Snap Store — `snapcraft metrics` via the CLI (no HTTP API for this figure).
+ * `null` when `SNAPCRAFT_STORE_CREDENTIALS` is unset, matching the MS Store
+ * fetcher's "unconfigured degrades like unreachable" contract.
+ */
+export async function fetchSnapInstalledBase(name = 'ai-job-hunter', env = process.env) {
+  if (!env.SNAPCRAFT_STORE_CREDENTIALS) return null;
+  try {
+    const { stdout } = await execFileAsync(
+      'snapcraft',
+      ['metrics', name, '--name', 'installed_base_by_channel', '--format', 'json'],
+      { timeout: 60_000, env }
+    );
+    return snapInstalledBase(JSON.parse(stdout));
+  } catch (err) {
+    // Only the exit code and a short stderr snippet — never the full output,
+    // which could echo back credentials on some failure paths.
+    const code = err?.code ?? 'unknown';
+    const stderrSnippet = String(err?.stderr ?? '').slice(0, 200);
+    process.stderr.write(`store-counts: snap metrics failed (exit ${code}): ${stderrSnippet}\n`);
+    return null;
+  }
+}
+
+/**
+ * Runs all four fetchers concurrently and reports one line per store on
+ * stderr. `Promise.allSettled` rather than `Promise.all`: every fetcher above
+ * already catches its own errors and resolves to `null`, but this stays
+ * correct even if one of them doesn't.
+ */
+export async function collectStoreCounts(env = process.env) {
+  const stores = [
+    ['msStore', fetchMsStoreAcquisitions(env)],
+    ['snap', fetchSnapInstalledBase('ai-job-hunter', env)],
+    ['chrome', fetchChromeUsers()],
+    ['firefox', fetchFirefoxUsers()],
+  ];
+  const settled = await Promise.allSettled(stores.map(([, p]) => p));
+
+  const result = {};
+  settled.forEach((outcome, i) => {
+    const [store] = stores[i];
+    const value = outcome.status === 'fulfilled' ? outcome.value : null;
+    const usable = typeof value === 'number' && Number.isFinite(value);
+    result[store] = usable ? value : null;
+    if (usable) {
+      process.stderr.write(`store-counts: ${store} = ${value}\n`);
+    } else {
+      const reason = outcome.status === 'rejected' ? (outcome.reason?.name ?? 'error') : 'no data';
+      process.stderr.write(`store-counts: ${store} unavailable (${reason})\n`);
+    }
+  });
+  return result;
+}

--- a/scripts/lib/store-counts.test.mjs
+++ b/scripts/lib/store-counts.test.mjs
@@ -1,12 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  collectStoreCounts,
+  fetchChromeUsers,
+  fetchFirefoxUsers,
+  fetchMsStoreAcquisitions,
+  fetchSnapInstalledBase,
   parseChromeUsers,
   parseFirefoxUsers,
   snapInstalledBase,
   sumAcquisitions,
   totalInstalls,
 } from './store-counts.mjs';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('parseChromeUsers', () => {
   it('parses the plain form', () => {
@@ -34,6 +43,10 @@ describe('parseChromeUsers', () => {
     expect(parseChromeUsers('<div>Overview</div>')).toBeNull();
     expect(parseChromeUsers('')).toBeNull();
     expect(parseChromeUsers(undefined)).toBeNull();
+  });
+
+  it('returns null above the sanity ceiling', () => {
+    expect(parseChromeUsers('10M users')).toBeNull();
   });
 });
 
@@ -92,6 +105,27 @@ describe('snapInstalledBase', () => {
     expect(snapInstalledBase({ series: [], buckets: [] })).toBeNull();
     expect(snapInstalledBase(null)).toBeNull();
   });
+
+  it('walks back one bucket when the latest is entirely null', () => {
+    const m = {
+      buckets: ['a', 'b'],
+      series: [
+        { name: 's', values: [5, null] },
+        { name: 't', values: [2, null] },
+      ],
+    };
+    expect(snapInstalledBase(m)).toBe(7);
+  });
+
+  it('returns null when every bucket is null', () => {
+    const m = { buckets: ['a', 'b'], series: [{ name: 's', values: [null, null] }] };
+    expect(snapInstalledBase(m)).toBeNull();
+  });
+
+  it("returns null when status is a string other than 'OK'", () => {
+    const m = { status: 'error', buckets: ['a'], series: [{ name: 's', values: [3] }] };
+    expect(snapInstalledBase(m)).toBeNull();
+  });
 });
 
 describe('sumAcquisitions', () => {
@@ -126,5 +160,142 @@ describe('totalInstalls', () => {
     expect(
       totalInstalls({ github: null, msStore: null, snap: null, chrome: null, firefox: null })
     ).toBe(0);
+  });
+});
+
+describe('fetchMsStoreAcquisitions', () => {
+  it('returns null and never calls fetch when secrets are missing', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await fetchMsStoreAcquisitions({})).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves a relative @nextLink to an absolute manage.devcenter.microsoft.com URL and sums both pages', async () => {
+    const urls = [];
+    let n = 0;
+    const fetchMock = vi.fn(async (url) => {
+      urls.push(String(url));
+      n += 1;
+      if (n === 1) return { ok: true, json: async () => ({ access_token: 'tok' }) };
+      if (n === 2) {
+        return {
+          ok: true,
+          json: async () => ({
+            Value: [{ acquisitionQuantity: 3 }],
+            '@nextLink': 'appacquisitions?applicationId=x&skip=10000',
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ Value: [{ acquisitionQuantity: 4 }] }) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const env = { MSSTORE_TENANT_ID: 't', MSSTORE_CLIENT_ID: 'c', MSSTORE_CLIENT_SECRET: 's' };
+    expect(await fetchMsStoreAcquisitions(env)).toBe(7);
+    expect(urls[2]).toMatch(/^https:\/\/manage\.devcenter\.microsoft\.com\//);
+  });
+
+  it('returns null when a page mid-pagination responds non-2xx', async () => {
+    let n = 0;
+    const fetchMock = vi.fn(async () => {
+      n += 1;
+      if (n === 1) return { ok: true, json: async () => ({ access_token: 'tok' }) };
+      if (n === 2) {
+        return {
+          ok: true,
+          json: async () => ({ Value: [{ acquisitionQuantity: 1 }], '@nextLink': 'more' }),
+        };
+      }
+      return { ok: false, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const env = { MSSTORE_TENANT_ID: 't', MSSTORE_CLIENT_ID: 'c', MSSTORE_CLIENT_SECRET: 's' };
+    expect(await fetchMsStoreAcquisitions(env)).toBeNull();
+  });
+
+  it('returns null and never fetches a foreign-origin absolute @nextLink', async () => {
+    let n = 0;
+    const hosts = [];
+    const fetchMock = vi.fn(async (url) => {
+      hosts.push(new URL(String(url)).host);
+      n += 1;
+      if (n === 1) return { ok: true, json: async () => ({ access_token: 'tok' }) };
+      return {
+        ok: true,
+        json: async () => ({
+          Value: [{ acquisitionQuantity: 1 }],
+          '@nextLink': 'https://evil.example.com/steal',
+        }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const env = { MSSTORE_TENANT_ID: 't', MSSTORE_CLIENT_ID: 'c', MSSTORE_CLIENT_SECRET: 's' };
+    expect(await fetchMsStoreAcquisitions(env)).toBeNull();
+    expect(hosts).not.toContain('evil.example.com');
+  });
+
+  it('returns null when more pages exist than the page cap', async () => {
+    let n = 0;
+    const fetchMock = vi.fn(async () => {
+      n += 1;
+      if (n === 1) return { ok: true, json: async () => ({ access_token: 'tok' }) };
+      return {
+        ok: true,
+        json: async () => ({
+          Value: [{ acquisitionQuantity: 1 }],
+          '@nextLink': `more?page=${n}`,
+        }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const env = { MSSTORE_TENANT_ID: 't', MSSTORE_CLIENT_ID: 'c', MSSTORE_CLIENT_SECRET: 's' };
+    expect(await fetchMsStoreAcquisitions(env)).toBeNull();
+  });
+});
+
+describe('fetchFirefoxUsers', () => {
+  it('returns null on a non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, json: async () => ({}) }))
+    );
+    expect(await fetchFirefoxUsers('ai-job-hunter')).toBeNull();
+  });
+});
+
+describe('fetchChromeUsers', () => {
+  it('returns null when fetch throws', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline');
+      })
+    );
+    expect(await fetchChromeUsers('id')).toBeNull();
+  });
+});
+
+describe('fetchSnapInstalledBase', () => {
+  it('returns null when SNAPCRAFT_STORE_CREDENTIALS is unset', async () => {
+    expect(await fetchSnapInstalledBase('ai-job-hunter', {})).toBeNull();
+  });
+});
+
+describe('collectStoreCounts', () => {
+  it('resolves (never rejects) with nulls for the HTTP stores when fetch throws', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline');
+      })
+    );
+
+    const result = await collectStoreCounts({});
+    expect(result).toEqual({ msStore: null, snap: null, chrome: null, firefox: null });
   });
 });

--- a/scripts/lib/store-counts.test.mjs
+++ b/scripts/lib/store-counts.test.mjs
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseChromeUsers,
+  parseFirefoxUsers,
+  snapInstalledBase,
+  sumAcquisitions,
+  totalInstalls,
+} from './store-counts.mjs';
+
+describe('parseChromeUsers', () => {
+  it('parses the plain form', () => {
+    expect(parseChromeUsers('<span>21 users</span>')).toBe(21);
+  });
+
+  it('parses a comma-grouped count', () => {
+    expect(parseChromeUsers('<span>1,234 users</span>')).toBe(1234);
+  });
+
+  it('applies the K multiplier', () => {
+    expect(parseChromeUsers('10K+ users')).toBe(10_000);
+  });
+
+  it('applies the M multiplier', () => {
+    expect(parseChromeUsers('2.5M users')).toBe(2_500_000);
+  });
+
+  it('finds the figure amid surrounding HTML noise', () => {
+    const html = '<div class="x"><b>21 users</b></div><script>ga("send")</script>';
+    expect(parseChromeUsers(html)).toBe(21);
+  });
+
+  it('returns null when there is no match', () => {
+    expect(parseChromeUsers('<div>Overview</div>')).toBeNull();
+    expect(parseChromeUsers('')).toBeNull();
+    expect(parseChromeUsers(undefined)).toBeNull();
+  });
+});
+
+describe('parseFirefoxUsers', () => {
+  it('returns the integer count', () => {
+    expect(parseFirefoxUsers({ average_daily_users: 1 })).toBe(1);
+  });
+
+  it('returns null when the field is missing', () => {
+    expect(parseFirefoxUsers({})).toBeNull();
+    expect(parseFirefoxUsers(null)).toBeNull();
+  });
+
+  it('returns null for negative or NaN values', () => {
+    expect(parseFirefoxUsers({ average_daily_users: -1 })).toBeNull();
+    expect(parseFirefoxUsers({ average_daily_users: Number.NaN })).toBeNull();
+  });
+});
+
+describe('snapInstalledBase', () => {
+  const metric = {
+    buckets: ['2026-09-08', '2026-09-09', '2026-09-10'],
+    series: [
+      { name: 'stable', values: [1, 2, 3] },
+      { name: 'edge', values: [null, 1, 4] },
+    ],
+  };
+
+  it('unwraps a metrics-wrapped payload', () => {
+    expect(snapInstalledBase({ metrics: [metric] })).toBe(7); // 3 + 4
+  });
+
+  it('accepts a bare metric object', () => {
+    expect(snapInstalledBase(metric)).toBe(7);
+  });
+
+  it('sums only the LAST bucket, not every bucket', () => {
+    const singleSeries = { buckets: ['a', 'b'], series: [{ name: 's', values: [100, 5] }] };
+    expect(snapInstalledBase(singleSeries)).toBe(5);
+  });
+
+  it('counts a null value as 0 rather than skipping the series', () => {
+    const withNull = {
+      buckets: ['a'],
+      series: [
+        { name: 's', values: [null] },
+        { name: 't', values: [3] },
+      ],
+    };
+    expect(snapInstalledBase(withNull)).toBe(3);
+  });
+
+  it('returns null for an unrecognized shape', () => {
+    expect(snapInstalledBase({})).toBeNull();
+    expect(snapInstalledBase({ metrics: [] })).toBeNull();
+    expect(snapInstalledBase({ series: [], buckets: [] })).toBeNull();
+    expect(snapInstalledBase(null)).toBeNull();
+  });
+});
+
+describe('sumAcquisitions', () => {
+  it('sums acquisitionQuantity across two pages', () => {
+    const pages = [
+      { Value: [{ acquisitionQuantity: 2 }, { acquisitionQuantity: 3 }] },
+      { Value: [{ acquisitionQuantity: 5 }] },
+    ];
+    expect(sumAcquisitions(pages)).toBe(10);
+  });
+
+  it('ignores rows missing the field', () => {
+    const pages = [{ Value: [{ acquisitionQuantity: 4 }, { date: '2026-09-09' }] }];
+    expect(sumAcquisitions(pages)).toBe(4);
+  });
+
+  it('returns null when no page has a Value array', () => {
+    expect(sumAcquisitions([{}])).toBeNull();
+    expect(sumAcquisitions([])).toBeNull();
+    expect(sumAcquisitions(undefined)).toBeNull();
+  });
+});
+
+describe('totalInstalls', () => {
+  it('ignores nulls and sums the rest', () => {
+    expect(totalInstalls({ github: 10, msStore: null, snap: 5, chrome: 2, firefox: null })).toBe(
+      17
+    );
+  });
+
+  it('returns 0 when every part is null', () => {
+    expect(
+      totalInstalls({ github: null, msStore: null, snap: null, chrome: null, firefox: null })
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## One public number, labeled "installs"

The nightly `repo-charts` job now adds four store-side counters to the floor-corrected GitHub installer downloads it already computes, and the shields badge in the README is relabeled **installs**:

| Source | Metric | Auth |
|---|---|---|
| Microsoft Store | cumulative acquisitions (Partner Center analytics API) | existing `MSSTORE_*` secrets, client-credentials token |
| Snap Store | installed base on the latest day with a reading (`snapcraft metrics`) | existing `SNAPCRAFT_STORE_CREDENTIALS` |
| Chrome Web Store | listed users (scraped from the public listing, no API exists) | none |
| Firefox AMO | average daily users (public API v5) | none |

Every term is an install by any reading and the sum undercounts if anything, so the label is honest without publishing the per-store breakdown, which is tiny today. The parts are still published as `store-counts.json` on the `badges` branch (nulls preserved when a store is unreachable), and the landing `/download` page shows the same total under its lede, hidden until the file lands. The downloads-over-time chart and its history stay GitHub-only: their seed is GitHub-only and mixing units would draw a fake jump on the day the stores were added.

## Soft-fail contract

A store outage, a missing credential or a markup change can never break the badge: every fetcher catches everything and degrades to null, the MS Store pagination is capped and origin-pinned (a foreign next link returns null before any request, so the bearer token never leaves `manage.devcenter.microsoft.com`), snapcraft runs with a three-variable env and only its exit code is logged, and the snapcraft install step is soft-failing with its own timeout.

## What I could not verify locally

The two credentialed fetchers only run in CI. First nightly run (or a manual `📈 Repo Charts` dispatch) will show in its log whether the exported snap login carries the metrics ACL and whether the Entra app's Manager role is enough for the analytics endpoint. Both degrade to null, not a failure.

## Review

Sonnet author → Opus pr-reviewer + Opus security critic (both APPROVE after one fix round) → advisories folded by a Sonnet pass → scripts vitest (270), landing typecheck/tests (366)/build/parity, landing-drift and workflow-catalog checks all green, plus the pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)